### PR TITLE
Revert "feat: enable DHCP relay to other VPC"

### DIFF
--- a/api/vpc/v1beta1/vpc_types.go
+++ b/api/vpc/v1beta1/vpc_types.go
@@ -99,8 +99,6 @@ type VPCSubnet struct {
 type VPCDHCP struct {
 	// Relay is the DHCP relay IP address, if specified, DHCP server will be disabled
 	Relay string `json:"relay,omitempty"`
-	// RelayVPC is the name of the VPC where the selected DHCP relay lives
-	RelayVPC string `json:"relayVPC,omitempty"`
 	// Enable enables DHCP server for the subnet
 	Enable bool `json:"enable,omitempty"`
 	// Range (optional) is the DHCP range for the subnet if DHCP server is enabled
@@ -443,8 +441,6 @@ func (vpc *VPC) Validate(ctx context.Context, kube kclient.Reader, fabricCfg *me
 			if err != nil {
 				return nil, errors.Wrapf(err, "subnet %s: failed to parse dhcp relay %s", subnetName, subnetCfg.DHCP.Relay)
 			}
-		} else if subnetCfg.DHCP.RelayVPC != "" {
-			return nil, errors.Errorf("subnet %s: dhcp relay VPC specified but dhcp relay is not enabled", subnetName)
 		}
 
 		if subnetCfg.DHCP.Options != nil && !subnetCfg.DHCP.Enable {
@@ -707,18 +703,6 @@ func (vpc *VPC) Validate(ctx context.Context, kube kclient.Reader, fabricCfg *me
 
 			if !subnetCfg.HostBGP && !vlanNs.Spec.Contains(subnetCfg.VLAN) {
 				return nil, errors.Errorf("vpc subnet %s (%s) vlan %d doesn't belong to the VLANNamespace %s", subnetName, subnetCfg.Subnet, subnetCfg.VLAN, vpc.Spec.VLANNamespace)
-			}
-
-			if subnetCfg.DHCP.RelayVPC != "" {
-				relayVPC := &VPC{}
-				err := kube.Get(ctx, ktypes.NamespacedName{Name: subnetCfg.DHCP.RelayVPC, Namespace: vpc.Namespace}, relayVPC)
-				if err != nil {
-					if kapierrors.IsNotFound(err) {
-						return nil, errors.Errorf("subnet %s: dhcp relay VPC %s not found", subnetName, subnetCfg.DHCP.RelayVPC)
-					}
-
-					return nil, errors.Wrapf(err, "subnet %s: failed to get dhcp relay VPC %s", subnetName, subnetCfg.DHCP.RelayVPC) // TODO replace with some internal error to not expose to the user
-				}
 			}
 		}
 

--- a/config/crd/bases/agent.githedgehog.com_agents.yaml
+++ b/config/crd/bases/agent.githedgehog.com_agents.yaml
@@ -1828,10 +1828,6 @@ spec:
                                 description: Relay is the DHCP relay IP address, if
                                   specified, DHCP server will be disabled
                                 type: string
-                              relayVPC:
-                                description: RelayVPC is the name of the VPC where
-                                  the selected DHCP relay lives
-                                type: string
                               static:
                                 additionalProperties:
                                   description: VPCDHCPStatic represents static IP

--- a/config/crd/bases/vpc.githedgehog.com_vpcs.yaml
+++ b/config/crd/bases/vpc.githedgehog.com_vpcs.yaml
@@ -191,10 +191,6 @@ spec:
                           description: Relay is the DHCP relay IP address, if specified,
                             DHCP server will be disabled
                           type: string
-                        relayVPC:
-                          description: RelayVPC is the name of the VPC where the selected
-                            DHCP relay lives
-                          type: string
                         static:
                           additionalProperties:
                             description: VPCDHCPStatic represents static IP assignment

--- a/docs/api.md
+++ b/docs/api.md
@@ -2011,7 +2011,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `relay` _string_ | Relay is the DHCP relay IP address, if specified, DHCP server will be disabled |  |  |
-| `relayVPC` _string_ | RelayVPC is the name of the VPC where the selected DHCP relay lives |  |  |
 | `enable` _boolean_ | Enable enables DHCP server for the subnet |  |  |
 | `range` _[VPCDHCPRange](#vpcdhcprange)_ | Range (optional) is the DHCP range for the subnet if DHCP server is enabled |  |  |
 | `options` _[VPCDHCPOptions](#vpcdhcpoptions)_ | Options (optional) is the DHCP options for the subnet if DHCP server is enabled |  |  |

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -2821,31 +2821,24 @@ func planVNIVPCSubnet(agent *agentapi.Agent, spec *dozer.Spec, vpcName string, v
 
 	if subnet.DHCP.Enable || subnet.DHCP.Relay != "" {
 		var dhcpRelayIP net.IP
-		var srcInterface *string
-		var relayVRF *string
 
 		if subnet.DHCP.Enable {
 			dhcpRelayIP, _, err = net.ParseCIDR(agent.Spec.Config.ControlVIP)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s (control vip) for vpc %s", agent.Spec.Config.ControlVIP, vpcName)
 			}
-			srcInterface = pointer.To(MgmtIface)
 		} else {
 			dhcpRelayIP, _, err = net.ParseCIDR(subnet.DHCP.Relay)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s for vpc %s", subnet.DHCP.Relay, vpcName)
 			}
-			if subnet.DHCP.RelayVPC != "" {
-				relayVRF = pointer.To(vpcVrfName(subnet.DHCP.RelayVPC))
-			}
 		}
 
 		spec.DHCPRelays[subnetIface] = &dozer.SpecDHCPRelay{
-			SourceInterface: srcInterface,
+			SourceInterface: pointer.To(MgmtIface),
 			RelayAddress:    []string{dhcpRelayIP.String()},
-			LinkSelect:      srcInterface != nil,
+			LinkSelect:      true,
 			VRFSelect:       true,
-			VRF:             relayVRF,
 		}
 	}
 
@@ -2882,31 +2875,24 @@ func planL3FlatVPCSubnet(agent *agentapi.Agent, spec *dozer.Spec, vpcName string
 
 	if subnet.DHCP.Enable || subnet.DHCP.Relay != "" {
 		var dhcpRelayIP net.IP
-		var srcInterface *string
-		var relayVRF *string
 
 		if subnet.DHCP.Enable {
 			dhcpRelayIP, _, err = net.ParseCIDR(agent.Spec.Config.ControlVIP)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s (control vip) for vpc %s", agent.Spec.Config.ControlVIP, vpcName)
 			}
-			srcInterface = pointer.To(MgmtIface)
 		} else {
 			dhcpRelayIP, _, err = net.ParseCIDR(subnet.DHCP.Relay)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse DHCP relay %s for vpc %s", subnet.DHCP.Relay, vpcName)
 			}
-			if subnet.DHCP.RelayVPC != "" {
-				relayVRF = pointer.To(vpcVrfName(subnet.DHCP.RelayVPC))
-			}
 		}
 
 		spec.DHCPRelays[subnetIface] = &dozer.SpecDHCPRelay{
-			SourceInterface: srcInterface,
+			SourceInterface: pointer.To(MgmtIface),
 			RelayAddress:    []string{dhcpRelayIP.String()},
-			LinkSelect:      srcInterface != nil,
+			LinkSelect:      true,
 			VRFSelect:       true, // just for consistency, not used in L3 VPCs as it's always in a default VRF
-			VRF:             relayVRF,
 		}
 	}
 

--- a/pkg/agent/dozer/bcm/spec_dhcp.go
+++ b/pkg/agent/dozer/bcm/spec_dhcp.go
@@ -61,7 +61,6 @@ var specDHCPRelayEnforcer = &DefaultValueEnforcer[string, *dozer.SpecDHCPRelay]{
 					Config: &oc.OpenconfigRelayAgent_RelayAgent_Dhcp_Interfaces_Interface_Config{
 						HelperAddress: value.RelayAddress,
 						SrcIntf:       value.SourceInterface,
-						Vrf:           value.VRF,
 					},
 				},
 			},
@@ -107,7 +106,6 @@ func unmarshalOCDHCPRelays(ocVal *oc.OpenconfigRelayAgent_RelayAgent_Dhcp_Interf
 			RelayAddress:    ocRelayIface.Config.HelperAddress,
 			LinkSelect:      cfg.LinkSelect == oc.OpenconfigRelayAgentExt_Mode_ENABLE,
 			VRFSelect:       cfg.VrfSelect == oc.OpenconfigRelayAgentExt_Mode_ENABLE,
-			VRF:             ocRelayIface.Config.Vrf,
 		}
 	}
 

--- a/pkg/agent/dozer/dozer.go
+++ b/pkg/agent/dozer/dozer.go
@@ -333,7 +333,6 @@ type SpecDHCPRelay struct {
 	RelayAddress    []string `json:"relayAddress,omitempty"`
 	LinkSelect      bool     `json:"linkSelect,omitempty"`
 	VRFSelect       bool     `json:"vrfSelect,omitempty"`
-	VRF             *string  `json:"vrf,omitempty"`
 }
 
 type SpecACL struct {


### PR DESCRIPTION
This reverts commit 4bedfc5b1a1c740cc17a462395b43a7b56f0c168.

We want to understand better the use case and come up with a solution that will work regardless of whether the VPCs are on the same leaf.