### PR TITLE
feat: fallback for cumulus with no vlan overlap support

### DIFF
--- a/pkg/ctrl/vpc_ctrl.go
+++ b/pkg/ctrl/vpc_ctrl.go
@@ -178,7 +178,7 @@ func (r *VPCReconciler) updateDHCPSubnets(ctx context.Context, vpc *vpcapi.VPC) 
 			vrf := ""
 			switch vpc.Spec.Mode {
 			case vpcapi.VPCModeL2VNI, vpcapi.VPCModeL3VNI:
-				vrf = fmt.Sprintf("VrfV%s", vpc.Name) // TODO move to utils
+				vrf = strings.ToLower(vpc.Name)
 			case vpcapi.VPCModeL3Flat:
 				vrf = "default"
 			}
@@ -202,7 +202,7 @@ func (r *VPCReconciler) updateDHCPSubnets(ctx context.Context, vpc *vpcapi.VPC) 
 				EndIP:               subnet.DHCP.Range.End,
 				LeaseTimeSeconds:    leaseTime,
 				VRF:                 vrf,
-				CircuitID:           fmt.Sprintf("Vlan%d", subnet.VLAN), // TODO move to utils
+				CircuitID:           fmt.Sprintf("vlan%d", subnet.VLAN), // TODO move to utils
 				PXEURL:              pxeURL,
 				DNSServers:          dnsServers,
 				TimeServers:         timeServers,

--- a/pkg/dhcp/ipam.go
+++ b/pkg/dhcp/ipam.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"strings"
 	"time"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
@@ -16,9 +17,13 @@ import (
 
 const (
 	defaultVRF = "default"
+	vlanPrefix = "vlan"
 )
 
 func subnetKey(vrf, circuitID string) string {
+	vrf = strings.ToLower(vrf)
+	circuitID = strings.ToLower(circuitID)
+
 	if vrf == "" {
 		vrf = defaultVRF
 	}


### PR DESCRIPTION
Due to lack of the VRF marking on DHCP relayed packets we can't reliable distinguish between VPCs with overlapping VLANs.