### PR TITLE
chore(agent): consider no status as completed for breakouts

### DIFF
--- a/pkg/agent/dozer/bcm/spec_system.go
+++ b/pkg/agent/dozer/bcm/spec_system.go
@@ -261,11 +261,13 @@ func unmarshalOCPortBreakouts(ocVal *oc.SonicPortBreakout_SonicPortBreakout) (ma
 	}
 
 	for _, breakoutCfg := range ocVal.BREAKOUT_CFG.BREAKOUT_CFG_LIST {
-		if breakoutCfg.Port == nil || breakoutCfg.BrkoutMode == nil || breakoutCfg.Status == nil {
+		if breakoutCfg.Port == nil || breakoutCfg.BrkoutMode == nil {
 			continue
 		}
 
-		if *breakoutCfg.Status != "Completed" || breakoutCfg.BreakoutOwner != oc.SonicPortBreakout_SonicPortBreakout_BREAKOUT_CFG_BREAKOUT_CFG_LIST_BreakoutOwner_MANUAL {
+		// if there is no status we consider it as completed
+		if breakoutCfg.Status != nil && *breakoutCfg.Status != "Completed" ||
+			breakoutCfg.BreakoutOwner != oc.SonicPortBreakout_SonicPortBreakout_BREAKOUT_CFG_BREAKOUT_CFG_LIST_BreakoutOwner_MANUAL {
 			continue
 		}
 


### PR DESCRIPTION
Seems like we're seeing agent trying to apply breakouts on some switches again and again as gNMI isn't showing Completed status for some breakouts for some reason. CLI still shows them as completed so it seems safe to assume no status is completed as well.

Related githedgehog/internal#239