### PR TITLE
Add CI job to check API ref doc build, fix broken links

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,6 +240,37 @@ jobs:
             exit 1
           fi
 
+  build-api-ref:
+    # To do: Run only if docs/api.md is changed, but checking changed files
+    # probably takes just as long as running this job.
+    runs-on: lab
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build API reference documentation
+        run: |
+          image_name='ghcr.io/githedgehog/hhdocs'
+          image_version='20241202'
+          image="${image_name}:${image_version}"
+
+          # Create a new directory, copy docs/api.md
+          dir='./api-ref-build-test'
+          mkdir -p "${dir}/docs"
+          cp docs/api.md "${dir}/docs/"
+
+          # Create minimal mkdocs.yml config file; warn on broken links
+          echo 'site_name: API Reference Build Test' > "${dir}/mkdocs.yml"
+          echo 'validation:'                        >> "${dir}/mkdocs.yml"
+          echo '  absolute_links: warn'             >> "${dir}/mkdocs.yml"
+          echo '  unrecognized_links: warn'         >> "${dir}/mkdocs.yml"
+          echo '  anchors: warn'                    >> "${dir}/mkdocs.yml"
+
+          # Make sure that docs/api.md builds as HTML with no warnings
+          docker run --rm -v "${dir}":/docs "${image}" mkdocs build --strict
+
   publish:
     runs-on: lab
     if: startsWith(github.event.ref, 'refs/tags/v') && github.event_name == 'push'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -240,37 +240,6 @@ jobs:
             exit 1
           fi
 
-  build-api-ref:
-    # To do: Run only if docs/api.md is changed, but checking changed files
-    # probably takes just as long as running this job.
-    runs-on: lab
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Build API reference documentation
-        run: |
-          image_name='ghcr.io/githedgehog/hhdocs'
-          image_version='20241202'
-          image="${image_name}:${image_version}"
-
-          # Create a new directory, copy docs/api.md
-          dir='./api-ref-build-test'
-          mkdir -p "${dir}/docs"
-          cp docs/api.md "${dir}/docs/"
-
-          # Create minimal mkdocs.yml config file; warn on broken links
-          echo 'site_name: API Reference Build Test' > "${dir}/mkdocs.yml"
-          echo 'validation:'                        >> "${dir}/mkdocs.yml"
-          echo '  absolute_links: warn'             >> "${dir}/mkdocs.yml"
-          echo '  unrecognized_links: warn'         >> "${dir}/mkdocs.yml"
-          echo '  anchors: warn'                    >> "${dir}/mkdocs.yml"
-
-          # Make sure that docs/api.md builds as HTML with no warnings
-          docker run --rm -v "${dir}":/docs "${image}" mkdocs build --strict
-
   publish:
     runs-on: lab
     if: startsWith(github.event.ref, 'refs/tags/v') && github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ codebook.toml
 last-actual.yaml
 last-agent.yaml
 last-desired.yaml
+
+docs/test

--- a/api/docs.config.yaml
+++ b/api/docs.config.yaml
@@ -21,3 +21,25 @@ processor:
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
   kubernetesVersion: 1.35
+  knownTypes:
+  - name: "map[string]VPCPeer"
+    package: go.githedgehog.com/fabric/api/vpc/v1beta1
+    link: "#vpcpeer"
+  - name: "map[string]SwitchStateBGPNeighbor"
+    package: go.githedgehog.com/fabric/api/agent/v1beta1
+    link: "#switchstatebgpneighbor"
+  - name: "map[string]SwitchStateBFDPeer"
+    package: go.githedgehog.com/fabric/api/agent/v1beta1
+    link: "#switchstatebfdpeer"
+  - name: NOSType
+    package: go.githedgehog.com/fabric/api/meta
+    link: ""
+  - name: PeeringNATPortForwardEntry
+    package: go.githedgehog.com/fabric/api/gateway/v1alpha1
+    link: ""
+  - name: VPCAttachmentSpecAnn
+    package: go.githedgehog.com/fabric/api/agent/v1beta1
+    link: ""
+  - name: RedundancyType
+    package: go.githedgehog.com/fabric/api/meta
+    link: ""

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,8 +227,8 @@ _Appears in:_
 | `interfaces` _object (keys:string, values:[SwitchStateInterface](#switchstateinterface))_ | Switch interfaces state (incl. physical, management and port channels) |  |  |
 | `breakouts` _object (keys:string, values:[SwitchStateBreakout](#switchstatebreakout))_ | Breakout ports state (port -> breakout state) |  |  |
 | `transceivers` _object (keys:string, values:[SwitchStateTransceiver](#switchstatetransceiver))_ | Transceivers state (port -> transceiver state) |  |  |
-| `bgpNeighbors` _object (keys:string, values:[map[string]SwitchStateBGPNeighbor](#map[string]switchstatebgpneighbor))_ | State of all BGP neighbors (VRF -> neighbor address -> state) |  |  |
-| `bfdPeers` _object (keys:string, values:[map[string]SwitchStateBFDPeer](#map[string]switchstatebfdpeer))_ | State of all BFD peers (VRF -> peer address -> state) |  |  |
+| `bgpNeighbors` _object (keys:string, values:[map[string]SwitchStateBGPNeighbor](#switchstatebgpneighbor))_ | State of all BGP neighbors (VRF -> neighbor address -> state) |  |  |
+| `bfdPeers` _object (keys:string, values:[map[string]SwitchStateBFDPeer](#switchstatebfdpeer))_ | State of all BFD peers (VRF -> peer address -> state) |  |  |
 | `platform` _[SwitchStatePlatform](#switchstateplatform)_ | State of the switch platform (fans, PSUs, sensors) |  |  |
 | `criticalResources` _[SwitchStateCRM](#switchstatecrm)_ | State of the critical resources (ACLs, routes, etc.) |  |  |
 | `roce` _boolean_ | State of the roce configuration |  |  |
@@ -1199,7 +1199,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `idleTimeout` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#duration-v1-meta)_ | Time since the last packet after which flows are removed from the connection state table |  |  |
-| `ports` _[PeeringNATPortForwardEntry](#peeringnatportforwardentry) array_ |  |  |  |
+| `ports` _PeeringNATPortForwardEntry array_ |  |  |  |
 
 
 
@@ -1214,7 +1214,7 @@ _Validation:_
 - Enum: [tcp udp ]
 
 _Appears in:_
-- [PeeringNATPortForwardEntry](#peeringnatportforwardentry)
+- PeeringNATPortForwardEntry
 
 | Field | Description |
 | --- | --- |
@@ -2105,7 +2105,7 @@ VPCAttachmentSpec defines the desired state of VPCAttachment
 
 _Appears in:_
 - [VPCAttachment](#vpcattachment)
-- [VPCAttachmentSpecAnn](#vpcattachmentspecann)
+- VPCAttachmentSpecAnn
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
@@ -2293,7 +2293,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `remote` _string_ |  |  |  |
-| `permit` _[map[string]VPCPeer](#map[string]vpcpeer) array_ | Permit defines a list of the peering policies - which VPC subnets will have access to the peer VPC subnets. |  | MaxItems: 10 <br />MinItems: 1 <br /> |
+| `permit` _[map[string]VPCPeer](#vpcpeer) array_ | Permit defines a list of the peering policies - which VPC subnets will have access to the peer VPC subnets. |  | MaxItems: 10 <br />MinItems: 1 <br /> |
 
 
 #### VPCPeeringStatus
@@ -3207,7 +3207,7 @@ _Appears in:_
 | `ports` _object (keys:string, values:[SwitchProfilePort](#switchprofileport))_ | Ports defines the switch port configuration |  |  |
 | `portGroups` _object (keys:string, values:[SwitchProfilePortGroup](#switchprofileportgroup))_ | PortGroups defines the switch port group configuration |  |  |
 | `portProfiles` _object (keys:string, values:[SwitchProfilePortProfile](#switchprofileportprofile))_ | PortProfiles defines the switch port profile configuration |  |  |
-| `nosType` _[NOSType](#nostype)_ | NOSType defines the NOS type to be used for the switch |  |  |
+| `nosType` _NOSType_ | NOSType defines the NOS type to be used for the switch |  |  |
 | `platform` _string_ | Platform is what expected to be request by ONIE and displayed in the NOS |  |  |
 | `pipelines` _object (keys:string, values:[SwitchProfilePipeline](#switchprofilepipeline))_ | Pipelines defines the switch pipeline configuration |  |  |
 | `maxPorts` _integer_ | MaxPorts defines the maximum number of ports (breakouts) allowed for the switch |  |  |
@@ -3244,7 +3244,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `group` _string_ | Group is the name of the redundancy group switch belongs to |  |  |
-| `type` _[RedundancyType](#redundancytype)_ | Type is the type of the redundancy group, could be mclag or eslag |  |  |
+| `type` _RedundancyType_ | Type is the type of the redundancy group, could be mclag or eslag |  |  |
 
 
 #### SwitchRole

--- a/justfile
+++ b/justfile
@@ -44,8 +44,28 @@ _kube_gen:
   # Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects
   {{controller_gen}} rbac:roleName=manager-role crd:allowDangerousTypes=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
+docs_image_name := "ghcr.io/githedgehog/hhdocs"
+docs_image_version := "20241202"
+docs_image := docs_image_name + ":" + docs_image_version
+docs_test_dir := './docs/test'
+
+test-docs:
+  rm -rf "{{docs_test_dir}}" || true
+  mkdir -p "{{docs_test_dir}}/docs"
+  cp docs/api.md "{{docs_test_dir}}/docs/"
+
+  # Create minimal mkdocs.yml config file; warn on broken links
+  echo 'site_name: API Reference Build Test' > "{{docs_test_dir}}/mkdocs.yml"
+  echo 'validation:'                        >> "{{docs_test_dir}}/mkdocs.yml"
+  echo '  absolute_links: warn'             >> "{{docs_test_dir}}/mkdocs.yml"
+  echo '  unrecognized_links: warn'         >> "{{docs_test_dir}}/mkdocs.yml"
+  echo '  anchors: warn'                    >> "{{docs_test_dir}}/mkdocs.yml"
+
+  # Make sure that docs/api.md builds as HTML with no warnings
+  docker run --rm -v "{{docs_test_dir}}":/docs "{{docs_image}}" mkdocs build --strict
+
 # Generate docs, code/manifests, things to embed, etc
-gen: _kube_gen _embed _crd_ref_docs
+gen: _kube_gen _embed _crd_ref_docs && test-docs
   {{crd_ref_docs}} --source-path=./api/ --config=api/docs.config.yaml --renderer=markdown --output-path=./docs/api.md
   go run cmd/fabric-gen/main.go profiles-ref
 

--- a/justfile
+++ b/justfile
@@ -57,6 +57,7 @@ test-docs:
   # Create minimal mkdocs.yml config file; warn on broken links
   echo 'site_name: API Reference Build Test' > "{{docs_test_dir}}/mkdocs.yml"
   echo 'validation:'                        >> "{{docs_test_dir}}/mkdocs.yml"
+  echo '  not_found: warn'                  >> "{{docs_test_dir}}/mkdocs.yml"
   echo '  absolute_links: warn'             >> "{{docs_test_dir}}/mkdocs.yml"
   echo '  unrecognized_links: warn'         >> "{{docs_test_dir}}/mkdocs.yml"
   echo '  anchors: warn'                    >> "{{docs_test_dir}}/mkdocs.yml"

--- a/justfile
+++ b/justfile
@@ -63,7 +63,11 @@ test-docs:
   echo '  anchors: warn'                    >> "{{docs_test_dir}}/mkdocs.yml"
 
   # Make sure that docs/api.md builds as HTML with no warnings
-  docker run --rm -v "{{docs_test_dir}}":/docs "{{docs_image}}" mkdocs build --strict
+  docker run --rm \
+      --user "$(id -u):$(id -g)" \
+      -v "{{docs_test_dir}}":/docs \
+      "{{docs_image}}" \
+      mkdocs build --strict
 
 # Generate docs, code/manifests, things to embed, etc
 gen: _kube_gen _embed _crd_ref_docs && test-docs


### PR DESCRIPTION
Make sure that the API reference builds with no warnings, before we attempt to synchronise it with the docs repo.

Follow-up to https://github.com/githedgehog/docs/pull/95.