### PR TITLE
ci: Add workflow to automate API reference sync on new version tags

### DIFF
--- a/.github/workflows/docs-update.yaml
+++ b/.github/workflows/docs-update.yaml
@@ -1,7 +1,7 @@
 # When we push a new tag to the repository, open a Pull Request to synchronize
-# the API reference documentation with the "docs" repository.
+# the API reference and other documentation with the "docs" repository.
 
-name: "Push API docs"
+name: "Update docs"
 
 concurrency:
   group: "ci-${{ github.ref_name }}"
@@ -32,13 +32,15 @@ jobs:
       - name: "Copy API reference from 'fabric' to 'docs'"
         run: |
           cp docs/api.md project_documentation/docs/reference/api.md
+          cp docs/profiles.md project_documentation/docs/reference/profiles.md
+          cp docs/supported-devices.md project_documentation/docs/install-upgrade/supported-devices.md.gen
 
       - name: "Generate token for the 'docs' repository"
         uses: "actions/create-github-app-token@v2"
         id: "app-token"
         with:
-          app-id: "${{ secrets.APIREF_APP_ID }}"
-          private-key: "${{ secrets.APIREF_PRIVATE_KEY }}"
+          app-id: "${{ secrets.DOCS_APP_ID }}"
+          private-key: "${{ secrets.DOCS_PRIVATE_KEY }}"
           repositories: |
             docs
 
@@ -48,14 +50,15 @@ jobs:
           token: "${{ steps.app-token.outputs.token }}"
           path: "project_documentation"
           commit-message: |
-            Update API reference from ${{ github.repository }} tag ${{ github.ref_name }}.
+            Update docs from ${{ github.repository }}@${{ github.ref_name }}.
 
             This is an automated commit created by GitHub Actions workflow,
             in the "${{ github.repository }}" repository.
           signoff: true
-          title: "Update API reference from ${{ github.repository }} tag ${{ github.ref_name }}"
+          title: "Update docs from ${{ github.repository }}@${{ github.ref_name }}"
           body: |
-            Update API reference from ${{ github.repository }} tag ${{ github.ref_name }}.
-
-            This is an automated Pull Requesst created by GitHub Actions workflow,
+            This is an automated Pull Request created by GitHub Actions workflow,
             in the "${{ github.repository }}" repository.
+
+            It should be merged only after ${{ github.repository }} in the fabricator
+            repository master branch updated to the ${{ github.ref_name }}.

--- a/.github/workflows/push-api-docs.yaml
+++ b/.github/workflows/push-api-docs.yaml
@@ -1,0 +1,52 @@
+# When we push a new tag to the repository, open a Pull Request to synchronize
+# the API reference documentation with the "docs" repository.
+
+name: "Push API docs"
+
+concurrency:
+  group: "ci-${{ github.ref_name }}"
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push-api-docs:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout 'fabric' repository"
+        uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+          persist-credentials: "false"
+
+      - name: "Checkout 'docs' repository"
+        uses: "actions/checkout@v4"
+        with:
+          repository: "githedgehog/docs"
+          path: "project_documentation"
+          persist-credentials: "false"
+
+      - name: "Copy API reference from 'fabric' to 'docs'"
+        run: |
+          cp docs/api.md project_documentation/docs/reference/api.md
+
+      - name: "Create Pull Request"
+        uses: "peter-evans/create-pull-request@v5"
+        with:
+          token: "${{ secrets.DOCS_API_REF_UPDATE_TOKEN }}"
+          path: "project_documentation"
+          commit-message: |
+            Update API reference from ${{ github.repository }} tag ${{ github.ref_name }}.
+
+            This is an automated commit created by GitHub Actions workflow,
+            in the "${{ github.repository }}" repository.
+          signoff: true
+          title: "Update API reference from ${{ github.repository }} tag ${{ github.ref_name }}"
+          body: |
+            Update API reference from ${{ github.repository }} tag ${{ github.ref_name }}.
+
+            This is an automated Pull Requesst created by GitHub Actions workflow,
+            in the "${{ github.repository }}" repository.

--- a/.github/workflows/push-api-docs.yaml
+++ b/.github/workflows/push-api-docs.yaml
@@ -33,10 +33,19 @@ jobs:
         run: |
           cp docs/api.md project_documentation/docs/reference/api.md
 
+      - name: "Generate token for the 'docs' repository"
+        uses: "actions/create-github-app-token@v2"
+        id: "app-token"
+        with:
+          app-id: "${{ secrets.APIREF_APP_ID }}"
+          private-key: "${{ secrets.APIREF_PRIVATE_KEY }}"
+          repositories: |
+            docs
+
       - name: "Create Pull Request"
         uses: "peter-evans/create-pull-request@v5"
         with:
-          token: "${{ secrets.DOCS_API_REF_UPDATE_TOKEN }}"
+          token: "${{ steps.app-token.outputs.token }}"
           path: "project_documentation"
           commit-message: |
             Update API reference from ${{ github.repository }} tag ${{ github.ref_name }}.


### PR DESCRIPTION
### Automation

The API reference generated in this repository is published via the `docs` repository for the project. This means that we regularly need to synchronize the document.

Instead of manually copying the API reference and creating a new Pull Request in the `docs` repo, let's add a workflow to automate this task. The workflow runs each time a new version tag is created in the `fabric` repository.

### Test

The workflow was tested successfully between my own forks of the `fabric` and `docs` repositories, leading to the automated creation of https://github.com/qmonnet/hhdocs/pull/1 when I pushed a tag to my fork.

### Authentication

For my test I used a fine-grained PAT (using the scope [from the docs](https://github.com/peter-evans/create-pull-request/blob/main/README.md#token)), passed as a repository secret. For the upstream `fabric` repo we probably need something different, something that makes the `github-actions` bot the author of the PR, maybe a GitHub App token? I'm not familiar with using those, though.