### PR TITLE
fix: make sure to skip unmapped ports and avoid spam for vs

### DIFF
--- a/pkg/ctrl/switchprofile/profile_vs.go
+++ b/pkg/ctrl/switchprofile/profile_vs.go
@@ -43,3 +43,21 @@ var VS = wiringapi.SwitchProfile{
 		PortProfiles: lo.OmitBy(DellS5248FON.Spec.PortProfiles, func(_ string, pp wiringapi.SwitchProfilePortProfile) bool { return pp.Breakout != nil }),
 	},
 }
+
+// Breakout ports are not supported on VS and should be ignored
+var ignoredNOSPorts = map[string]bool{
+	"Ethernet48": true,
+	"Ethernet52": true,
+	"Ethernet56": true,
+	"Ethernet60": true,
+	"Ethernet64": true,
+	"Ethernet68": true,
+	"Ethernet72": true,
+	"Ethernet76": true,
+}
+
+func VSIsIgnoredNOSPort(port string) bool {
+	_, ok := ignoredNOSPorts[port]
+
+	return ok
+}


### PR DESCRIPTION
- we should actually skip interfaces when we can't map NOS names to API names (incl. transceivers)
- for VS we're intentionally ignoring breakout ports as they aren't working, so we should silently ignore them as well to avoid spam in the agent logs

Currently in the logs

```
time=2025-05-06T17:49:03.554Z level=DEBUG msg="Switch state updated" took=1.209500289s                                                                  
time=2025-05-06T17:49:17.344Z level=DEBUG msg="Sending heartbeat" name=leaf-01                                                                                            
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet64                                                          
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet68         
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet48                                                          
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet76            
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet60          
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet72        
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet56                                                          
time=2025-05-06T17:49:17.869Z level=WARN msg="Port mapping not found, ignoring for metrics" interface=Ethernet52                                                          
time=2025-05-06T17:49:18.578Z level=DEBUG msg="Switch state updated" took=1.234205546s                                                                                    
time=2025-05-06T17:49:32.345Z level=INFO msg="Processing agent config" name=leaf-01 gen=4 res=232900  
```