### PR TITLE
[agent] switch to bcm sonic 4.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/vishvananda/netlink v1.1.0
-	go.githedgehog.com/fabric-bcm-ygot v0.1.0-4.2.0
+	go.githedgehog.com/fabric-bcm-ygot v0.2.0-4.4.0
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	k8s.io/api v0.30.3

--- a/go.sum
+++ b/go.sum
@@ -932,8 +932,8 @@ github.com/zealic/xignore v0.3.3/go.mod h1:lhS8V7fuSOtJOKsvKI7WfsZE276/7AYEqokv3
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.8 h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA=
 go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
-go.githedgehog.com/fabric-bcm-ygot v0.1.0-4.2.0 h1:6Gw5biRQxL7TPT55U03GufJtlV6iH/pHsj8J5evS6JE=
-go.githedgehog.com/fabric-bcm-ygot v0.1.0-4.2.0/go.mod h1:P/rTRtJedD3Pw72xgXYLPZAP8RpK2YmUR15qHGHxQWE=
+go.githedgehog.com/fabric-bcm-ygot v0.2.0-4.4.0 h1:vxflsKB6+aIrXGeuWxagL82Eze8N2eGJzQ9bCazvcPU=
+go.githedgehog.com/fabric-bcm-ygot v0.2.0-4.4.0/go.mod h1:P/rTRtJedD3Pw72xgXYLPZAP8RpK2YmUR15qHGHxQWE=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -311,11 +311,12 @@ func (svc *Service) processAgent(ctx context.Context, agent *agentapi.Agent, rea
 	}
 	slog.Debug("Desired state generated")
 
+	startActual := time.Now()
 	actual, err := svc.processor.LoadActualState(ctx, agent)
 	if err != nil {
 		return errors.Wrapf(err, "failed to load actual state")
 	}
-	slog.Debug("Actual state loaded")
+	slog.Debug("Actual state loaded", "took", time.Since(startActual))
 
 	actions, err := svc.processor.CalculateActions(ctx, actual, desired)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_lldp.go
+++ b/pkg/agent/dozer/bcm/spec_lldp.go
@@ -127,6 +127,10 @@ func unmarshalActualLLDPInterfaces(ocVal *oc.OpenconfigLldp_Lldp_Interfaces) (ma
 			continue
 		}
 
+		if ocInterface.Config.Enabled == nil || !*ocInterface.Config.Enabled {
+			continue
+		}
+
 		lldpInterfaces[name] = &dozer.SpecLLDPInterface{
 			Enabled:        ocInterface.Config.Enabled,
 			ManagementIPv4: ocInterface.Config.ManagementAddressIpv4,

--- a/pkg/agent/dozer/bcm/state.go
+++ b/pkg/agent/dozer/bcm/state.go
@@ -110,6 +110,10 @@ func (p *BroadcomProcessor) updateInterfaceMetrics(ctx context.Context, reg *swi
 			continue
 		}
 
+		if strings.Contains(ifaceNameRaw, ".") || strings.Contains(ifaceNameRaw, "|") {
+			continue
+		}
+
 		if iface.State == nil {
 			continue
 		}
@@ -297,6 +301,7 @@ func (p *BroadcomProcessor) updateTransceiverMetrics(ctx context.Context, agent 
 		if !strings.HasPrefix(transceiverNameRaw, "Ethernet") {
 			continue
 		}
+
 		if transceiver.State == nil {
 			continue
 		}
@@ -667,11 +672,17 @@ func (p *BroadcomProcessor) updateBGPNeighborMetrics(ctx context.Context, reg *s
 			}
 
 			if ocSt.LocalAs != nil {
-				st.LocalAS = *ocSt.LocalAs
+				// TODO parse https://datatracker.ietf.org/doc/html/rfc5396
+				if val, ok := ocSt.LocalAs.(oc.UnionUint32); ok {
+					st.LocalAS = uint32(val)
+				}
 			}
 
 			if ocSt.PeerAs != nil {
-				st.PeerAS = *ocSt.PeerAs
+				// TODO parse https://datatracker.ietf.org/doc/html/rfc5396
+				if val, ok := ocSt.PeerAs.(oc.UnionUint32); ok {
+					st.PeerAS = uint32(val)
+				}
 			}
 
 			if ocSt.PeerGroup != nil {


### PR DESCRIPTION
- bump ygot gen code to 4.4.0
- ASNs only processed as uint32 for now (not textual)
- ignore LLDP interfaces that aren't enabled for actual state
- query ALL for ifaces to get subif vlan status