### PR TITLE
fix(inspect): avoid stack trace in LLDP warning log

### DIFF
--- a/pkg/hhfctl/inspect/inspect.go
+++ b/pkg/hhfctl/inspect/inspect.go
@@ -17,6 +17,7 @@ package inspect
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"slices"
@@ -143,7 +144,7 @@ func Render[TIn In, TOut Out[TIn]](now time.Time, output OutputType, w io.Writer
 		}
 
 		if len(errs) > 0 {
-			return errors.Errorf("inspect function reported %d errors", len(errs))
+			return fmt.Errorf("inspect function reported %d errors", len(errs)) //nolint:err113
 		}
 	}
 


### PR DESCRIPTION
Use fmt.Errorf instead of pkg/errors.Errorf for the sentinel error returned from Render, so the full stack trace is not embedded when it gets logged via slog.Warn upstream.