### PR TITLE
fix: sort nexthops in static routes

### DIFF
--- a/pkg/agent/dozer/bcm/spec_vrf.go
+++ b/pkg/agent/dozer/bcm/spec_vrf.go
@@ -17,6 +17,7 @@ package bcm
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -860,6 +861,7 @@ func unmarshalOCVRFs(ocVal *oc.OpenconfigNetworkInstance_NetworkInstances) (map[
 							})
 						}
 					}
+					slices.SortStableFunc(nextHops, NextHopCompare)
 
 					staticRoutes[prefix] = &dozer.SpecVRFStaticRoute{
 						NextHops: nextHops,


### PR DESCRIPTION
to normalize config and avoid churn due to out of order nexthops when computing the diffs

Fixes #858 