### PR TITLE
DHCP relay to another VPC (take 2)

### DIFF
--- a/api/vpc/v1beta1/vpc_types.go
+++ b/api/vpc/v1beta1/vpc_types.go
@@ -99,6 +99,8 @@ type VPCSubnet struct {
 type VPCDHCP struct {
 	// Relay is the DHCP relay IP address, if specified, DHCP server will be disabled
 	Relay string `json:"relay,omitempty"`
+	// RelayVPC is the name of the VPC where the selected DHCP relay lives
+	RelayVPC string `json:"relayVPC,omitempty"`
 	// Enable enables DHCP server for the subnet
 	Enable bool `json:"enable,omitempty"`
 	// Range (optional) is the DHCP range for the subnet if DHCP server is enabled
@@ -441,6 +443,8 @@ func (vpc *VPC) Validate(ctx context.Context, kube kclient.Reader, fabricCfg *me
 			if err != nil {
 				return nil, errors.Wrapf(err, "subnet %s: failed to parse dhcp relay %s", subnetName, subnetCfg.DHCP.Relay)
 			}
+		} else if subnetCfg.DHCP.RelayVPC != "" {
+			return nil, errors.Errorf("subnet %s: dhcp relay VPC specified but dhcp relay is not enabled", subnetName)
 		}
 
 		if subnetCfg.DHCP.Options != nil && !subnetCfg.DHCP.Enable {
@@ -703,6 +707,18 @@ func (vpc *VPC) Validate(ctx context.Context, kube kclient.Reader, fabricCfg *me
 
 			if !subnetCfg.HostBGP && !vlanNs.Spec.Contains(subnetCfg.VLAN) {
 				return nil, errors.Errorf("vpc subnet %s (%s) vlan %d doesn't belong to the VLANNamespace %s", subnetName, subnetCfg.Subnet, subnetCfg.VLAN, vpc.Spec.VLANNamespace)
+			}
+
+			if subnetCfg.DHCP.RelayVPC != "" {
+				relayVPC := &VPC{}
+				err := kube.Get(ctx, ktypes.NamespacedName{Name: subnetCfg.DHCP.RelayVPC, Namespace: vpc.Namespace}, relayVPC)
+				if err != nil {
+					if kapierrors.IsNotFound(err) {
+						return nil, errors.Errorf("subnet %s: dhcp relay VPC %s not found", subnetName, subnetCfg.DHCP.RelayVPC)
+					}
+
+					return nil, errors.Wrapf(err, "subnet %s: failed to get dhcp relay VPC %s", subnetName, subnetCfg.DHCP.RelayVPC) // TODO replace with some internal error to not expose to the user
+				}
 			}
 		}
 

--- a/config/crd/bases/agent.githedgehog.com_agents.yaml
+++ b/config/crd/bases/agent.githedgehog.com_agents.yaml
@@ -1831,6 +1831,10 @@ spec:
                                 description: Relay is the DHCP relay IP address, if
                                   specified, DHCP server will be disabled
                                 type: string
+                              relayVPC:
+                                description: RelayVPC is the name of the VPC where
+                                  the selected DHCP relay lives
+                                type: string
                               static:
                                 additionalProperties:
                                   description: VPCDHCPStatic represents static IP

--- a/config/crd/bases/vpc.githedgehog.com_vpcs.yaml
+++ b/config/crd/bases/vpc.githedgehog.com_vpcs.yaml
@@ -191,6 +191,10 @@ spec:
                           description: Relay is the DHCP relay IP address, if specified,
                             DHCP server will be disabled
                           type: string
+                        relayVPC:
+                          description: RelayVPC is the name of the VPC where the selected
+                            DHCP relay lives
+                          type: string
                         static:
                           additionalProperties:
                             description: VPCDHCPStatic represents static IP assignment

--- a/docs/api.md
+++ b/docs/api.md
@@ -2011,6 +2011,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `relay` _string_ | Relay is the DHCP relay IP address, if specified, DHCP server will be disabled |  |  |
+| `relayVPC` _string_ | RelayVPC is the name of the VPC where the selected DHCP relay lives |  |  |
 | `enable` _boolean_ | Enable enables DHCP server for the subnet |  |  |
 | `range` _[VPCDHCPRange](#vpcdhcprange)_ | Range (optional) is the DHCP range for the subnet if DHCP server is enabled |  |  |
 | `options` _[VPCDHCPOptions](#vpcdhcpoptions)_ | Options (optional) is the DHCP options for the subnet if DHCP server is enabled |  |  |

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -2849,24 +2849,36 @@ func planVNIVPCSubnet(agent *agentapi.Agent, spec *dozer.Spec, vpcName string, v
 
 	if subnet.DHCP.Enable || subnet.DHCP.Relay != "" {
 		var dhcpRelayIP net.IP
+		var srcInterface *string
+		var relayVRF *string
 
 		if subnet.DHCP.Enable {
 			dhcpRelayIP, _, err = net.ParseCIDR(agent.Spec.Config.ControlVIP)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s (control vip) for vpc %s", agent.Spec.Config.ControlVIP, vpcName)
 			}
+			srcInterface = pointer.To(MgmtIface)
 		} else {
 			dhcpRelayIP, _, err = net.ParseCIDR(subnet.DHCP.Relay)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s for vpc %s", subnet.DHCP.Relay, vpcName)
 			}
+			if subnet.DHCP.RelayVPC != "" {
+				relayVrfName := vpcVrfName(subnet.DHCP.RelayVPC)
+				if _, exists := spec.VRFs[relayVrfName]; !exists {
+					return errors.Errorf("subnet %s of VPC %s is configured with DHCP relay to VPC %s but the corresponding VRF is not known", subnetName, vpcName, subnet.DHCP.RelayVPC)
+				}
+				relayVRF = pointer.To(relayVrfName)
+				srcInterface = pointer.To(subnetIface)
+			}
 		}
 
 		spec.DHCPRelays[subnetIface] = &dozer.SpecDHCPRelay{
-			SourceInterface: pointer.To(MgmtIface),
+			SourceInterface: srcInterface,
 			RelayAddress:    []string{dhcpRelayIP.String()},
-			LinkSelect:      true,
+			LinkSelect:      srcInterface != nil,
 			VRFSelect:       true,
+			VRF:             relayVRF,
 		}
 	}
 
@@ -2903,24 +2915,36 @@ func planL3FlatVPCSubnet(agent *agentapi.Agent, spec *dozer.Spec, vpcName string
 
 	if subnet.DHCP.Enable || subnet.DHCP.Relay != "" {
 		var dhcpRelayIP net.IP
+		var srcInterface *string
+		var relayVRF *string
 
 		if subnet.DHCP.Enable {
 			dhcpRelayIP, _, err = net.ParseCIDR(agent.Spec.Config.ControlVIP)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s (control vip) for vpc %s", agent.Spec.Config.ControlVIP, vpcName)
 			}
+			srcInterface = pointer.To(MgmtIface)
 		} else {
 			dhcpRelayIP, _, err = net.ParseCIDR(subnet.DHCP.Relay)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s for vpc %s", subnet.DHCP.Relay, vpcName)
 			}
+			if subnet.DHCP.RelayVPC != "" {
+				relayVrfName := vpcVrfName(subnet.DHCP.RelayVPC)
+				if _, exists := spec.VRFs[relayVrfName]; !exists {
+					return errors.Errorf("subnet %s of VPC %s is configured with DHCP relay to VPC %s but the corresponding VRF is not known", subnetName, vpcName, subnet.DHCP.RelayVPC)
+				}
+				relayVRF = pointer.To(relayVrfName)
+				srcInterface = pointer.To(subnetIface)
+			}
 		}
 
 		spec.DHCPRelays[subnetIface] = &dozer.SpecDHCPRelay{
-			SourceInterface: pointer.To(MgmtIface),
+			SourceInterface: srcInterface,
 			RelayAddress:    []string{dhcpRelayIP.String()},
-			LinkSelect:      true,
+			LinkSelect:      srcInterface != nil,
 			VRFSelect:       true, // just for consistency, not used in L3 VPCs as it's always in a default VRF
+			VRF:             relayVRF,
 		}
 	}
 

--- a/pkg/agent/dozer/bcm/spec_dhcp.go
+++ b/pkg/agent/dozer/bcm/spec_dhcp.go
@@ -61,6 +61,7 @@ var specDHCPRelayEnforcer = &DefaultValueEnforcer[string, *dozer.SpecDHCPRelay]{
 					Config: &oc.OpenconfigRelayAgent_RelayAgent_Dhcp_Interfaces_Interface_Config{
 						HelperAddress: value.RelayAddress,
 						SrcIntf:       value.SourceInterface,
+						Vrf:           value.VRF,
 					},
 				},
 			},
@@ -106,6 +107,7 @@ func unmarshalOCDHCPRelays(ocVal *oc.OpenconfigRelayAgent_RelayAgent_Dhcp_Interf
 			RelayAddress:    ocRelayIface.Config.HelperAddress,
 			LinkSelect:      cfg.LinkSelect == oc.OpenconfigRelayAgentExt_Mode_ENABLE,
 			VRFSelect:       cfg.VrfSelect == oc.OpenconfigRelayAgentExt_Mode_ENABLE,
+			VRF:             ocRelayIface.Config.Vrf,
 		}
 	}
 

--- a/pkg/agent/dozer/dozer.go
+++ b/pkg/agent/dozer/dozer.go
@@ -339,6 +339,7 @@ type SpecDHCPRelay struct {
 	RelayAddress    []string `json:"relayAddress,omitempty"`
 	LinkSelect      bool     `json:"linkSelect,omitempty"`
 	VRFSelect       bool     `json:"vrfSelect,omitempty"`
+	VRF             *string  `json:"vrf,omitempty"`
 }
 
 type SpecACL struct {

--- a/pkg/ctrl/agent_ctrl.go
+++ b/pkg/ctrl/agent_ctrl.go
@@ -438,20 +438,29 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, req kctrl.Request) (kct
 
 	vpcs := map[string]vpcapi.VPCSpec{}
 	vpcList := &vpcapi.VPCList{}
+	vpcRelays := map[string]bool{}
 	err = r.List(ctx, vpcList, kclient.InNamespace(sw.Namespace))
 	if err != nil {
 		return kctrl.Result{}, errors.Wrapf(err, "error listing vpcs")
 	}
 	for _, vpc := range vpcList.Items {
 		ok := attachedVPCs[vpc.Name] || staticExtVPCs[vpc.Name]
-		for subnetName := range vpc.Spec.Subnets {
+		for subnetName, subnetSpec := range vpc.Spec.Subnets {
 			if configuredSubnets[fmt.Sprintf("%s/%s", vpc.Name, subnetName)] {
 				ok = true
-
-				break
+				// if an attached VPC subnet refers to another VPC as DHCP relay, we need to add the VPC too
+				if subnetSpec.DHCP.RelayVPC != "" {
+					vpcRelays[subnetSpec.DHCP.RelayVPC] = true
+				}
 			}
 		}
 		if ok {
+			vpcs[vpc.Name] = vpc.Spec
+		}
+	}
+
+	for _, vpc := range vpcList.Items {
+		if vpcRelays[vpc.Name] {
 			vpcs[vpc.Name] = vpc.Spec
 		}
 	}


### PR DESCRIPTION
re-enable the relayVPC option, but:
- configure the realyVPC locally on a switch if any of the VPCs attached to the switch use the VPC for relay (to ensure that the VRF is there and we can forward requests via vxlan)
- use the vlan interface of the _client_ as source, and re-enable the linkSelect option

for inter-leaf relay, peering between the two vpcs is required so that DHCP offer can make it back to the client. this is not necessary when both client and server are attached to the same leaf.

Fix #1356 