### PR TITLE
bump: go => 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.githedgehog.com/fabric
 
-go 1.25.7
+go 1.26
 
 replace gopkg.in/natefinch/lumberjack.v2 v2.2.1 => github.com/githedgehog/lumberjack/v2 v2.2.1-hh
 


### PR DESCRIPTION
Setting it to 1.26 (without a patch) enables automatic retrieval of the latest patch version, which is nice.