### PR TITLE
Show type as mandatory arg in conn get help

### DIFF
--- a/cmd/hhfctl/main.go
+++ b/cmd/hhfctl/main.go
@@ -390,8 +390,10 @@ func main() {
 				},
 				Subcommands: []*cli.Command{
 					{
-						Name:  "get",
-						Usage: "Get connections",
+						Name:        "get",
+						Usage:       "Get connections",
+						ArgsUsage:   " <type>",
+						Description: "Available types: management, fabric, and vpc-loopback",
 						Flags: []cli.Flag{
 							verboseFlag,
 						},


### PR DESCRIPTION
Improve UX highlighting `<type>` as required in the CLI to avoid hitting

```
core@control-1 ~ $ kubectl fabric conn get
14:56:16 ERR Failed err="failed to get connections: type is required"
```

```
core@control-1 ~ $ kubectl fabric conn 
NAME:
   kubectl fabric connection - Connection commands

USAGE:
   kubectl fabric connection command <type> [command options] 
```