### PR TITLE
[agent] Don't stamp static routes with VRF community

### DIFF
--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -1059,9 +1059,6 @@ func planVPCs(agent *agentapi.Agent, spec *dozer.Spec) error {
 			dozer.SpecVRFBGPTableConnectionConnected: {
 				ImportPolicies: []string{stampVPCRouteMap},
 			},
-			dozer.SpecVRFBGPTableConnectionStatic: {
-				ImportPolicies: []string{stampVPCRouteMap},
-			},
 		}
 		spec.VRFs[vrfName].Interfaces[irbIface] = &dozer.SpecVRFInterface{}
 


### PR DESCRIPTION
We should never distribute static routes that are set for local VPC or External peering with another VPC. Don't stamp such routes.