### PR TITLE
make new ASN/mgmt subnet params mandatory

### DIFF
--- a/api/meta/types.go
+++ b/api/meta/types.go
@@ -302,30 +302,39 @@ func (cfg *FabricConfig) Init() (*FabricConfig, error) {
 		return nil, errors.Errorf("config: gatewayASN is required")
 	}
 
-	// TODO: make these fields required after we update fabricator to populate them
+	if cfg.SpineASN == 0 {
+		return nil, errors.Errorf("config: spineASN is required")
+	}
+	if cfg.LeafASNStart == 0 {
+		return nil, errors.Errorf("config: leafASNStart is required")
+	}
+	if cfg.LeafASNEnd == 0 {
+		return nil, errors.Errorf("config: leafASNEnd is required")
+	}
 	if cfg.LeafASNEnd < cfg.LeafASNStart {
 		return nil, errors.Errorf("config: leafASNEnd must be greater than or equal to leafASNStart")
 	}
-	if cfg.SpineASN != 0 && cfg.SpineASN >= cfg.LeafASNStart && cfg.SpineASN <= cfg.LeafASNEnd {
+	if cfg.SpineASN >= cfg.LeafASNStart && cfg.SpineASN <= cfg.LeafASNEnd {
 		return nil, errors.Errorf("config: spineASN must not be in the leaf ASN range")
 	}
-	if cfg.ManagementSubnet != "" {
-		_, mgmtSubnet, err := net.ParseCIDR(cfg.ManagementSubnet)
-		if err != nil {
-			return nil, errors.Errorf("config: managementSubnet is invalid: %v", err)
-		}
-		if cfg.ManagementDHCPStart == "" {
-			return nil, errors.Errorf("config: managementDHCPStart is required")
-		}
-		if cfg.ManagementDHCPEnd == "" {
-			return nil, errors.Errorf("config: managementDHCPEnd is required")
-		}
-		if ipStart := net.ParseIP(cfg.ManagementDHCPStart); ipStart == nil || !mgmtSubnet.Contains(ipStart) {
-			return nil, errors.Errorf("config: managementDHCPStart is not a valid IP in managementSubnet")
-		}
-		if ipEnd := net.ParseIP(cfg.ManagementDHCPEnd); ipEnd == nil || !mgmtSubnet.Contains(ipEnd) {
-			return nil, errors.Errorf("config: managementDHCPEnd is not a valid IP in managementSubnet")
-		}
+	if cfg.ManagementSubnet == "" {
+		return nil, errors.Errorf("config: managementSubnet is required")
+	}
+	if cfg.ManagementDHCPStart == "" {
+		return nil, errors.Errorf("config: managementDHCPStart is required")
+	}
+	if cfg.ManagementDHCPEnd == "" {
+		return nil, errors.Errorf("config: managementDHCPEnd is required")
+	}
+	_, mgmtSubnet, err := net.ParseCIDR(cfg.ManagementSubnet)
+	if err != nil {
+		return nil, errors.Errorf("config: managementSubnet is invalid: %v", err)
+	}
+	if ipStart := net.ParseIP(cfg.ManagementDHCPStart); ipStart == nil || !mgmtSubnet.Contains(ipStart) {
+		return nil, errors.Errorf("config: managementDHCPStart is not a valid IP in managementSubnet")
+	}
+	if ipEnd := net.ParseIP(cfg.ManagementDHCPEnd); ipEnd == nil || !mgmtSubnet.Contains(ipEnd) {
+		return nil, errors.Errorf("config: managementDHCPEnd is not a valid IP in managementSubnet")
 	}
 
 	// TODO enable in future releases

--- a/api/wiring/v1beta1/switch_types.go
+++ b/api/wiring/v1beta1/switch_types.go
@@ -248,19 +248,13 @@ func (sw *Switch) HydrationValidation(ctx context.Context, kube kclient.Reader, 
 	if err != nil {
 		return errors.Wrapf(err, "failed to parse Fabric control VIP %s", fabricCfg.ControlVIP)
 	}
-	var mgmtSubnet netip.Prefix
-	var mgmtDHCPStart netip.Addr
-	if fabricCfg.ManagementSubnet != "" {
-		mgmtSubnet, err = netip.ParsePrefix(fabricCfg.ManagementSubnet)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse Fabric management subnet %s", fabricCfg.ManagementSubnet)
-		}
+	mgmtSubnet, err := netip.ParsePrefix(fabricCfg.ManagementSubnet)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse Fabric management subnet %s", fabricCfg.ManagementSubnet)
 	}
-	if fabricCfg.ManagementDHCPStart != "" {
-		mgmtDHCPStart, err = netip.ParseAddr(fabricCfg.ManagementDHCPStart)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse Fabric management DHCP start %s", fabricCfg.ManagementDHCPStart)
-		}
+	mgmtDHCPStart, err := netip.ParseAddr(fabricCfg.ManagementDHCPStart)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse Fabric management DHCP start %s", fabricCfg.ManagementDHCPStart)
 	}
 	mgmtIPs[controlVIP.Addr()] = true
 
@@ -294,10 +288,10 @@ func (sw *Switch) HydrationValidation(ctx context.Context, kube kclient.Reader, 
 			return errors.Wrapf(err, "parsing switch %s IP %s", sw.Name, sw.Spec.IP)
 		}
 
-		if mgmtSubnet.IsValid() && !mgmtSubnet.Contains(swIP.Addr()) {
+		if !mgmtSubnet.Contains(swIP.Addr()) {
 			return errors.Errorf("switch %s management IP %s is not in the management subnet %s", sw.Name, swIP, mgmtSubnet) //nolint:goerr113
 		}
-		if mgmtDHCPStart.IsValid() && swIP.Addr().Compare(mgmtDHCPStart) >= 0 {
+		if swIP.Addr().Compare(mgmtDHCPStart) >= 0 {
 			return errors.Errorf("switch %s management IP %s is in the management DHCP range starting at %s", sw.Name, swIP, mgmtDHCPStart) //nolint:goerr113
 		}
 		if _, exist := mgmtIPs[swIP.Addr()]; exist {
@@ -339,13 +333,13 @@ func (sw *Switch) HydrationValidation(ctx context.Context, kube kclient.Reader, 
 			return errors.Errorf("leaf %s ASN %d is already in use", sw.Name, sw.Spec.ASN) //nolint:goerr113
 		}
 		// also check if it's within the fabric leaf ASN range
-		if fabricCfg.LeafASNStart != 0 && fabricCfg.LeafASNEnd != 0 && (sw.Spec.ASN < fabricCfg.LeafASNStart || sw.Spec.ASN > fabricCfg.LeafASNEnd) {
+		if sw.Spec.ASN < fabricCfg.LeafASNStart || sw.Spec.ASN > fabricCfg.LeafASNEnd {
 			return errors.Errorf("leaf %s ASN %d is not within the fabric leaf ASN range %d-%d", sw.Name, sw.Spec.ASN, fabricCfg.LeafASNStart, fabricCfg.LeafASNEnd) //nolint:goerr113
 		}
 	}
 
 	// spine ASN consistency check
-	if sw.Spec.Role.IsSpine() && fabricCfg.SpineASN != 0 && sw.Spec.ASN != fabricCfg.SpineASN {
+	if sw.Spec.Role.IsSpine() && sw.Spec.ASN != fabricCfg.SpineASN {
 		return errors.Errorf("spine %s ASN %d is not the expected spine ASN %d", sw.Name, sw.Spec.ASN, fabricCfg.SpineASN) //nolint:goerr113
 	}
 


### PR DESCRIPTION
This reverts commit 5511ac020eb13b2e68e398b70b54896ea9ba90fd.

Fabricator now populates these fields, so we do not need to worry about them not being available.

Fix https://github.com/githedgehog/internal/issues/253