### PR TITLE
fix(agent): only import peered subnets in external VRF

### DIFF
--- a/pkg/agent/dozer/bcm/README.plan.md
+++ b/pkg/agent/dozer/bcm/README.plan.md
@@ -1086,6 +1086,15 @@ from going out via the external attachment:
      seq 65535 permit ip any any
     !
     ```
+1. We create a prefix list and a route-map to filter what is imported into the external's
+VRF via route leaking, i.e. when we peer a VPC with the external via the Fabric. The
+prefix list, initially empty, is dynamically populated with the prefixes of the VPC
+subnets that are permitted in the [external peerings](#external-peerings):
+    ```
+    route-map ext-import--ext-name permit 10
+     match ip address prefix-list ext-import--ext-name
+    !
+    ```
 1. We configure a BGP instance for the external VRF. This is done for all externals,
 not just BGP-speaking ones, because it's part of how we handle external VRFs "as VPCs"
 and peer them via the gateway as needed. 
@@ -1098,7 +1107,7 @@ and peer them via the gateway as needed.
      address-family ipv4 unicast
       maximum-paths 16
       maximum-paths ibgp 1
-      import vrf route-map ipns-subnets--default
+      import vrf route-map ext-import--ext-name
      !
      address-family l2vpn evpn
       advertise ipv4 unicast
@@ -1132,7 +1141,7 @@ In the outbound route-map, used in the out direction with the external:
   - we permit any route matching the IPv4 namespace the external belongs to, and we tag those with the external's outbound community
   - we permit any route matching the gateway priority community list (`all-gw-prios`), and we tag those with the external's outbound community;
   this is to ensure that NATed prefixes learned from the gateway are exported to the external
-  - we deny everything else
+  - we deny everything else. Note that in practice, due to the route-leaking route-map, nothing else should be present in the VRF anyway.
 In the `ipns-ext-communities-<IPV4NAMESPACE>` route-map, used to filter routes leaked in the external VRF:
   - we permit routes that match the corresponding community list mentioned above
   - we deny everything else
@@ -1258,6 +1267,11 @@ will also match on the inbound community of that external.
      match community ext-inbound--ext-name
      set local-preference 500
     !
+    ```
+1. We add the VPC subnet(s) to the prefix list for the external's VRF route leaking, allowing
+them through:
+    ```
+    ip prefix-list ext-import--ext-name seq 101 permit 10.0.1.0/24 le 32
     ```
 1. We enable route leaking between the VRFs of the VPC and the external:
     ```

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -1052,6 +1052,20 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 			seq += 10
 		}
 
+		spec.PrefixLists[extImportPrefixListName(externalName)] = &dozer.SpecPrefixList{
+			Prefixes: map[uint32]*dozer.SpecPrefixListEntry{},
+		}
+		spec.RouteMaps[extImportRouteMapName(externalName)] = &dozer.SpecRouteMap{
+			Statements: map[string]*dozer.SpecRouteMapStatement{
+				"10": {
+					Conditions: dozer.SpecRouteMapConditions{
+						MatchPrefixList: pointer.To(extImportPrefixListName(externalName)),
+					},
+					Result: dozer.SpecRouteMapResultAccept,
+				},
+			},
+		}
+
 		if spec.VRFs[extVrfName] == nil {
 			protocolIP, _, err := net.ParseCIDR(agent.Spec.Switch.ProtocolIP)
 			if err != nil {
@@ -1073,7 +1087,7 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 						MaxPaths:     pointer.To(getMaxPaths(agent)),
 						Networks:     map[string]*dozer.SpecVRFBGPNetwork{},
 						ImportVRFs:   map[string]*dozer.SpecVRFBGPImportVRF{},
-						ImportPolicy: pointer.To(ipnsSubnetsPrefixListName(external.IPv4Namespace)),
+						ImportPolicy: pointer.To(extImportRouteMapName(externalName)),
 					},
 					L2VPNEVPN: dozer.SpecVRFBGPL2VPNEVPN{
 						Enabled:              agent.IsSpineLeaf(),
@@ -3137,9 +3151,24 @@ func planExternalPeerings(agent *agentapi.Agent, spec *dozer.Spec) error {
 		}
 
 		for _, subnetName := range peering.Permit.VPC.Subnets {
-			_, exists := vpc.Subnets[subnetName]
+			subnet, exists := vpc.Subnets[subnetName]
 			if !exists {
 				return errors.Errorf("VPC %s subnet %s not found for external peering %s", vpcName, subnetName, name)
+			}
+			idx := agent.Spec.Catalog.SubnetIDs[subnet.Subnet]
+			if idx == 0 {
+				return errors.Errorf("no vpc subnet id for subnet %s of vpc %s in peering %s", subnet.Subnet, vpcName, name)
+			}
+			if idx >= 65000 {
+				return errors.Errorf("vpc subnet id for subnet %s of vpc %s in peering %s is too large", subnet.Subnet, vpcName, name)
+			}
+
+			spec.PrefixLists[extImportPrefixListName(externalName)].Prefixes[idx] = &dozer.SpecPrefixListEntry{
+				Prefix: dozer.SpecPrefixListPrefix{
+					Prefix: subnet.Subnet,
+					Le:     32,
+				},
+				Action: dozer.SpecPrefixListActionPermit,
 			}
 		}
 
@@ -3433,6 +3462,16 @@ func extInboundCommListName(external string) string {
 
 func extInboundRouteMapName(external string) string {
 	return fmt.Sprintf("ext-inbound--%s", external)
+}
+
+// route-map to filter what we import in the external's VRF. matches on the prefix list below
+func extImportRouteMapName(external string) string {
+	return fmt.Sprintf("ext-import--%s", external)
+}
+
+// prefix list with all the VPC subnets that have been peered with a given external, to filter what we import in the external's VRF
+func extImportPrefixListName(external string) string {
+	return fmt.Sprintf("ext-import--%s", external)
 }
 
 func extOutboundRouteMapName(external string) string {

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
@@ -257,6 +257,14 @@ prefixLists:
         prefix:
           le: 32
           prefix: 0.0.0.0/0
+  ext-import--ext-snp-02:
+    prefixes:
+      "101":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.2.0/24
+  ext-import--ext-sp-01: {}
   import-vrf--vpc-02--ext-snp-02:
     prefixes:
       "103":
@@ -387,6 +395,18 @@ prefixLists:
           le: 32
           prefix: 10.0.3.0/24
 routeMaps:
+  ext-import--ext-snp-02:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ext-import--ext-snp-02
+        result: accept
+  ext-import--ext-sp-01:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ext-import--ext-sp-01
+        result: accept
   filter-attached-hosts:
     statements:
       "10":
@@ -699,7 +719,7 @@ vrfs:
       as: 65101
       ipv4Unicast:
         enable: true
-        importPolicy: ipns-subnets--default
+        importPolicy: ext-import--ext-snp-02
         importVRFs:
           VrfVvpc-02: {}
         maxPaths: 16
@@ -729,7 +749,7 @@ vrfs:
       as: 65101
       ipv4Unicast:
         enable: true
-        importPolicy: ipns-subnets--default
+        importPolicy: ext-import--ext-sp-01
         maxPaths: 16
       l2vpnEvpn:
         advertiseIPv4Unicast: true

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
@@ -239,6 +239,13 @@ prefixLists:
         prefix:
           le: 32
           prefix: 0.0.0.0/0
+  ext-import--ext-bgp-01:
+    prefixes:
+      "100":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.3.0/24
   import-vrf--vpc-03--ext-bgp-01:
     prefixes:
       "101":
@@ -297,6 +304,12 @@ prefixLists:
           le: 32
           prefix: 10.0.3.0/24
 routeMaps:
+  ext-import--ext-bgp-01:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ext-import--ext-bgp-01
+        result: accept
   ext-inbound--ext-bgp-01:
     statements:
       "5":
@@ -518,7 +531,7 @@ vrfs:
       as: 65103
       ipv4Unicast:
         enable: true
-        importPolicy: ipns-subnets--default
+        importPolicy: ext-import--ext-bgp-01
         importVRFs:
           VrfVvpc-03: {}
         maxPaths: 16

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
@@ -304,6 +304,18 @@ prefixLists:
         prefix:
           le: 32
           prefix: 0.0.0.0/0
+  ext-import--external-01:
+    prefixes:
+      "103":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.5.0/24
+      "105":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.1.0/24
   import-vrf--vpc-01--external-01:
     prefixes:
       "106":
@@ -471,6 +483,12 @@ prefixLists:
           le: 32
           prefix: 10.0.8.0/24
 routeMaps:
+  ext-import--external-01:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ext-import--external-01
+        result: accept
   ext-inbound--external-01:
     statements:
       "5":
@@ -823,7 +841,7 @@ vrfs:
       as: 65102
       ipv4Unicast:
         enable: true
-        importPolicy: ipns-subnets--default
+        importPolicy: ext-import--external-01
         importVRFs:
           VrfVvpc-01: {}
           VrfVvpc-03: {}


### PR DESCRIPTION
anything that is not a prefix form a peered VPC subnet should not be imported into the external VRF via route leaking, least we expose those prefixes to the external device and break our promise of isolation

Fix #1349 