### PR TITLE
[external] Remove Le/Ge from the API

### DIFF
--- a/api/vpc/v1alpha2/externalpeering_types.go
+++ b/api/vpc/v1alpha2/externalpeering_types.go
@@ -66,10 +66,11 @@ type ExternalPeeringSpecExternal struct {
 type ExternalPeeringSpecPrefix struct {
 	// Prefix is the subnet to permit from the External to the VPC, e.g. 0.0.0.0/0 for default route
 	Prefix string `json:"prefix,omitempty"`
+	// Temporary removing LE and GE from the spec.
 	// Ge is the minimum prefix length to permit from the External to the VPC, e.g. 24 for /24
-	Ge uint8 `json:"ge,omitempty"`
+	// Ge uint8 `json:"ge,omitempty"`
 	// Le is the maximum prefix length to permit from the External to the VPC, e.g. 32 for /32
-	Le uint8 `json:"le,omitempty"`
+	// Le uint8 `json:"le,omitempty"`
 }
 
 // ExternalPeeringStatus defines the observed state of ExternalPeering
@@ -143,7 +144,7 @@ func (peering *ExternalPeering) Validate(ctx context.Context, kube client.Reader
 		if permit.Prefix == "" {
 			return nil, errors.Errorf("external.prefixes.prefix is required")
 		}
-		if permit.Ge > permit.Le {
+		/*if permit.Ge > permit.Le {
 			return nil, errors.Errorf("external.prefixes.ge must be <= external.prefixes.le")
 		}
 		if permit.Ge > 32 {
@@ -151,7 +152,7 @@ func (peering *ExternalPeering) Validate(ctx context.Context, kube client.Reader
 		}
 		if permit.Le > 32 {
 			return nil, errors.Errorf("external.prefixes.le must be <= 32")
-		}
+		}*/
 
 		// TODO add more validation for prefix/ge/le
 	}

--- a/config/crd/bases/agent.githedgehog.com_agents.yaml
+++ b/config/crd/bases/agent.githedgehog.com_agents.yaml
@@ -702,16 +702,6 @@ spec:
                                 description: ExternalPeeringSpecPrefix defines the
                                   prefix to permit from the External to the VPC
                                 properties:
-                                  ge:
-                                    description: Ge is the minimum prefix length to
-                                      permit from the External to the VPC, e.g. 24
-                                      for /24
-                                    type: integer
-                                  le:
-                                    description: Le is the maximum prefix length to
-                                      permit from the External to the VPC, e.g. 32
-                                      for /32
-                                    type: integer
                                   prefix:
                                     description: Prefix is the subnet to permit from
                                       the External to the VPC, e.g. 0.0.0.0/0 for

--- a/config/crd/bases/vpc.githedgehog.com_externalpeerings.yaml
+++ b/config/crd/bases/vpc.githedgehog.com_externalpeerings.yaml
@@ -77,14 +77,6 @@ spec:
                           description: ExternalPeeringSpecPrefix defines the prefix
                             to permit from the External to the VPC
                           properties:
-                            ge:
-                              description: Ge is the minimum prefix length to permit
-                                from the External to the VPC, e.g. 24 for /24
-                              type: integer
-                            le:
-                              description: Le is the maximum prefix length to permit
-                                from the External to the VPC, e.g. 32 for /32
-                              type: integer
                             prefix:
                               description: Prefix is the subnet to permit from the
                                 External to the VPC, e.g. 0.0.0.0/0 for default route

--- a/docs/api.md
+++ b/docs/api.md
@@ -350,8 +350,6 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `prefix` _string_ | Prefix is the subnet to permit from the External to the VPC, e.g. 0.0.0.0/0 for default route |
-| `ge` _integer_ | Ge is the minimum prefix length to permit from the External to the VPC, e.g. 24 for /24 |
-| `le` _integer_ | Le is the maximum prefix length to permit from the External to the VPC, e.g. 32 for /32 |
 
 
 #### ExternalPeeringSpecVPC

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -2094,8 +2094,7 @@ func planExternalPeerings(agent *agentapi.Agent, spec *dozer.Spec) error {
 				prefixes[idx] = &dozer.SpecPrefixListEntry{
 					Prefix: dozer.SpecPrefixListPrefix{
 						Prefix: prefix.Prefix,
-						Ge:     prefix.Ge,
-						Le:     prefix.Le,
+						Le:     32,
 					},
 					Action: dozer.SpecPrefixListActionPermit,
 				}

--- a/pkg/hhfctl/external.go
+++ b/pkg/hhfctl/external.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 	vpcapi "go.githedgehog.com/fabric/api/vpc/v1alpha2"
@@ -98,8 +96,9 @@ func ExternalPeering(ctx context.Context, printYaml bool, options *ExternalPeeri
 		},
 	}
 
-	for _, rawPrefix := range options.ExternalPrefixes {
-		le, ge := 0, 0
+	for _, prefix := range options.ExternalPrefixes {
+		// Temporarty remove le/ge
+		/*le, ge := 0, 0
 
 		prefixParts := strings.Split(rawPrefix, "_")
 		if len(prefixParts) > 3 {
@@ -131,6 +130,9 @@ func ExternalPeering(ctx context.Context, printYaml bool, options *ExternalPeeri
 			Prefix: prefix,
 			Le:     uint8(le),
 			Ge:     uint8(ge),
+		})*/
+		extPeering.Spec.Permit.External.Prefixes = append(extPeering.Spec.Permit.External.Prefixes, vpcapi.ExternalPeeringSpecPrefix{
+			Prefix: prefix,
 		})
 	}
 


### PR DESCRIPTION
Remove only config part of the external prefix, we can keep the agent part since it won't hurt and also will keep prefix list state valid regardless of any manual changes.