### PR TITLE
fix: route-map on gw conn bgp session

### DIFF
--- a/pkg/agent/dozer/bcm/README.plan.md
+++ b/pkg/agent/dozer/bcm/README.plan.md
@@ -396,6 +396,8 @@ and assigning it a /31 IPv4 address from the hydration pool, e.g.:
 1. create a BGP session with the other host in that /31 range. The ASN of the
 gateway currently comes from config (note: we could use `remote-as external` instead).
 Like for other EVPN peers in our config, we set `allowas-in` in the L2VPN AF.
+We also set the `l2vpn-neighbors` route-map in the import direction, which ensures
+that the correct gateway route will be picked based on priorities/communities.
     ```
     neighbor 172.30.128.13
      description "Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1"
@@ -407,6 +409,7 @@ Like for other EVPN peers in our config, we set `allowas-in` in the L2VPN AF.
      address-family l2vpn evpn
       activate
       allowas-in
+      route-map l2vpn-neighbors in
     ```
 
 #### Workaround for TH5-based platforms

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -842,13 +842,14 @@ func planGatewayConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 			}
 
 			spec.VRFs[VRFDefault].BGP.Neighbors[ip.String()] = &dozer.SpecVRFBGPNeighbor{
-				Enabled:             pointer.To(true),
-				Description:         pointer.To(fmt.Sprintf("Gateway %s %s", remote, connName)),
-				RemoteAS:            pointer.To(agent.Spec.Config.GatewayASN), // TODO load peer GW and get ASN from it
-				IPv4Unicast:         pointer.To(true),
-				L2VPNEVPN:           pointer.To(true),
-				L2VPNEVPNAllowOwnAS: pointer.To(true),
-				BFDProfile:          bfdProfile,
+				Enabled:                 pointer.To(true),
+				Description:             pointer.To(fmt.Sprintf("Gateway %s %s", remote, connName)),
+				RemoteAS:                pointer.To(agent.Spec.Config.GatewayASN), // TODO load peer GW and get ASN from it
+				IPv4Unicast:             pointer.To(true),
+				L2VPNEVPN:               pointer.To(true),
+				L2VPNEVPNAllowOwnAS:     pointer.To(true),
+				L2VPNEVPNImportPolicies: []string{RouteMapL2VPNNeighbors},
+				BFDProfile:              bfdProfile,
 			}
 		}
 	}

--- a/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.spec.expected.yaml
@@ -408,6 +408,8 @@ vrfs:
           ipv4Unicast: true
           l2vpnEvpn: true
           l2vpnEvpnAllowOwnAS: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
           remoteAS: 65534
       networkImportCheck: true
       routerID: 172.30.8.0


### PR DESCRIPTION
we were setting it on the fabric connections but not on the sessions between fabric nodes and gateways; this could create route flapping, as fabric nodes believed they had better routes than the ones they learned from a peer connected to the gateway

Fix https://github.com/githedgehog/fabricator/issues/1421