### PR TITLE
fix(ctrl): catalog subnets for staticExt

### DIFF
--- a/pkg/ctrl/agent_ctrl.go
+++ b/pkg/ctrl/agent_ctrl.go
@@ -621,9 +621,6 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req kctrl.Request) (kct
 		if conn.StaticExternal == nil {
 			continue
 		}
-		if conn.StaticExternal.WithinVPC == "" {
-			continue
-		}
 
 		_, ipNet, err := net.ParseCIDR(conn.StaticExternal.Link.Switch.IP)
 		if err != nil {


### PR DESCRIPTION
previously we did not care to add to the catalog subnets for static external connections that were not within a VPC; however after the BGP simplification code we create a prefix list for it regardless, so we cannot skip the catalog step.

see: https://github.com/githedgehog/fabricator/pull/796#issuecomment-3107666114 and https://github.com/githedgehog/fabricator/pull/796#issuecomment-3107857738