### PR TITLE
No breakouts for VS profile and nil check

### DIFF
--- a/api/wiring/v1beta1/switchprofile_types.go
+++ b/api/wiring/v1beta1/switchprofile_types.go
@@ -925,6 +925,13 @@ func (sp *SwitchProfileSpec) GetAutoNegsDefaultsFor(sw *SwitchSpec) (map[string]
 }
 
 func (sp *SwitchProfileSpec) GetBreakoutDefaults(sw *SwitchSpec) (map[string]string, error) {
+	if sp == nil {
+		return nil, errors.Errorf("switch profile spec is nil")
+	}
+	if sw == nil {
+		return nil, errors.Errorf("switch spec is nil")
+	}
+
 	def := map[string]string{}
 
 	for portName, port := range sp.Ports {

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -853,7 +853,7 @@ This is a virtual switch profile. It's for testing/demo purpose only with limite
 
 Switch Silicon: **vs**
 
-Ports Summary: **48xSFP28-25G, 8xQSFP28-100G**
+Ports Summary: **48xSFP28-25G**
 
 **Supported features:**
 
@@ -916,13 +916,5 @@ Label column is a port label on a physical switch.
 | E1/46 | 46 | Port Group | 12 | 25G | 10G, 25G |
 | E1/47 | 47 | Port Group | 12 | 25G | 10G, 25G |
 | E1/48 | 48 | Port Group | 12 | 25G | 10G, 25G |
-| E1/49 | 49 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
-| E1/50 | 50 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
-| E1/51 | 51 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
-| E1/52 | 52 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
-| E1/53 | 53 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
-| E1/54 | 54 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
-| E1/55 | 55 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
-| E1/56 | 56 | Breakout |  | 1x100G | 1x100G, 1x10G, 1x25G, 1x40G, 1x50G, 2x50G, 4x10G, 4x25G |
 
 

--- a/pkg/ctrl/switchprofile/profile_vs.go
+++ b/pkg/ctrl/switchprofile/profile_vs.go
@@ -15,6 +15,7 @@
 package switchprofile
 
 import (
+	"github.com/samber/lo"
 	"go.githedgehog.com/fabric/api/meta"
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,8 +38,8 @@ var VS = wiringapi.SwitchProfile{
 		Config: wiringapi.SwitchProfileConfig{
 			MaxPathsEBGP: 16,
 		},
-		Ports:        DellS5248FON.Spec.Ports,
+		Ports:        lo.OmitBy(DellS5248FON.Spec.Ports, func(_ string, p wiringapi.SwitchProfilePort) bool { return p.BaseNOSName != "" }),
 		PortGroups:   DellS5248FON.Spec.PortGroups,
-		PortProfiles: DellS5248FON.Spec.PortProfiles,
+		PortProfiles: lo.OmitBy(DellS5248FON.Spec.PortProfiles, func(_ string, pp wiringapi.SwitchProfilePortProfile) bool { return pp.Breakout != nil }),
 	},
 }


### PR DESCRIPTION
We've started enforcing all breakouts to their default mode and on VS it leads to them being in the "In Progress" mode and agent trying to enable them on each periodic enforcement.

So, each two mins it'll be spam like:

```
time=2025-04-15T19:28:58.380Z level=DEBUG msg=Action idx=4 weight=7 summary="Create Port Breakout 1/49" command=update path="/components/component[name=1/49]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.430Z level=INFO msg="Action applied" idx=4 summary="Create Port Breakout 1/49"
time=2025-04-15T19:28:58.430Z level=DEBUG msg=Action idx=5 weight=7 summary="Create Port Breakout 1/50" command=update path="/components/component[name=1/50]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.481Z level=INFO msg="Action applied" idx=5 summary="Create Port Breakout 1/50"
time=2025-04-15T19:28:58.481Z level=DEBUG msg=Action idx=6 weight=7 summary="Create Port Breakout 1/51" command=update path="/components/component[name=1/51]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.532Z level=INFO msg="Action applied" idx=6 summary="Create Port Breakout 1/51"
time=2025-04-15T19:28:58.532Z level=DEBUG msg=Action idx=7 weight=7 summary="Create Port Breakout 1/52" command=update path="/components/component[name=1/52]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.583Z level=INFO msg="Action applied" idx=7 summary="Create Port Breakout 1/52"
time=2025-04-15T19:28:58.583Z level=DEBUG msg=Action idx=8 weight=7 summary="Create Port Breakout 1/53" command=update path="/components/component[name=1/53]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.634Z level=INFO msg="Action applied" idx=8 summary="Create Port Breakout 1/53"
time=2025-04-15T19:28:58.634Z level=DEBUG msg=Action idx=9 weight=7 summary="Create Port Breakout 1/54" command=update path="/components/component[name=1/54]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.684Z level=INFO msg="Action applied" idx=9 summary="Create Port Breakout 1/54"
time=2025-04-15T19:28:58.684Z level=DEBUG msg=Action idx=10 weight=7 summary="Create Port Breakout 1/55" command=update path="/components/component[name=1/55]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.734Z level=INFO msg="Action applied" idx=10 summary="Create Port Breakout 1/55"
time=2025-04-15T19:28:58.734Z level=DEBUG msg=Action idx=11 weight=7 summary="Create Port Breakout 1/56" command=update path="/components/component[name=1/56]/port/breakout-mode/groups/group[index=1]/config"
time=2025-04-15T19:28:58.783Z level=INFO msg="Action applied" idx=11 summary="Create Port Breakout 1/56"
```

while it'll never get ready

```
admin@sonic:~$ sonic-cli
leaf-01# show interface breakout 
-----------------------------------------------
Port  Breakout Mode  Status        Interfaces          
-----------------------------------------------
1/49  1x100G         InProgress    Ethernet48          
1/50  1x100G         InProgress    Ethernet52          
1/51  1x100G         InProgress    Ethernet56          
1/52  1x100G         InProgress    Ethernet60          
1/53  1x100G         InProgress    Ethernet64          
1/54  1x100G         InProgress    Ethernet68          
1/55  1x100G         InProgress    Ethernet72          
1/56  1x100G         InProgress    Ethernet76 
```