### PR TITLE
ci(runners): switch to finally migrated to hetzner runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,3 @@
 self-hosted-runner:
   labels:
     - lab
-    - lab-h

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
   #         limit-access-to-actor: true
 
   test:
-    runs-on: lab-h
+    runs-on: lab
     # needs:
     #   - cache-tools
 
@@ -120,7 +120,7 @@ jobs:
           limit-access-to-actor: true
 
   test-api:
-    runs-on: lab-h
+    runs-on: lab
     # needs:
     #   - cache-tools
 
@@ -160,7 +160,7 @@ jobs:
           limit-access-to-actor: true
 
   build:
-    runs-on: lab-h
+    runs-on: lab
     # needs:
     #   - cache-tools
 
@@ -194,7 +194,7 @@ jobs:
           limit-access-to-actor: true
 
   publish:
-    runs-on: lab-h
+    runs-on: lab
     if: startsWith(github.event.ref, 'refs/tags/v') && github.event_name == 'push'
     needs:
       # - cache-tools


### PR DESCRIPTION
Enables githedgehog/lab#245