### PR TITLE
revert: "chore: correct platform string for ds3000 v2"

### DIFF
--- a/pkg/ctrl/switchprofile/p_bcm_celestica_ds3000.go
+++ b/pkg/ctrl/switchprofile/p_bcm_celestica_ds3000.go
@@ -28,7 +28,7 @@ var CelesticaDS3000 = wiringapi.SwitchProfile{
 			ECMPRoCEQPN:   false,
 		},
 		NOSType:  meta.NOSTypeSONiCBCMBase,
-		Platform: "x86_64-cls_ds3000-r0",
+		Platform: "x86_64-cel_seastone_2-r0",
 		Config:   wiringapi.SwitchProfileConfig{},
 		Ports: map[string]wiringapi.SwitchProfilePort{
 			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth0"},


### PR DESCRIPTION
This reverts commit d3c8bef56931b952cbdcb29e504a3df347980ac6.

We shouldn't change onie platform string w/o actually having the onie-updater ready and published.