### PR TITLE
ci: add skip vlabs status check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - vlab
-    if: ${{ always() }}
+    if: ${{ needs.vlab.result != 'skipped' }}
 
     steps:
       - run: |


### PR DESCRIPTION
Coming from https://github.com/githedgehog/fabric/pull/1126