### PR TITLE
feat(agent): add per-port FEC configuration knobs

### DIFF
--- a/api/wiring/v1beta1/switch_types.go
+++ b/api/wiring/v1beta1/switch_types.go
@@ -68,6 +68,17 @@ func (r SwitchRole) IsLeaf() bool {
 	return r == SwitchRoleServerLeaf || r == SwitchRoleBorderLeaf || r == SwitchRoleMixedLeaf
 }
 
+// +kubebuilder:validation:Enum=rs;fc;auto;disabled
+// PortFECMode is the FEC mode for a port
+type PortFECMode string
+
+const (
+	PortFECModeRS       PortFECMode = "rs"
+	PortFECModeFC       PortFECMode = "fc"
+	PortFECModeAuto     PortFECMode = "auto"
+	PortFECModeDisabled PortFECMode = "disabled"
+)
+
 // SwitchRedundancy is the switch redundancy configuration which includes name of the redundancy group switch belongs
 // to and its type, used both for MCLAG and ESLAG connections. It defines how redundancy will be configured and handled
 // on the switch as well as which connection types will be available. If not specified, switch will not be part of any
@@ -118,6 +129,9 @@ type SwitchSpec struct {
 	PortBreakouts map[string]string `json:"portBreakouts,omitempty"`
 	// PortAutoNegs is a map of port auto negotiation, key is the port name, value is true or false
 	PortAutoNegs map[string]bool `json:"portAutoNegs,omitempty"`
+	// PortFECs is a map of port FEC modes, key is the port name, value is the FEC mode (rs/fc/auto/disabled).
+	// Only ports with an entry are managed; ports without one are left untouched at the NOS default.
+	PortFECs map[string]PortFECMode `json:"portFECs,omitempty"`
 	// Boot is the boot/provisioning information of the switch
 	Boot SwitchBoot `json:"boot,omitempty"`
 	// EnableAllPorts is a flag to enable all ports on the switch regardless of them being used or not
@@ -624,6 +638,18 @@ func (sw *Switch) Validate(ctx context.Context, kube kclient.Reader, fabricCfg *
 		for name := range sw.Spec.PortAutoNegs {
 			if !autoNegAllowed[name] {
 				return nil, errors.Errorf("port %s does not support configuring auto negotiation", name)
+			}
+		}
+
+		fecPorts, err := sp.Spec.GetFECConfigurablePorts(&sw.Spec)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get FEC-configurable ports")
+		}
+
+		for name := range sw.Spec.PortFECs {
+			if !fecPorts[name] {
+				return nil, errors.Errorf("port %s does not support configuring FEC "+
+					"(a broken-out port must be configured per sub-port, e.g. E1/53/1)", name)
 			}
 		}
 

--- a/api/wiring/v1beta1/switchprofile_types.go
+++ b/api/wiring/v1beta1/switchprofile_types.go
@@ -1057,6 +1057,45 @@ func (sp *SwitchProfileSpec) GetAvailableAPIPorts(sw *SwitchSpec) (map[string]bo
 	return ports, nil
 }
 
+// GetFECConfigurablePorts returns the set of API port names on which FEC may be configured.
+// It is GetAvailableAPIPorts (speed/group base names and breakout sub-port names) plus the
+// base name of any breakout port that is NOT broken out (its configured mode has a single
+// lane, e.g. "E1/53" at 1x100G), which may be addressed directly. A broken-out (multi-lane)
+// port keeps only its sub-port names, so its base name is rejected and the explicit sub-port
+// name (e.g. "E1/53/1") must be used.
+func (sp *SwitchProfileSpec) GetFECConfigurablePorts(sw *SwitchSpec) (map[string]bool, error) {
+	if sw == nil {
+		sw = &SwitchSpec{}
+	}
+
+	ports, err := sp.GetAvailableAPIPorts(sw)
+	if err != nil {
+		return nil, err
+	}
+
+	for portName, port := range sp.Ports {
+		if port.Management || port.Profile == "" {
+			continue
+		}
+
+		profile, ok := sp.PortProfiles[port.Profile]
+		if !ok || profile.Breakout == nil {
+			continue
+		}
+
+		mode := profile.Breakout.Default
+		if b, ok := sw.PortBreakouts[portName]; ok {
+			mode = b
+		}
+
+		if bm, ok := profile.Breakout.Supported[mode]; ok && len(bm.Offsets) == 1 {
+			ports[portName] = true // not broken out: base name is directly addressable
+		}
+	}
+
+	return ports, nil
+}
+
 func (sp *SwitchProfileSpec) GetPortsShortSummary() (string, error) {
 	portCount := map[string]int{}
 	for _, port := range sp.Ports {

--- a/api/wiring/v1beta1/zz_generated.deepcopy.go
+++ b/api/wiring/v1beta1/zz_generated.deepcopy.go
@@ -1365,6 +1365,13 @@ func (in *SwitchSpec) DeepCopyInto(out *SwitchSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.PortFECs != nil {
+		in, out := &in.PortFECs, &out.PortFECs
+		*out = make(map[string]PortFECMode, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.Boot = in.Boot
 	out.ECMP = in.ECMP
 	if in.LinkFlapErrDisable != nil {

--- a/config/crd/bases/agent.githedgehog.com_agents.yaml
+++ b/config/crd/bases/agent.githedgehog.com_agents.yaml
@@ -1303,6 +1303,19 @@ spec:
                       the port name, value is the breakout configuration, such as
                       "1/55: 4x25G"'
                     type: object
+                  portFECs:
+                    additionalProperties:
+                      description: PortFECMode is the FEC mode for a port
+                      enum:
+                      - rs
+                      - fc
+                      - auto
+                      - disabled
+                      type: string
+                    description: |-
+                      PortFECs is a map of port FEC modes, key is the port name, value is the FEC mode (rs/fc/auto/disabled).
+                      Only ports with an entry are managed; ports without one are left untouched at the NOS default.
+                    type: object
                   portGroupSpeeds:
                     additionalProperties:
                       type: string
@@ -1649,6 +1662,19 @@ spec:
                       description: 'PortBreakouts is a map of port breakouts, key
                         is the port name, value is the breakout configuration, such
                         as "1/55: 4x25G"'
+                      type: object
+                    portFECs:
+                      additionalProperties:
+                        description: PortFECMode is the FEC mode for a port
+                        enum:
+                        - rs
+                        - fc
+                        - auto
+                        - disabled
+                        type: string
+                      description: |-
+                        PortFECs is a map of port FEC modes, key is the port name, value is the FEC mode (rs/fc/auto/disabled).
+                        Only ports with an entry are managed; ports without one are left untouched at the NOS default.
                       type: object
                     portGroupSpeeds:
                       additionalProperties:

--- a/config/crd/bases/wiring.githedgehog.com_switches.yaml
+++ b/config/crd/bases/wiring.githedgehog.com_switches.yaml
@@ -154,6 +154,19 @@ spec:
                 description: 'PortBreakouts is a map of port breakouts, key is the
                   port name, value is the breakout configuration, such as "1/55: 4x25G"'
                 type: object
+              portFECs:
+                additionalProperties:
+                  description: PortFECMode is the FEC mode for a port
+                  enum:
+                  - rs
+                  - fc
+                  - auto
+                  - disabled
+                  type: string
+                description: |-
+                  PortFECs is a map of port FEC modes, key is the port name, value is the FEC mode (rs/fc/auto/disabled).
+                  Only ports with an entry are managed; ports without one are left untouched at the NOS default.
+                type: object
               portGroupSpeeds:
                 additionalProperties:
                   type: string

--- a/docs/api.md
+++ b/docs/api.md
@@ -2854,6 +2854,26 @@ _Appears in:_
 | `leaf2` _[ConnFabricLinkSwitch](#connfabriclinkswitch)_ |  |  |  |
 
 
+#### PortFECMode
+
+_Underlying type:_ _string_
+
+PortFECMode is the FEC mode for a port
+
+_Validation:_
+- Enum: [rs fc auto disabled]
+
+_Appears in:_
+- [SwitchSpec](#switchspec)
+
+| Field | Description |
+| --- | --- |
+| `rs` |  |
+| `fc` |  |
+| `auto` |  |
+| `disabled` |  |
+
+
 #### Server
 
 
@@ -3353,6 +3373,7 @@ _Appears in:_
 | `portSpeeds` _object (keys:string, values:string)_ | PortSpeeds is a map of port speeds, key is the port name, value is the speed |  |  |
 | `portBreakouts` _object (keys:string, values:string)_ | PortBreakouts is a map of port breakouts, key is the port name, value is the breakout configuration, such as "1/55: 4x25G" |  |  |
 | `portAutoNegs` _object (keys:string, values:boolean)_ | PortAutoNegs is a map of port auto negotiation, key is the port name, value is true or false |  |  |
+| `portFECs` _object (keys:string, values:[PortFECMode](#portfecmode))_ | PortFECs is a map of port FEC modes, key is the port name, value is the FEC mode (rs/fc/auto/disabled).<br />Only ports with an entry are managed; ports without one are left untouched at the NOS default. |  |  |
 | `boot` _[SwitchBoot](#switchboot)_ | Boot is the boot/provisioning information of the switch |  |  |
 | `enableAllPorts` _boolean_ | EnableAllPorts is a flag to enable all ports on the switch regardless of them being used or not |  |  |
 | `roce` _boolean_ | RoCE is a flag to enable RoCEv2 support on the switch which includes lossless queues and QoS configuration |  |  |

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -247,6 +247,12 @@ func (p *BroadcomProcessor) PlanDesiredState(_ context.Context, agent *agentapi.
 		return nil, errors.Wrap(err, "failed to translate port names")
 	}
 
+	// after translatePortNames: spec.Interfaces is keyed by NOS names, which planPortFECs needs
+	err = planPortFECs(agent, spec)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to plan port FECs")
+	}
+
 	spec.Normalize()
 
 	return spec, nil
@@ -3900,6 +3906,39 @@ func planPortAutoNegs(agent *agentapi.Agent, spec *dozer.Spec) error {
 
 		if iface, exists := spec.Interfaces[name]; exists {
 			iface.AutoNegotiate = pointer.To(autoNeg)
+		}
+	}
+
+	return nil
+}
+
+// planPortFECs must run AFTER translatePortNames: it resolves each user-provided PortFECs
+// key (a hedgehog name, base or breakout sub-port form) to its NOS name and applies the FEC
+// mode to the now-NOS-keyed interface. Resolving through GetAPI2NOSPortsFor means a port
+// referenced in a connection as either "E1/53" or "E1/53/1" lands on the same NOS interface.
+//
+// Only ports explicitly listed in PortFECs are managed; the rest are left untouched at the
+// NOS default. We deliberately do not write a default FEC mode to every port: the device
+// resolves an abstract DEFAULT to a concrete mode and never echoes DEFAULT back, which would
+// make the desired state perpetually differ from the actual one (drift).
+func planPortFECs(agent *agentapi.Agent, spec *dozer.Spec) error {
+	api2nos, err := agent.Spec.SwitchProfile.GetAPI2NOSPortsFor(&agent.Spec.Switch)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get NOS port mapping for FEC")
+	}
+
+	for name, fec := range agent.Spec.Switch.PortFECs {
+		if strings.HasPrefix(name, wiringapi.ManagementPortPrefix) {
+			continue
+		}
+
+		nosName, ok := api2nos[name]
+		if !ok {
+			continue // validated at admission
+		}
+
+		if iface, exists := spec.Interfaces[nosName]; exists {
+			iface.FEC = pointer.To(string(fec))
 		}
 	}
 

--- a/pkg/agent/dozer/bcm/plan_fec_test.go
+++ b/pkg/agent/dozer/bcm/plan_fec_test.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Hedgehog
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/agent/dozer"
+)
+
+// TestPlanPortFECs verifies that an explicit FEC entry is applied to the correct NOS-keyed
+// interface regardless of whether the user (or the connection) used the base name or the
+// breakout sub-port name for a non-broken-out QSFP port — both resolve to the same NOS name.
+func TestPlanPortFECs(t *testing.T) {
+	profile := &wiringapi.SwitchProfileSpec{
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true},
+			"E1/53": {NOSName: "1/53", BaseNOSName: "Ethernet64", Profile: "QSFP28-100G"},
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x100G": {Offsets: []string{"0"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range []struct {
+		name   string
+		fecKey string
+		want   string // expected FEC on Ethernet64; "" means nil
+	}{
+		{"base name resolves to NOS interface", "E1/53", "rs"},
+		{"sub-port name resolves to NOS interface", "E1/53/1", "rs"},
+		{"unknown port is ignored", "E9/9", ""},
+		{"management port is ignored", "M1", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := &agentapi.Agent{
+				Spec: agentapi.AgentSpec{
+					SwitchProfile: profile,
+					Switch: wiringapi.SwitchSpec{
+						PortFECs: map[string]wiringapi.PortFECMode{
+							tt.fecKey: wiringapi.PortFECModeRS,
+						},
+					},
+				},
+			}
+			// spec.Interfaces is NOS-keyed at this point (planPortFECs runs after translation)
+			spec := &dozer.Spec{
+				Interfaces: map[string]*dozer.SpecInterface{
+					"Ethernet64": {},
+				},
+			}
+
+			err := planPortFECs(agent, spec)
+			require.NoError(t, err)
+
+			if tt.want == "" {
+				require.Nil(t, spec.Interfaces["Ethernet64"].FEC)
+			} else {
+				require.NotNil(t, spec.Interfaces["Ethernet64"].FEC)
+				require.Equal(t, tt.want, *spec.Interfaces["Ethernet64"].FEC)
+			}
+		})
+	}
+}

--- a/pkg/agent/dozer/bcm/spec_interface.go
+++ b/pkg/agent/dozer/bcm/spec_interface.go
@@ -95,6 +95,10 @@ var specInterfaceEnforcer = &DefaultValueEnforcer[string, *dozer.SpecInterface]{
 			return errors.Wrap(err, "failed to handle interface ethernet")
 		}
 
+		if err := specInterfaceEthernetFECEnforcer.Handle(basePath, name, actual, desired, actions); err != nil {
+			return errors.Wrap(err, "failed to handle interface FEC")
+		}
+
 		if err := specInterfaceEthernetSwitchedAccessEnforcer.Handle(basePath, name, actual, desired, actions); err != nil {
 			return errors.Wrap(err, "failed to handle interface switched access")
 		}
@@ -494,6 +498,36 @@ var specInterfaceEthernetBaseEnforcer = &DefaultValueEnforcer[string, *dozer.Spe
 	},
 }
 
+// specInterfaceEthernetFECEnforcer manages the port FEC mode separately from the base
+// ethernet config so that a FEC change only touches /ethernet/config/port-fec instead of
+// re-applying the whole ethernet config. Only ports with an explicit FEC mode are managed
+// (planPortFECs leaves the rest nil); the Skip below ignores ports without one, so an
+// unmanaged port never diffs against whatever concrete mode the device reports. Removing an
+// override therefore leaves the port at its last applied mode rather than resetting it.
+var specInterfaceEthernetFECEnforcer = &DefaultValueEnforcer[string, *dozer.SpecInterface]{
+	Summary: "Interface %s FEC",
+	Skip: func(name string, _, desired *dozer.SpecInterface) bool {
+		return !isPhysical(name) || desired == nil || desired.FEC == nil
+	},
+	Getter: func(_ string, value *dozer.SpecInterface) any {
+		return value.FEC
+	},
+	Path:         "/ethernet/config/port-fec",
+	NoReplace:    true,
+	UpdateWeight: ActionWeightInterfaceEthernetBaseUpdate,
+	DeleteWeight: ActionWeightInterfaceEthernetBaseDelete,
+	Marshal: func(_ string, value *dozer.SpecInterface) (ygot.ValidatedGoStruct, error) {
+		fecMode, ok := MarshalPortFEC(*value.FEC)
+		if !ok {
+			return nil, errors.Errorf("invalid FEC mode %s", *value.FEC)
+		}
+
+		return &oc.OpenconfigInterfaces_Interfaces_Interface_Ethernet_Config{
+			PortFec: fecMode,
+		}, nil
+	},
+}
+
 var specInterfaceEthernetSwitchedAccessEnforcer = &DefaultValueEnforcer[string, *dozer.SpecInterface]{
 	Summary: "Interface %s Switched Access VLAN",
 	Skip:    func(name string, _, _ *dozer.SpecInterface) bool { return !isPhysical(name) },
@@ -700,6 +734,20 @@ func unmarshalOCInterfaces(agent *agentapi.Agent, ocVal *oc.OpenconfigInterfaces
 		skipSpeedPorts[name] = true
 	}
 
+	// FEC is only read back for ports the fabric explicitly manages (those in PortFECs). For
+	// every other port the device reports a concrete resolved mode (e.g. disabled) that has no
+	// counterpart in the desired spec; reading it would surface a perpetual cosmetic diff.
+	api2nos, err := sp.GetAPI2NOSPortsFor(&agent.Spec.Switch)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get NOS port mapping")
+	}
+	managedFEC := map[string]bool{}
+	for name := range agent.Spec.Switch.PortFECs {
+		if nosName, ok := api2nos[name]; ok {
+			managedFEC[nosName] = true
+		}
+	}
+
 	for name, ocIface := range ocVal.Interface {
 		if ocIface.Config == nil {
 			continue
@@ -865,6 +913,13 @@ func unmarshalOCInterfaces(agent *agentapi.Agent, ocVal *oc.OpenconfigInterfaces
 				}
 
 				iface.AutoNegotiate = ocIface.Ethernet.Config.AutoNegotiate
+				if managedFEC[name] {
+					// Only read FEC for fabric-managed ports; UNSET/DEFAULT (or an unmanaged
+					// port) leaves iface.FEC nil so it never shows a spurious diff.
+					if fecString, ok := UnmarshalPortFEC(ocIface.Ethernet.Config.PortFec); ok {
+						iface.FEC = &fecString
+					}
+				}
 			}
 
 			if ocIface.Ethernet.SwitchedVlan != nil && ocIface.Ethernet.SwitchedVlan.Config != nil {

--- a/pkg/agent/dozer/bcm/spec_interface_fec_test.go
+++ b/pkg/agent/dozer/bcm/spec_interface_fec_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Hedgehog
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.githedgehog.com/fabric/pkg/agent/dozer"
+	"go.githedgehog.com/fabric/pkg/util/pointer"
+)
+
+func TestSpecInterfaceEthernetFECEnforcer(t *testing.T) {
+	const port = IfacePrefixPhysical + "0"
+
+	for _, tt := range []struct {
+		name        string
+		actual      *dozer.SpecInterface
+		desired     *dozer.SpecInterface
+		wantActions int
+	}{
+		{
+			// Unmanaged port: no explicit FEC requested. The device reports a concrete mode
+			// (rs), but with no desired FEC the enforcer must not act (no drift).
+			name:        "no desired FEC, device reports rs",
+			actual:      &dozer.SpecInterface{FEC: pointer.To("rs")},
+			desired:     &dozer.SpecInterface{FEC: nil},
+			wantActions: 0,
+		},
+		{
+			name:        "explicit rs desired, device unset",
+			actual:      &dozer.SpecInterface{FEC: nil},
+			desired:     &dozer.SpecInterface{FEC: pointer.To("rs")},
+			wantActions: 1,
+		},
+		{
+			name:        "explicit rs desired, device already rs",
+			actual:      &dozer.SpecInterface{FEC: pointer.To("rs")},
+			desired:     &dozer.SpecInterface{FEC: pointer.To("rs")},
+			wantActions: 0,
+		},
+		{
+			name:        "explicit fc desired, device reports rs",
+			actual:      &dozer.SpecInterface{FEC: pointer.To("rs")},
+			desired:     &dozer.SpecInterface{FEC: pointer.To("fc")},
+			wantActions: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actions := &ActionQueue{}
+			err := specInterfaceEthernetFECEnforcer.Handle("", port, tt.actual, tt.desired, actions)
+			require.NoError(t, err)
+			require.Len(t, actions.actions, tt.wantActions)
+		})
+	}
+}

--- a/pkg/agent/dozer/bcm/util.go
+++ b/pkg/agent/dozer/bcm/util.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -63,6 +64,37 @@ func MarshalPortSpeed(speed string) (oc.E_OpenconfigIfEthernet_ETHERNET_SPEED, b
 	}
 
 	return res, ok
+}
+
+func MarshalPortFEC(fec string) (oc.E_OpenconfigPlatformTypes_FEC_MODE_TYPE, bool) {
+	switch wiringapi.PortFECMode(fec) {
+	case wiringapi.PortFECModeRS:
+		return oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_RS, true
+	case wiringapi.PortFECModeFC:
+		return oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_FC, true
+	case wiringapi.PortFECModeAuto:
+		return oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_AUTO, true
+	case wiringapi.PortFECModeDisabled:
+		return oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_DISABLED, true
+	default:
+		return oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_UNSET, false
+	}
+}
+
+func UnmarshalPortFEC(fec oc.E_OpenconfigPlatformTypes_FEC_MODE_TYPE) (string, bool) {
+	switch fec { //nolint:exhaustive
+	case oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_DISABLED:
+		return string(wiringapi.PortFECModeDisabled), true
+	case oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_AUTO:
+		return string(wiringapi.PortFECModeAuto), true
+	case oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_FC:
+		return string(wiringapi.PortFECModeFC), true
+	case oc.OpenconfigPlatformTypes_FEC_MODE_TYPE_FEC_RS:
+		return string(wiringapi.PortFECModeRS), true
+	default:
+		// UNSET / DEFAULT and any other unsupported mode are treated as "not managed".
+		return "", false
+	}
 }
 
 func UnmarshalPortBreakout(mode string) string {

--- a/pkg/agent/dozer/dozer.go
+++ b/pkg/agent/dozer/dozer.go
@@ -133,6 +133,7 @@ type SpecInterface struct {
 	MTU                *uint16                      `json:"mtu,omitempty"`
 	Speed              *string                      `json:"speed,omitempty"`
 	AutoNegotiate      *bool                        `json:"autoNegotiate,omitempty"`
+	FEC                *string                      `json:"fec,omitempty"`
 	VLANIPs            map[string]*SpecInterfaceIP  `json:"vlanIPs,omitempty"`
 	VLANAnycastGateway []string                     `json:"vlanAnycastGateway,omitempty"`
 	Subinterfaces      map[uint32]*SpecSubinterface `json:"subinterfaces,omitempty"`

--- a/pkg/ctrl/switchprofile/fec_breakout_test.go
+++ b/pkg/ctrl/switchprofile/fec_breakout_test.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Hedgehog
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package switchprofile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+)
+
+// TestDellFECConfigurablePorts guards the FEC port-name rule on a real Dell profile:
+// Switch.Validate gates PortFECs on GetFECConfigurablePorts, which must accept the base name
+// of a NON-broken-out QSFP port (e.g. E1/1 at 1x100G) as well as its sub-port (E1/1/1), but
+// once the port is broken out only the sub-port names are valid. Management ports are never
+// configurable.
+func TestDellFECConfigurablePorts(t *testing.T) {
+	t.Run("not broken out: base and first sub-port both valid", func(t *testing.T) {
+		ports, err := DellS5232FON.Spec.GetFECConfigurablePorts(&wiringapi.SwitchSpec{})
+		require.NoError(t, err)
+
+		require.True(t, ports["E1/1"], "base name of a non-broken-out QSFP port must be configurable")
+		require.True(t, ports["E1/1/1"], "sub-port of a non-broken-out QSFP port must be configurable")
+		require.False(t, ports["M1"], "management port M1 must not be configurable")
+	})
+
+	t.Run("broken out: only sub-ports valid, base rejected", func(t *testing.T) {
+		ports, err := DellS5232FON.Spec.GetFECConfigurablePorts(&wiringapi.SwitchSpec{
+			PortBreakouts: map[string]string{"E1/1": "4x25G"},
+		})
+		require.NoError(t, err)
+
+		require.False(t, ports["E1/1"], "base name of a broken-out port must be rejected")
+		for _, sub := range []string{"E1/1/1", "E1/1/2", "E1/1/3", "E1/1/4"} {
+			require.True(t, ports[sub], "breakout sub-port %s must be configurable", sub)
+		}
+	})
+}


### PR DESCRIPTION
Add PortFECs map[string]PortFECMode to SwitchSpec, mirroring the PortAutoNegs pattern. Supported modes: rs, fc, auto, disabled.

Only ports that are explicitly configured by the user are managed by the agent. Removing the relevant config from the switch spec does NOT reset the FEC value on the port; the ideal action would be to set it to DEFAULT, but that value is then translated to something else depending on a number of factors (i.e. port speed/ breakout mode, auto neg setting), and the config diff would never be resolved.

Because of this, this is meant as an internal only, emergency kinda feature that we are not planning to advertise. Based on our investigations, figuring out what the default value is in all cases is very complex (e.g. it depends on port speed, breakouts, whether it's DAC or optics, whether it's switch-to-switch or towards an NVIDIA Bluefield card etc.), so we don't want to go there if it's not strictly needed.

Fix https://github.com/githedgehog/internal/issues/350