### PR TITLE
chore: delete VRF VNIs before VLAN ones

### DIFF
--- a/pkg/agent/dozer/bcm/enforcer.go
+++ b/pkg/agent/dozer/bcm/enforcer.go
@@ -138,6 +138,7 @@ const (
 	ActionWeightLSTGroupUpdate
 	ActionWeightLSTInterfaceUpdate
 
+	ActionWeightVRFVNIDelete
 	ActionWeightVXLANTunnelMapDelete
 	ActionWeightVXLANTunnelUpdate
 	ActionWeightVXLANEVPNNVODelete
@@ -161,8 +162,6 @@ const (
 
 	ActionWeightVRFBGPImportVRFDelete
 	ActionWeightVRFBGPImportVRFPolicyDelete
-
-	ActionWeightVRFVNIDelete
 
 	ActionWeightLSTInterfaceDelete
 	ActionWeightLSTGroupDelete


### PR DESCRIPTION
following the instructions given to us by BCM as a workaround for an issue with VXLAN tunnel resources leaking in the DS5000

(Hopefully) fixes https://github.com/githedgehog/internal/issues/244