### PR TITLE
chore: add fake gnmi based coverage to plan test with roundtrip test

### DIFF
--- a/pkg/agent/dozer/bcm/enforcer.go
+++ b/pkg/agent/dozer/bcm/enforcer.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
@@ -45,7 +44,7 @@ type Action struct {
 	Type           ActionType             `json:"type,omitempty"`
 	Path           string                 `json:"path,omitempty"`
 	Value          ygot.ValidatedGoStruct `json:"value,omitempty"`
-	CustomFunc     func(ctx context.Context, client *gnmi.Client) error
+	CustomFunc     func(ctx context.Context, client GNMICClient) error
 	WarningOnError bool
 }
 

--- a/pkg/agent/dozer/bcm/gnmi_client.go
+++ b/pkg/agent/dozer/bcm/gnmi_client.go
@@ -1,0 +1,34 @@
+// Copyright 2023 Hedgehog
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bcm
+
+import (
+	"context"
+
+	gnmiproto "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmic/pkg/api"
+	"github.com/openconfig/ygot/ygot"
+	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
+)
+
+// GNMICClient abstracts the subset of *gnmi.Client used inside this package
+// so tests can swap in a mock backed by an in-memory OC tree.
+type GNMICClient interface {
+	Set(ctx context.Context, req *gnmiproto.SetRequest) error
+	Get(ctx context.Context, path string, dest ygot.ValidatedGoStruct, opts ...api.GNMIOption) error
+	CallOperation(ctx context.Context, name string, body []byte) ([]byte, error)
+}
+
+var _ GNMICClient = (*gnmi.Client)(nil)

--- a/pkg/agent/dozer/bcm/gnmi_client_mock_test.go
+++ b/pkg/agent/dozer/bcm/gnmi_client_mock_test.go
@@ -1,0 +1,229 @@
+// Copyright 2023 Hedgehog
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bcm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	gnmiproto "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmic/pkg/api"
+	gnmipath "github.com/openconfig/gnmic/pkg/api/path"
+	"github.com/openconfig/ygot/ygot"
+	"github.com/openconfig/ygot/ytypes"
+	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
+	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
+)
+
+var (
+	errMockGetUnmarshal      = errors.New("mock get: could not unmarshal into dest")
+	errMockCallOpUnsupported = errors.New("gnmiMockClient.CallOperation is not implemented (test should not call it)")
+)
+
+// gnmiMockClient is a test-only gnmiClient that applies SetRequests to an
+// in-memory *oc.Device root using ytypes (the same primitives a real gNMI
+// server uses), so we can golden-test the device state ApplyActions would
+// produce without talking to a real switch.
+type gnmiMockClient struct {
+	root *oc.Device
+}
+
+var _ GNMICClient = (*gnmiMockClient)(nil)
+
+func newGNMIMock() *gnmiMockClient {
+	return &gnmiMockClient{root: &oc.Device{}}
+}
+
+func (m *gnmiMockClient) Set(_ context.Context, req *gnmiproto.SetRequest) error {
+	schema := oc.SchemaTree["Device"]
+
+	// gNMI semantics: process deletes, then replaces, then updates.
+	for _, p := range req.GetDelete() {
+		if err := ytypes.DeleteNode(schema, m.root, stripPathOriginPrefixes(p)); err != nil {
+			return fmt.Errorf("mock delete %s: %w", gnmipath.GnmiPathToXPath(p, false), err)
+		}
+	}
+	for _, u := range req.GetReplace() {
+		if err := m.applySet(u, true); err != nil {
+			return fmt.Errorf("mock replace %s: %w", gnmipath.GnmiPathToXPath(u.Path, false), err)
+		}
+	}
+	for _, u := range req.GetUpdate() {
+		if err := m.applySet(u, false); err != nil {
+			return fmt.Errorf("mock update %s: %w", gnmipath.GnmiPathToXPath(u.Path, false), err)
+		}
+	}
+
+	return nil
+}
+
+// applySet writes a single gNMI update/replace into the OC root tree.
+//
+// Production Marshal funcs in spec_*.go return a parent ygot struct that
+// already wraps the value with a field named after the path's last element
+// (e.g., path=/ztp/config, value={"config": {...}}). The real switch's gNMI
+// server is lenient about this off-by-one wrapping; ytypes.SetNode is not.
+// We compensate by setting the value at the path's PARENT, which aligns the
+// wrapped value with the schema's actual shape at that level.
+func (m *gnmiMockClient) applySet(u *gnmiproto.Update, replace bool) error {
+	schema := oc.SchemaTree["Device"]
+	cleanPath := stripPathOriginPrefixes(u.Path)
+
+	parentPath := cleanPath
+	if len(cleanPath.Elem) > 0 {
+		parentPath = &gnmiproto.Path{
+			Origin: cleanPath.Origin,
+			Target: cleanPath.Target,
+			Elem:   cleanPath.Elem[:len(cleanPath.Elem)-1],
+		}
+	}
+
+	if replace {
+		// gNMI replace prunes the target subtree first; ignore "not found" on cold boot.
+		_ = ytypes.DeleteNode(schema, m.root, cleanPath)
+	}
+
+	if err := ytypes.SetNode(schema, m.root, parentPath, u.Val,
+		&ytypes.InitMissingElements{}, &ytypes.TolerateJSONInconsistencies{}); err != nil {
+		return fmt.Errorf("ytypes.SetNode: %w", err)
+	}
+
+	return nil
+}
+
+// stripPathOriginPrefixes returns a copy of p with module-name prefixes
+// (e.g. "openconfig-bfd:bfd") stripped from each element name. ytypes
+// matches against schema entry names without the YANG module prefix.
+func stripPathOriginPrefixes(p *gnmiproto.Path) *gnmiproto.Path {
+	if p == nil {
+		return nil
+	}
+	out := &gnmiproto.Path{
+		Origin: p.Origin,
+		Target: p.Target,
+		Elem:   make([]*gnmiproto.PathElem, len(p.Elem)),
+	}
+	for i, e := range p.Elem {
+		name := e.Name
+		if idx := strings.Index(name, ":"); idx >= 0 {
+			name = name[idx+1:]
+		}
+		out.Elem[i] = &gnmiproto.PathElem{Name: name, Key: e.Key}
+	}
+
+	return out
+}
+
+// Get reads a subtree from the in-memory OC root and unmarshals it into dest.
+//
+// The bcm code's loadActual* functions expect dest to be populated as if a
+// real SONiC gNMI server returned the value AT the requested path — but with
+// the same off-by-one wrapping that the Marshal funcs produce on writes
+// (e.g., Get("/system/config", &System{}) expects {config: {hostname: ...}}
+// to be unmarshaled into the System parent). To match this:
+//
+//  1. Locate the parent node (path minus its last element) in our state tree.
+//  2. Marshal that parent to IETF JSON — it naturally includes the
+//     last-element key as the wrapper.
+//  3. Try to unmarshal that wrapped JSON into dest (matches the common case
+//     where dest is the parent type).
+//  4. On failure, unwrap one level and retry (matches the ZTP-style case
+//     where dest is the leaf type).
+//
+// If the parent is missing/empty, return success with an untouched dest —
+// the loadActual* callers handle empty results the same way they handle
+// production gNMI's NotFound.
+func (m *gnmiMockClient) Get(_ context.Context, path string, dest ygot.ValidatedGoStruct, _ ...api.GNMIOption) error {
+	schema := oc.SchemaTree["Device"]
+
+	p, err := gnmipath.ParsePath(path)
+	if err != nil {
+		return fmt.Errorf("mock get: parse path %s: %w", path, err)
+	}
+	p = stripPathOriginPrefixes(p)
+
+	parentPath := p
+	if len(p.Elem) > 0 {
+		parentPath = &gnmiproto.Path{Origin: p.Origin, Target: p.Target, Elem: p.Elem[:len(p.Elem)-1]}
+	}
+
+	nodes, _ := ytypes.GetNode(schema, m.root, parentPath)
+	if len(nodes) == 0 {
+		return nil // no data at this subtree — leave dest at zero value
+	}
+	parentStruct, ok := nodes[0].Data.(ygot.GoStruct)
+	if !ok {
+		return nil
+	}
+	if rv := reflect.ValueOf(parentStruct); rv.Kind() == reflect.Pointer && rv.IsNil() {
+		return nil // parent container exists in schema but has no data
+	}
+
+	jsonMap, err := ygot.ConstructIETFJSON(parentStruct, &ygot.RFC7951JSONConfig{})
+	if err != nil {
+		return fmt.Errorf("mock get: construct ietf json for %s: %w", path, err)
+	}
+	if len(jsonMap) == 0 {
+		return nil
+	}
+
+	rawBytes, err := json.Marshal(jsonMap)
+	if err != nil {
+		return fmt.Errorf("mock get: marshal json for %s: %w", path, err)
+	}
+
+	// Try unmarshaling the parent-wrapped JSON into dest.
+	if err := gnmi.Unmarshal(rawBytes, dest); err == nil {
+		return nil
+	}
+
+	// Fallback: dest matches the path's last element type (ZTP-style),
+	// so unwrap one level and retry.
+	if len(p.Elem) > 0 {
+		lastName := p.Elem[len(p.Elem)-1].Name
+		if inner, ok := jsonMap[lastName]; ok {
+			innerBytes, err := json.Marshal(inner)
+			if err != nil {
+				return fmt.Errorf("mock get: marshal inner json for %s: %w", path, err)
+			}
+			if err := gnmi.Unmarshal(innerBytes, dest); err != nil {
+				return fmt.Errorf("mock get: unmarshal %s into %T: %w", path, dest, err)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%w: %s into %T", errMockGetUnmarshal, path, dest)
+}
+
+func (m *gnmiMockClient) CallOperation(_ context.Context, _ string, _ []byte) ([]byte, error) {
+	return nil, errMockCallOpUnsupported
+}
+
+// StateMap returns the accumulated device state as RFC7951 IETF JSON in
+// map[string]any form, ready for kyaml.Marshal.
+func (m *gnmiMockClient) StateMap() (map[string]any, error) {
+	out, err := gnmi.Marshal(m.root)
+	if err != nil {
+		return nil, fmt.Errorf("gnmi.Marshal root: %w", err)
+	}
+
+	return out, nil
+}

--- a/pkg/agent/dozer/bcm/plan_test.go
+++ b/pkg/agent/dozer/bcm/plan_test.go
@@ -15,6 +15,7 @@
 package bcm
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -192,6 +193,8 @@ func TestPlan(t *testing.T) {
 		{name: "mesh-leaf-03"}, // standalone, bgp externals connected to it
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			updateGoldens := os.Getenv("UPDATE") == "true"
+
 			agData, err := os.ReadFile(filepath.Join(testdataDir, tt.name+".in.agent.yaml"))
 			require.NoError(t, err, "reading agent file")
 
@@ -213,7 +216,7 @@ func TestPlan(t *testing.T) {
 			err = os.WriteFile(actualFileName, actualSpecData, 0o600)
 			require.NoError(t, err, "writing actual spec file")
 
-			if os.Getenv("UPDATE") == "true" {
+			if updateGoldens {
 				err = os.WriteFile(expectedFileName, actualSpecData, 0o600)
 				require.NoError(t, err, "writing expected spec file")
 			}
@@ -256,7 +259,7 @@ func TestPlan(t *testing.T) {
 			err = os.WriteFile(actualActionsFileName, actualActionsData, 0o600)
 			require.NoError(t, err, "writing actual actions file")
 
-			if os.Getenv("UPDATE") == "true" {
+			if updateGoldens {
 				err = os.WriteFile(expectedActionsFileName, actualActionsData, 0o600)
 				require.NoError(t, err, "writing expected actions file")
 			}
@@ -266,8 +269,100 @@ func TestPlan(t *testing.T) {
 
 			require.Equal(t, string(expectedActionsData), string(actualActionsData),
 				"actions mismatch, you can compare expected and actual actions files in testdata dir or re-generate expected by running just test-update")
+
+			mock := newGNMIMock()
+			bp.client = mock
+			bp.skipCustomFuncs = true
+			_, err = bp.ApplyActions(t.Context(), actions)
+			require.NoError(t, err, "applying actions to mock gnmi client")
+
+			state, err := mock.StateMap()
+			require.NoError(t, err, "marshalling mock gnmi state")
+
+			actualGNMIData, err := kyaml.Marshal(state)
+			require.NoError(t, err, "marshalling gnmi state to yaml")
+
+			expectedGNMIFileName := filepath.Join(testdataDir, tt.name+".out.gnmi.expected.yaml")
+			actualGNMIFileName := filepath.Join(testdataDir, tt.name+".out.gnmi.actual.yaml")
+
+			err = os.WriteFile(actualGNMIFileName, actualGNMIData, 0o600)
+			require.NoError(t, err, "writing actual gnmi state file")
+
+			if updateGoldens {
+				err = os.WriteFile(expectedGNMIFileName, actualGNMIData, 0o600)
+				require.NoError(t, err, "writing expected gnmi state file")
+			}
+
+			expectedGNMIData, err := os.ReadFile(expectedGNMIFileName)
+			require.NoError(t, err, "reading expected gnmi state file")
+
+			require.Equal(t, string(expectedGNMIData), string(actualGNMIData),
+				"gnmi state mismatch, you can compare expected and actual gnmi state files in testdata dir or re-generate expected by running just test-update")
+
+			loadedSpec, err := bp.LoadActualState(t.Context(), ag)
+			require.NoError(t, err, "loading actual state from mock gnmi client")
+
+			// Strip fields that production loadActual* deliberately doesn't
+			// reconstruct from gNMI (so the round-trip is fair). Mirror the
+			// stripping on the planned spec so the comparison is symmetric.
+			roundTripStrippedSpec, err := stripNonRoundTrippable(actualSpec)
+			require.NoError(t, err, "stripping non-round-trippable fields from actual spec")
+
+			roundTripData, err := kyaml.Marshal(roundTripStrippedSpec)
+			require.NoError(t, err, "marshalling stripped planned spec")
+
+			loadedSpecData, err := kyaml.Marshal(loadedSpec)
+			require.NoError(t, err, "marshalling loaded spec")
+
+			// Compare via YAML to normalise nil-vs-empty-map differences that
+			// arise from the OC marshal/unmarshal round-trip (semantically
+			// identical, but trip up reflect.DeepEqual).
+			require.Equal(t, string(roundTripData), string(loadedSpecData),
+				"round-trip mismatch: spec loaded back from gnmi state differs from the planned spec")
 		})
 	}
+}
+
+// stripNonRoundTrippable returns a deep copy of spec with fields cleared that
+// production loadActual* functions deliberately don't reconstruct from gNMI.
+// These are real gaps in the round-trip — by design, not bugs:
+//
+//   - User Password / AuthorizedKeys: the password is hashed and write-only on
+//     the device; authorized keys are installed by a CustomFunc to the local
+//     filesystem, never sent to gNMI. unmarshalOCUsers (spec_system.go) only
+//     reads Role.
+//   - Interface AutoNegotiate on management interfaces: PlanDesiredState sets
+//     AutoNegotiate=true for Management0 (plan.go), but
+//     specInterfaceEthernetBaseEnforcer skips non-physical interfaces, so it
+//     never reaches gNMI.
+//   - VRF AttachedHosts: written under
+//     /protocols/protocol[ATTACHED_HOST]/attached-host but loadActualVRFs
+//     does not currently parse them back.
+func stripNonRoundTrippable(spec *dozer.Spec) (*dozer.Spec, error) {
+	// Deep copy via YAML round-trip so we don't mutate the input spec.
+	data, err := kyaml.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling spec: %w", err)
+	}
+	out := &dozer.Spec{}
+	if err := kyaml.Unmarshal(data, out); err != nil {
+		return nil, fmt.Errorf("unmarshaling spec: %w", err)
+	}
+
+	for _, user := range out.Users {
+		user.Password = ""
+		user.AuthorizedKeys = nil
+	}
+	for name, iface := range out.Interfaces {
+		if isManagement(name) {
+			iface.AutoNegotiate = nil
+		}
+	}
+	for _, vrf := range out.VRFs {
+		vrf.AttachedHosts = nil
+	}
+
+	return out, nil
 }
 
 type goldenAction struct {

--- a/pkg/agent/dozer/bcm/processor.go
+++ b/pkg/agent/dozer/bcm/processor.go
@@ -36,7 +36,7 @@ import (
 )
 
 type BroadcomProcessor struct {
-	client          *gnmi.Client
+	client          GNMICClient
 	skipCustomFuncs bool
 }
 
@@ -46,7 +46,7 @@ func Processor() *BroadcomProcessor {
 	return &BroadcomProcessor{}
 }
 
-func (p *BroadcomProcessor) SetClient(client *gnmi.Client) {
+func (p *BroadcomProcessor) SetClient(client GNMICClient) {
 	p.client = client
 }
 

--- a/pkg/agent/dozer/bcm/spec.go
+++ b/pkg/agent/dozer/bcm/spec.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pkg/errors"
 	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 )
 
 var specEnforcer = &DefaultValueEnforcer[string, *dozer.Spec]{
@@ -161,7 +160,7 @@ var specEnforcer = &DefaultValueEnforcer[string, *dozer.Spec]{
 	},
 }
 
-func loadActualSpec(ctx context.Context, agent *agentapi.Agent, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualSpec(ctx context.Context, agent *agentapi.Agent, client GNMICClient, spec *dozer.Spec) error {
 	if err := loadActualZTP(ctx, client, spec); err != nil {
 		return errors.Wrapf(err, "failed to load ztp")
 	}

--- a/pkg/agent/dozer/bcm/spec_acl.go
+++ b/pkg/agent/dozer/bcm/spec_acl.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -338,7 +337,7 @@ func marshalACLInterface(name string, value *dozer.SpecACLInterface, includeIngr
 	}, nil
 }
 
-func loadActualACLs(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualACLs(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.OpenconfigAcl_Acl{}
 	err := client.Get(ctx, "/acl/acl-sets", ocVal, api.DataTypeCONFIG())
 	if err != nil {
@@ -467,7 +466,7 @@ func unmarshalOCACLs(ocVal *oc.OpenconfigAcl_Acl) (map[string]*dozer.SpecACL, er
 	return acls, nil
 }
 
-func loadActualACLInterfaces(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualACLInterfaces(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.OpenconfigAcl_Acl{}
 	err := client.Get(ctx, "/acl/interfaces", ocVal, api.DataTypeCONFIG())
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_aspath_lists.go
+++ b/pkg/agent/dozer/bcm/spec_aspath_lists.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -58,7 +57,7 @@ var specAsPathListEnforcer = &DefaultValueEnforcer[string, *dozer.SpecAsPathList
 	},
 }
 
-func loadActualAsPathLists(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualAsPathLists(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocAsPathLists := &oc.OpenconfigRoutingPolicy_RoutingPolicy_DefinedSets_BgpDefinedSets{}
 	err := client.Get(ctx, "/routing-policy/defined-sets/bgp-defined-sets/as-path-sets", ocAsPathLists)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_bfd.go
+++ b/pkg/agent/dozer/bcm/spec_bfd.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -44,7 +43,7 @@ var specBFDProfileEnforcer = &DefaultValueEnforcer[string, *dozer.SpecBFDProfile
 	},
 }
 
-func loadActualBFDProfiles(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualBFDProfiles(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocBFD := &oc.OpenconfigBfd_Bfd{}
 	err := client.Get(ctx, "/openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile", ocBFD)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_comm_lists.go
+++ b/pkg/agent/dozer/bcm/spec_comm_lists.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -64,7 +63,7 @@ var specCommunityListEnforcer = &DefaultValueEnforcer[string, *dozer.SpecCommuni
 	},
 }
 
-func loadActualCommunityLists(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualCommunityLists(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocCommLists := &oc.OpenconfigRoutingPolicy_RoutingPolicy_DefinedSets_BgpDefinedSets{}
 	err := client.Get(ctx, "/routing-policy/defined-sets/bgp-defined-sets/community-sets", ocCommLists)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_dhcp.go
+++ b/pkg/agent/dozer/bcm/spec_dhcp.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -69,7 +68,7 @@ var specDHCPRelayEnforcer = &DefaultValueEnforcer[string, *dozer.SpecDHCPRelay]{
 	},
 }
 
-func loadActualDHCPRelays(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualDHCPRelays(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocDHCPRelayInterfaces := &oc.OpenconfigRelayAgent_RelayAgent_Dhcp_Interfaces{}
 	err := client.Get(ctx, "/relay-agent/dhcp/interfaces/interface", ocDHCPRelayInterfaces, api.DataTypeCONFIG())
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_ecmp.go
+++ b/pkg/agent/dozer/bcm/spec_ecmp.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -32,7 +31,7 @@ var specECMPRoCEEnforcer = &DefaultValueEnforcer[string, *dozer.Spec]{
 	},
 }
 
-func loadActualECMPRoCE(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualECMPRoCE(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocECMP := &oc.OpenconfigLoadshareModeExt_Loadshare{}
 	err := client.Get(ctx, "/loadshare/roce-attrs", ocECMP, api.DataTypeCONFIG())
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_interface.go
+++ b/pkg/agent/dozer/bcm/spec_interface.go
@@ -25,7 +25,6 @@ import (
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -640,7 +639,7 @@ var specInterfaceVLANAnycastGatewayEnforcer = &DefaultValueEnforcer[string, *doz
 	},
 }
 
-func loadActualInterfaces(ctx context.Context, agent *agentapi.Agent, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualInterfaces(ctx context.Context, agent *agentapi.Agent, client GNMICClient, spec *dozer.Spec) error {
 	ocInterfaces := &oc.OpenconfigInterfaces_Interfaces{}
 	err := client.Get(ctx, "/interfaces/interface", ocInterfaces)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_lldp.go
+++ b/pkg/agent/dozer/bcm/spec_lldp.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -41,7 +40,7 @@ var specLLDPEnforcer = &DefaultValueEnforcer[string, *dozer.SpecLLDP]{
 	},
 }
 
-func loadActualLLDP(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualLLDP(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocLLDP := &oc.OpenconfigLldp_Lldp{}
 	err := client.Get(ctx, "/lldp/config", ocLLDP)
 	if err != nil {
@@ -100,7 +99,7 @@ var specLLDPInterfaceEnforcer = &DefaultValueEnforcer[string, *dozer.SpecLLDPInt
 	},
 }
 
-func loadActualLLDPInterfaces(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualLLDPInterfaces(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocLLDP := &oc.OpenconfigLldp_Lldp{}
 	err := client.Get(ctx, "/lldp/interfaces", ocLLDP)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_lst.go
+++ b/pkg/agent/dozer/bcm/spec_lst.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -53,7 +52,7 @@ var specLSTGroupEnforcer = &DefaultValueEnforcer[string, *dozer.SpecLSTGroup]{
 	},
 }
 
-func loadActualLSTGroups(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualLSTGroups(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocLST := &oc.OpenconfigLstExt_Lst{}
 	err := client.Get(ctx, "/lst/lst-groups", ocLST)
 	if err != nil {
@@ -132,7 +131,7 @@ var specLSTInterfaceEnforcer = &DefaultValueEnforcer[string, *dozer.SpecLSTInter
 	},
 }
 
-func loadActualLSTInterfaces(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualLSTInterfaces(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocLST := &oc.OpenconfigLstExt_Lst{}
 	err := client.Get(ctx, "/lst/interfaces", ocLST)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_mclag.go
+++ b/pkg/agent/dozer/bcm/spec_mclag.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -78,7 +77,7 @@ var specMCLAGInterfaceEnforcer = &DefaultValueEnforcer[string, *dozer.SpecMCLAGI
 	},
 }
 
-func loadActualMCLAGs(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualMCLAGs(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	gnmiMCLAG := &oc.OpenconfigMclag_Mclag{}
 	err := client.Get(ctx, "/mclag/mclag-domains", gnmiMCLAG, api.DataTypeCONFIG())
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_ntp.go
+++ b/pkg/agent/dozer/bcm/spec_ntp.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -63,7 +62,7 @@ var specNTPServerEnforcer = &DefaultValueEnforcer[string, *dozer.SpecNTPServer]{
 	},
 }
 
-func loadActualNTP(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualNTP(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocNTP := &oc.OpenconfigSystem_System_Ntp{}
 	err := client.Get(ctx, "/system/ntp/config", ocNTP)
 	if err != nil {
@@ -87,7 +86,7 @@ func unmarshalOCNTP(ocVal *oc.OpenconfigSystem_System_Ntp) (*dozer.SpecNTP, erro
 	}, nil
 }
 
-func loadActualNTPServers(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualNTPServers(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocNTP := &oc.OpenconfigSystem_System_Ntp{}
 	err := client.Get(ctx, "/system/ntp/servers", ocNTP)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_pc_config.go
+++ b/pkg/agent/dozer/bcm/spec_pc_config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 )
 
 var specPortChannelConfigsEnforcer = &DefaultMapEnforcer[string, *dozer.SpecPortChannelConfig]{
@@ -74,7 +73,7 @@ var specPortChannelConfigFallbackEnforcer = &DefaultValueEnforcer[string, *dozer
 	},
 }
 
-func loadActualPortChannelConfigs(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualPortChannelConfigs(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocPortChannel := &oc.SonicPortchannel_SonicPortchannel{}
 	err := client.Get(ctx, "/sonic-portchannel/PORTCHANNEL", ocPortChannel)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_prefix_lists.go
+++ b/pkg/agent/dozer/bcm/spec_prefix_lists.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -155,7 +154,7 @@ var specPrefixListEntryEnforcer = &DefaultValueEnforcer[uint32, *dozer.SpecPrefi
 	},
 }
 
-func loadActualPrefixLists(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualPrefixLists(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocPrefixLists := &oc.OpenconfigRoutingPolicy_RoutingPolicy_DefinedSets{}
 	err := client.Get(ctx, "/routing-policy/defined-sets/prefix-sets", ocPrefixLists, api.DataTypeCONFIG())
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_route_maps.go
+++ b/pkg/agent/dozer/bcm/spec_route_maps.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -247,7 +246,7 @@ var specRouteMapStatementEnforcer = &DefaultValueEnforcer[string, *dozer.SpecRou
 	},
 }
 
-func loadActualRouteMaps(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualRouteMaps(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocRouteMaps := &oc.OpenconfigRoutingPolicy_RoutingPolicy{}
 	err := client.Get(ctx, "/routing-policy/policy-definitions", ocRouteMaps, api.DataTypeCONFIG())
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_system.go
+++ b/pkg/agent/dozer/bcm/spec_system.go
@@ -46,7 +46,7 @@ var specZTPEnforcer = &DefaultValueEnforcer[string, *dozer.Spec]{
 	},
 }
 
-func loadActualZTP(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualZTP(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocZTP := &oc.OpenconfigZtp_Ztp_Config{}
 	err := client.Get(ctx, "/ztp/config", ocZTP, api.DataTypeCONFIG())
 	if err != nil {
@@ -86,7 +86,7 @@ var specHostnameEnforcer = &DefaultValueEnforcer[string, *dozer.Spec]{
 	},
 }
 
-func loadActualHostname(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualHostname(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	gnmiSystemConfig := &oc.OpenconfigSystem_System{}
 	err := client.Get(ctx, "/system/config", gnmiSystemConfig, api.DataTypeCONFIG())
 	if err != nil {
@@ -148,7 +148,7 @@ var specPortGroupEnforcer = &DefaultValueEnforcer[string, *dozer.SpecPortGroup]{
 	},
 }
 
-func loadActualPortGroups(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualPortGroups(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.OpenconfigPortGroup_PortGroups{}
 	err := client.Get(ctx, "/port-groups/port-group", ocVal)
 	if err != nil {
@@ -239,7 +239,7 @@ var specPortBreakoutEnforcer = &DefaultValueEnforcer[string, *dozer.SpecPortBrea
 	},
 }
 
-func loadActualPortBreakouts(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualPortBreakouts(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.SonicPortBreakout_SonicPortBreakout{}
 	err := client.Get(ctx, "/sonic-port-breakout/BREAKOUT_CFG", ocVal)
 	if err != nil {
@@ -322,7 +322,7 @@ var specUserAuthorizedKeysEnforcer = &DefaultValueEnforcer[string, *dozer.SpecUs
 			if err := actions.Add(&Action{
 				ASummary: fmt.Sprintf("User %s authorized keys", name),
 				Weight:   ActionWeightUserAuthorizedKeys,
-				CustomFunc: func(_ context.Context, _ *gnmi.Client) error {
+				CustomFunc: func(_ context.Context, _ GNMICClient) error {
 					return installAuthorizedKeys(user, name, false)
 				},
 			}); err != nil {
@@ -378,7 +378,7 @@ func installAuthorizedKeys(user *dozer.SpecUser, name string, skipUnknown bool) 
 	return nil
 }
 
-func loadActualUsers(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualUsers(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.OpenconfigSystem_System_Aaa_Authentication_Users{}
 	err := client.Get(ctx, "/system/aaa/authentication/users/user", ocVal)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_vrf.go
+++ b/pkg/agent/dozer/bcm/spec_vrf.go
@@ -27,7 +27,6 @@ import (
 	"github.com/samber/lo"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -706,7 +705,7 @@ var specVRFAttachedHostEnforcer = &DefaultValueEnforcer[string, *dozer.SpecVRFAt
 	},
 }
 
-func loadActualVRFs(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualVRFs(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.OpenconfigNetworkInstance_NetworkInstances{}
 	err := client.Get(ctx, "/network-instances/network-instance", ocVal, api.DataTypeCONFIG())
 	if err != nil {

--- a/pkg/agent/dozer/bcm/spec_vxlan.go
+++ b/pkg/agent/dozer/bcm/spec_vxlan.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
-	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -137,7 +136,7 @@ var specVRFVNIEnforcer = &DefaultValueEnforcer[string, *dozer.SpecVRFVNIEntry]{
 	},
 }
 
-func loadActualVXLANs(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualVXLANs(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.Device{}
 	err := client.Get(ctx, "/sonic-vxlan", ocVal)
 	if err != nil {
@@ -205,7 +204,7 @@ func unmarshalActualVXLANs(ocVal *oc.SonicVxlan_SonicVxlan) (map[string]*dozer.S
 	return vxlanTunnels, vxlanEvpnNvos, vxlanTunnelMaps, nil
 }
 
-func loadActualVRFVNIMap(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualVRFVNIMap(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVRFMap := &oc.SonicVrf_SonicVrf_VRF{}
 	err := client.Get(ctx, "/sonic-vrf/VRF/VRF_LIST", ocVRFMap)
 	if err != nil {
@@ -262,7 +261,7 @@ var specSuppressVLANNeighEnforcer = &DefaultValueEnforcer[string, *dozer.SpecSup
 	},
 }
 
-func loadActualSuppressVLANNeighs(ctx context.Context, client *gnmi.Client, spec *dozer.Spec) error {
+func loadActualSuppressVLANNeighs(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
 	ocVal := &oc.SonicVxlan_SonicVxlan_SUPPRESS_VLAN_NEIGH{}
 	err := client.Get(ctx, "/sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST", ocVal)
 	if err != nil {

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
@@ -1,0 +1,2383 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 10
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+          sequence-id: 10
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: ipns-egress--default
+        name: ipns-egress--default
+        type: ACL_IPV4
+      name: ipns-egress--default
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+  interfaces:
+    interface:
+    - config:
+        id: Vlan3000
+      id: Vlan3000
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: no-ipns-peering--default
+            type: ACL_IPV4
+          set-name: no-ipns-peering--default
+          type: ACL_IPV4
+      interface-ref:
+        config:
+          interface: Vlan3000
+    - config:
+        id: Vlan3001
+      id: Vlan3001
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: no-ipns-peering--default
+            type: ACL_IPV4
+          set-name: no-ipns-peering--default
+          type: ACL_IPV4
+      interface-ref:
+        config:
+          interface: Vlan3001
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: External leaf-01--external
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 10
+        index: 10
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.16.0
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.16.0
+          proxy-arp:
+            config:
+              mode: REMOTE_ONLY
+        vlan:
+          config:
+            vlan-id: 10
+      - config:
+          index: 20
+        index: 20
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 100.1.20.2
+                prefix-length: 24
+                secondary: false
+              ip: 100.1.20.2
+        vlan:
+          config:
+            vlan-id: 20
+  - config:
+      description: Unbundled server-01 server-01--unbundled--leaf-01
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1003
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Unbundled server-03 server-03--unbundled--leaf-01
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 1001
+        index: 1001
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1001
+      - config:
+          index: 1002
+        index: 1002
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1002
+  - config:
+      description: Unbundled server-04 server-04--unbundled--leaf-01
+      enabled: true
+      mtu: 9036
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 1001
+        index: 1001
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1001
+      - config:
+          index: 1002
+        index: 1002
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1002
+  - config:
+      description: Fabric spine-01/E1/1 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.1
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.1
+  - config:
+      description: Fabric spine-01/E1/2 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.3
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.3
+  - config:
+      description: Fabric spine-02/E1/1 spine-02--fabric--leaf-01
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.11
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.11
+  - config:
+      description: Fabric spine-02/E1/2 spine-02--fabric--leaf-01
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.13
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.13
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.2
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.2
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.0
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.9
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.9
+  - config:
+      description: VPC vpc-03/default
+      enabled: true
+      name: Vlan1003
+    name: Vlan1003
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.3.1/24
+  - config:
+      description: External ext-snp-02 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: External ext-sp-01 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3002
+    name: Vlan3002
+  - config:
+      description: VPC vpc-02 IRB
+      enabled: true
+      name: Vlan3003
+    name: Vlan3003
+  - config:
+      description: VPC vpc-03 IRB
+      enabled: true
+      name: Vlan3004
+    name: Vlan3004
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-01
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfEext-snp-02
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet0.20
+        id: Ethernet0.20
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfEext-snp-02
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-02
+                    policy-name: ext-import--ext-snp-02
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+        identifier: BGP
+        name: bgp
+      - identifier: STATIC
+        name: static
+        static-routes:
+          static:
+          - config:
+              prefix: 0.0.0.0/0
+            next-hops:
+              next-hop:
+              - config:
+                  index: Eth0.20_100.1.20.1
+                  next-hop: 100.1.20.1
+                index: Eth0.20_100.1.20.1
+                interface-ref:
+                  config:
+                    interface: Eth0.20
+            prefix: 0.0.0.0/0
+          - config:
+              prefix: 100.1.20.1/32
+            next-hops:
+              next-hop:
+              - config:
+                  index: Eth0.20
+                index: Eth0.20
+                interface-ref:
+                  config:
+                    interface: Eth0.20
+            prefix: 100.1.20.1/32
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfEext-sp-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet0.10
+        id: Ethernet0.10
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfEext-sp-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    policy-name: ext-import--ext-sp-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+        identifier: BGP
+        name: bgp
+      - identifier: STATIC
+        name: static
+        static-routes:
+          static:
+          - config:
+              prefix: 0.0.0.0/0
+            next-hops:
+              next-hop:
+              - config:
+                  index: Eth0.10_100.1.10.1
+                  next-hop: 100.1.10.1
+                index: Eth0.10_100.1.10.1
+                interface-ref:
+                  config:
+                    interface: Eth0.10
+            prefix: 0.0.0.0/0
+          - config:
+              prefix: 100.1.10.1/32
+            next-hops:
+              next-hop:
+              - config:
+                  index: Eth0.10
+                index: Eth0.10
+                interface-ref:
+                  config:
+                    interface: Eth0.10
+            prefix: 100.1.10.1/32
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet2.1001
+        id: Ethernet2.1001
+      - config:
+          id: Ethernet3.1001
+        id: Ethernet3.1001
+      - config:
+          id: Vlan3002
+        id: Vlan3002
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-03
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-01--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet2.1001
+                enabled: true
+                neighbor-address: Ethernet2.1001
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet2.1001
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-01--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet3.1001
+                enabled: true
+                neighbor-address: Ethernet3.1001
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet3.1001
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-02
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet2.1002
+        id: Ethernet2.1002
+      - config:
+          id: Ethernet3.1002
+        id: Ethernet3.1002
+      - config:
+          id: Vlan3003
+        id: Vlan3003
+    name: VrfVvpc-02
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfEext-snp-02
+                    policy-name: import-vrf--vpc-02
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-02--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet2.1002
+                enabled: true
+                neighbor-address: Ethernet2.1002
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet2.1002
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-02--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet3.1002
+                enabled: true
+                neighbor-address: Ethernet3.1002
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet3.1002
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-02
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-02
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-03
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1003
+        id: Vlan1003
+      - config:
+          id: Vlan3004
+        id: Vlan3004
+    name: VrfVvpc-03
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1003
+              interface-id: Vlan1003
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    policy-name: import-vrf--vpc-03
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-03
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-03
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.2/32
+                    prefix: 172.30.8.2/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/1 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.0
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/1 spine-02--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.10
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.10
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/2 spine-02--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.12
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.12
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/2 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.2
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65100
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65100
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.2
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1003
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:5"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-02
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-02
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-03
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:5"
+            community-set-name: vpc-peers--vpc-03
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ext-import--ext-snp-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 101
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 101
+        name: ext-import--ext-snp-02
+      - config:
+          mode: IPV4
+          name: ext-import--ext-sp-01
+        name: ext-import--ext-sp-01
+      - config:
+          mode: IPV4
+          name: import-vrf--vpc-02--ext-snp-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 103
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 103
+        name: import-vrf--vpc-02--ext-snp-02
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.2/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.2/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vips-only--vpc-01--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vips-only--vpc-01--default
+      - config:
+          mode: IPV4
+          name: vips-only--vpc-02--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vips-only--vpc-02--default
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 103
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 103
+        name: vpc-ext-prefixes--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-03
+        name: vpc-ext-prefixes--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 501
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 501
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-02
+        name: vpc-peers--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+        name: vpc-peers--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-02
+        name: vpc-static-ext-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-03
+        name: vpc-static-ext-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-03
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: ext-import--ext-snp-02
+      name: ext-import--ext-snp-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ext-import--ext-snp-02
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: ext-import--ext-sp-01
+      name: ext-import--ext-sp-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ext-import--ext-sp-01
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-03
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-03
+          config:
+            name: "10005"
+          name: "10005"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-02
+      name: import-vrf--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-02
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-02
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: import-vrf--vpc-02--ext-snp-02
+          config:
+            name: "50010"
+          name: "50010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+            match-src-network-instance:
+              config:
+                name: VrfEext-snp-02
+          config:
+            name: "5010"
+          name: "5010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-03
+      name: import-vrf--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-01
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-01
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-03
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-03
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vips-only--vpc-01--default
+      name: vips-only--vpc-01--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vips-only--vpc-01--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vips-only--vpc-02--default
+      name: vips-only--vpc-02--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vips-only--vpc-02--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-02
+      name: vpc-redistribute-connected--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:4"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-03
+      name: vpc-redistribute-connected--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:5"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-02
+      name: vpc-redistribute-static--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-02
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-03
+      name: vpc-redistribute-static--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-03
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 100
+      vrf_name: VrfEext-snp-02
+    - vni: 200
+      vrf_name: VrfEext-sp-01
+    - vni: 300
+      vrf_name: VrfVvpc-01
+    - vni: 400
+      vrf_name: VrfVvpc-02
+    - vni: 500
+      vrf_name: VrfVvpc-03
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1003
+      suppress: "on"
+    - name: Vlan3002
+      suppress: "on"
+    - name: Vlan3003
+      suppress: "on"
+    - name: Vlan3004
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.0
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_100_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 100
+    - mapname: map_200_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 200
+    - mapname: map_300_Vlan3002
+      name: vtepfabric
+      vlan: Vlan3002
+      vni: 300
+    - mapname: map_400_Vlan3003
+      name: vtepfabric
+      vlan: Vlan3003
+      vni: 400
+    - mapname: map_500_Vlan3004
+      name: vtepfabric
+      vlan: Vlan3004
+      vni: 500
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-01
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.gnmi.expected.yaml
@@ -1,0 +1,2000 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: Unbundled server-02 server-02--unbundled--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1003
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Unbundled server-03 server-03--unbundled--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 1001
+        index: 1001
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1001
+      - config:
+          index: 1002
+        index: 1002
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1002
+  - config:
+      description: Unbundled server-04 server-04--unbundled--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 1001
+        index: 1001
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1001
+      - config:
+          index: 1002
+        index: 1002
+        ipv6:
+          config:
+            enabled: true
+        vlan:
+          config:
+            vlan-id: 1002
+  - config:
+      description: Fabric spine-01/E1/3 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.5
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.5
+  - config:
+      description: Fabric spine-01/E1/4 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.7
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.7
+  - config:
+      description: Fabric spine-02/E1/3 spine-02--fabric--leaf-02
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.15
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.15
+  - config:
+      description: Fabric spine-02/E1/4 spine-02--fabric--leaf-02
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.17
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.17
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.3
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.3
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.1
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.1
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.10
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.10
+  - config:
+      description: VPC vpc-03/default
+      enabled: true
+      name: Vlan1003
+    name: Vlan1003
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.3.1/24
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-02 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+  - config:
+      description: VPC vpc-03 IRB
+      enabled: true
+      name: Vlan3002
+    name: Vlan3002
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-02
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet1.1001
+        id: Ethernet1.1001
+      - config:
+          id: Ethernet2.1001
+        id: Ethernet2.1001
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-03
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.3
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-01--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet1.1001
+                enabled: true
+                neighbor-address: Ethernet1.1001
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet1.1001
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-01--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet2.1001
+                enabled: true
+                neighbor-address: Ethernet2.1001
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet2.1001
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-02
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet1.1002
+        id: Ethernet1.1002
+      - config:
+          id: Ethernet2.1002
+        id: Ethernet2.1002
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-02
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    policy-name: import-vrf--vpc-02
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.3
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-02--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet1.1002
+                enabled: true
+                neighbor-address: Ethernet1.1002
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet1.1002
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - vips-only--vpc-02--default
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    as-override: true
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: HostBGP unnumbered Ethernet2.1002
+                enabled: true
+                neighbor-address: Ethernet2.1002
+                peer-type: EXTERNAL
+              neighbor-address: Ethernet2.1002
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-02
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-02
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-03
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1003
+        id: Vlan1003
+      - config:
+          id: Vlan3002
+        id: Vlan3002
+    name: VrfVvpc-03
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1003
+              interface-id: Vlan1003
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    policy-name: import-vrf--vpc-03
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.3
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-03
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-03
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.3/32
+                    prefix: 172.30.8.3/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.3
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/3 spine-02--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.14
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.14
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/4 spine-02--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.16
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.16
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/3 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.4
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/4 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.6
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.6
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65100
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.3
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65100
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.3
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1003
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:5"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-02
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-02
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-03
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:5"
+            community-set-name: vpc-peers--vpc-03
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.3/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.3/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vips-only--vpc-01--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vips-only--vpc-01--default
+      - config:
+          mode: IPV4
+          name: vips-only--vpc-02--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vips-only--vpc-02--default
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-02
+        name: vpc-ext-prefixes--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-03
+        name: vpc-ext-prefixes--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 501
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 501
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-02
+        name: vpc-peers--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+        name: vpc-peers--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-02
+        name: vpc-static-ext-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-03
+        name: vpc-static-ext-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-03
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-03
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-03
+          config:
+            name: "10005"
+          name: "10005"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-02
+      name: import-vrf--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-02
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-02
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-03
+      name: import-vrf--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-01
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-01
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-03
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-03
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vips-only--vpc-01--default
+      name: vips-only--vpc-01--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vips-only--vpc-01--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vips-only--vpc-02--default
+      name: vips-only--vpc-02--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vips-only--vpc-02--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-02
+      name: vpc-redistribute-connected--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:4"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-03
+      name: vpc-redistribute-connected--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:5"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-02
+      name: vpc-redistribute-static--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-02
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-03
+      name: vpc-redistribute-static--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-03
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 300
+      vrf_name: VrfVvpc-01
+    - vni: 400
+      vrf_name: VrfVvpc-02
+    - vni: 500
+      vrf_name: VrfVvpc-03
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1003
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+    - name: Vlan3002
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.1
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_300_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 300
+    - mapname: map_400_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 400
+    - mapname: map_500_Vlan3002
+      name: vtepfabric
+      vlan: Vlan3002
+      vni: 500
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-02
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.gnmi.expected.yaml
@@ -1,0 +1,665 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: true
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: Fabric leaf-01/E1/5 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.0
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.0
+  - config:
+      description: Fabric leaf-01/E1/6 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet1
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.2
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.2
+  - config:
+      description: Fabric leaf-02/E1/4 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet2
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.4
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.4
+  - config:
+      description: Fabric leaf-02/E1/5 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.6
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.6
+  - config:
+      description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.8
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.8
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.0
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.7
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.7
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: spine-01
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: default
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.0/32
+                    prefix: 172.30.8.0/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65100
+              network-import-check: true
+              router-id: 172.30.8.0
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/5 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.1
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.1
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/6 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.3
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.3
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/4 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.5
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.5
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/5 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.7
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.7
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+                enabled: true
+                neighbor-address: 172.30.128.9
+                peer-as: 65534
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.9
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.2
+                peer-as: 65101
+              neighbor-address: 172.30.8.2
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.3
+                peer-as: 65102
+              neighbor-address: 172.30.8.3
+              transport:
+                config:
+                  local-address: 172.30.8.0
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.0/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.0/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: spine-01
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.gnmi.expected.yaml
@@ -1,0 +1,1751 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: PC2 ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet0
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Unbundled server-03 server-03--unbundled--leaf-01
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1002
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Mesh leaf-02/E1/5 leaf-01--mesh--leaf-02
+      enabled: true
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.2
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.2
+  - config:
+      description: Mesh leaf-02/E1/6 leaf-01--mesh--leaf-02
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.4
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.4
+  - config:
+      description: Mesh leaf-03/E1/5 leaf-01--mesh--leaf-03
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.6
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.6
+  - config:
+      description: Mesh leaf-03/E1/6 leaf-01--mesh--leaf-03
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.8
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.8
+  - config:
+      description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.0
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.0
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.0
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.0
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.7
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.7
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1001
+    config:
+      description: ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1001
+    config:
+      description: ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel2
+    name: PortChannel2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: VPC vpc-01/subnet-01
+      enabled: true
+      name: Vlan1001
+    name: Vlan1001
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.1.1/24
+  - config:
+      description: VPC vpc-02/subnet-01
+      enabled: true
+      name: Vlan1002
+    name: Vlan1002
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.2.1/24
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-02 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-01
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+lst:
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet3
+      id: Ethernet3
+      interface-ref:
+        config:
+          interface: Ethernet3
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  lst-groups:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1001
+        id: Vlan1001
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1001
+              interface-id: Vlan1001
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-02
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.0
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-02
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1002
+        id: Vlan1002
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-02
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1002
+              interface-id: Vlan1002
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    policy-name: import-vrf--vpc-02
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.0
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-02
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-02
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    evpn:
+      ethernet-segments:
+        ethernet-segment:
+        - config:
+            esi: 00f20000f20000000002
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel1
+            name: PortChannel1
+          name: PortChannel1
+        - config:
+            esi: 00f20000f20000000001
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel2
+            name: PortChannel2
+          name: PortChannel2
+      evpn-mh:
+        config:
+          mac-holdtime: 60
+          startup-delay: 60
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.0/32
+                    prefix: 172.30.8.0/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.0
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+                enabled: true
+                neighbor-address: 172.30.128.1
+                peer-as: 65534
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.1
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/5 leaf-01--mesh--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.3
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.3
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/6 leaf-01--mesh--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.5
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.5
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-03/E1/5 leaf-01--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.7
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.7
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-03/E1/6 leaf-01--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.9
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.9
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-02 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65102
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-03 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.2
+                peer-as: 65103
+              neighbor-address: 172.30.8.2
+              transport:
+                config:
+                  local-address: 172.30.8.0
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1001
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1002
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:3"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-02
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:3"
+            community-set-name: vpc-peers--vpc-02
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.0/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.0/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-02
+        name: vpc-ext-prefixes--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 201
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 201
+        name: vpc-peers--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-02
+        name: vpc-static-ext-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-02
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-02
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-02
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-02
+      name: import-vrf--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-01
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-01
+          config:
+            name: "10002"
+          name: "10002"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-02
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-02
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:2"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-02
+      name: vpc-redistribute-connected--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-02
+      name: vpc-redistribute-static--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-02
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+      system_mac: f2:00:00:00:00:02
+    - fallback: false
+      name: PortChannel2
+      system_mac: f2:00:00:00:00:01
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 200
+      vrf_name: VrfVvpc-01
+    - vni: 300
+      vrf_name: VrfVvpc-02
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1001
+      suppress: "on"
+    - name: Vlan1002
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.0
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_200_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 200
+    - mapname: map_201_Vlan1001
+      name: vtepfabric
+      vlan: Vlan1001
+      vni: 201
+    - mapname: map_300_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 300
+    - mapname: map_301_Vlan1002
+      name: vtepfabric
+      vlan: Vlan1002
+      vni: 301
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-01
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.gnmi.expected.yaml
@@ -1,0 +1,1781 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: PC2 ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet0
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC3 Bundled server-04 server-04--bundled--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        aggregate-id: PortChannel3
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC3 Bundled server-04 server-04--bundled--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet3
+    ethernet:
+      config:
+        aggregate-id: PortChannel3
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Mesh leaf-01/E1/4 leaf-01--mesh--leaf-02
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.3
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.3
+  - config:
+      description: Mesh leaf-01/E1/5 leaf-01--mesh--leaf-02
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.5
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.5
+  - config:
+      description: Mesh leaf-03/E1/7 leaf-02--mesh--leaf-03
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.12
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.12
+  - config:
+      description: Mesh leaf-03/E1/8 leaf-02--mesh--leaf-03
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.14
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.14
+  - config:
+      description: Gateway gateway-1/enp2s2 leaf-02--gateway--gateway-1
+      enabled: true
+      name: Ethernet8
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet8
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.10
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.10
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.1
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.1
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.1
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.1
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.8
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.8
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1001
+    config:
+      description: ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1001
+    config:
+      description: ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel2
+    name: PortChannel2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1002
+    config:
+      description: Bundled server-04 server-04--bundled--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel3
+    name: PortChannel3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: VPC vpc-01/subnet-01
+      enabled: true
+      name: Vlan1001
+    name: Vlan1001
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.1.1/24
+  - config:
+      description: VPC vpc-02/subnet-01
+      enabled: true
+      name: Vlan1002
+    name: Vlan1002
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.2.1/24
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-02 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-02
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+lst:
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet7
+      id: Ethernet7
+      interface-ref:
+        config:
+          interface: Ethernet7
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  lst-groups:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1001
+        id: Vlan1001
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1001
+              interface-id: Vlan1001
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-02
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.1
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-02
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1002
+        id: Vlan1002
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-02
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1002
+              interface-id: Vlan1002
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    policy-name: import-vrf--vpc-02
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.1
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-02
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-02
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    evpn:
+      ethernet-segments:
+        ethernet-segment:
+        - config:
+            esi: 00f20000f20000000002
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel1
+            name: PortChannel1
+          name: PortChannel1
+        - config:
+            esi: 00f20000f20000000001
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel2
+            name: PortChannel2
+          name: PortChannel2
+      evpn-mh:
+        config:
+          mac-holdtime: 60
+          startup-delay: 60
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.1/32
+                    prefix: 172.30.8.1/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.1
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Gateway gateway-1/enp2s2 leaf-02--gateway--gateway-1
+                enabled: true
+                neighbor-address: 172.30.128.11
+                peer-as: 65534
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.11
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-03/E1/7 leaf-02--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.13
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.13
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-03/E1/8 leaf-02--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.15
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.15
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/4 leaf-01--mesh--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.2
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/5 leaf-01--mesh--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.4
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-01 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65101
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.1
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-03 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.2
+                peer-as: 65103
+              neighbor-address: 172.30.8.2
+              transport:
+                config:
+                  local-address: 172.30.8.1
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1001
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1002
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:3"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-02
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:3"
+            community-set-name: vpc-peers--vpc-02
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.1/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.1/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-02
+        name: vpc-ext-prefixes--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 201
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 201
+        name: vpc-peers--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-02
+        name: vpc-static-ext-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-02
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-02
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-02
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-02
+      name: import-vrf--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-01
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-01
+          config:
+            name: "10002"
+          name: "10002"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-02
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-02
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:2"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-02
+      name: vpc-redistribute-connected--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-02
+      name: vpc-redistribute-static--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-02
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+      system_mac: f2:00:00:00:00:02
+    - fallback: false
+      name: PortChannel2
+      system_mac: f2:00:00:00:00:01
+    - fallback: false
+      name: PortChannel3
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 200
+      vrf_name: VrfVvpc-01
+    - vni: 300
+      vrf_name: VrfVvpc-02
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1001
+      suppress: "on"
+    - name: Vlan1002
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.1
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_200_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 200
+    - mapname: map_201_Vlan1001
+      name: vtepfabric
+      vlan: Vlan1001
+      vni: 201
+    - mapname: map_300_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 300
+    - mapname: map_301_Vlan1002
+      name: vtepfabric
+      vlan: Vlan1002
+      vni: 301
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-02
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
@@ -1,0 +1,1587 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 10
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+          sequence-id: 10
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: ipns-egress--default
+        name: ipns-egress--default
+        type: ACL_IPV4
+      name: ipns-egress--default
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet0.10
+      egress-acl-sets:
+        egress-acl-set:
+        - config:
+            set-name: ipns-egress--default
+            type: ACL_IPV4
+          set-name: ipns-egress--default
+          type: ACL_IPV4
+      id: Ethernet0.10
+      interface-ref:
+        config:
+          interface: Ethernet0
+          subinterface: 10
+    - config:
+        id: Vlan3000
+      id: Vlan3000
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: no-ipns-peering--default
+            type: ACL_IPV4
+          set-name: no-ipns-peering--default
+          type: ACL_IPV4
+      interface-ref:
+        config:
+          interface: Vlan3000
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: External leaf-03--external
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 10
+        index: 10
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 100.1.10.1
+                prefix-length: 24
+                secondary: false
+              ip: 100.1.10.1
+        vlan:
+          config:
+            vlan-id: 10
+  - config:
+      description: Unbundled server-05 server-05--unbundled--leaf-03
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1003
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 Bundled server-06 server-06--bundled--leaf-03
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 Bundled server-06 server-06--bundled--leaf-03
+      enabled: true
+      mtu: 9036
+      name: Ethernet3
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Mesh leaf-01/E1/6 leaf-01--mesh--leaf-03
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.7
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.7
+  - config:
+      description: Mesh leaf-01/E1/7 leaf-01--mesh--leaf-03
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.9
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.9
+  - config:
+      description: Mesh leaf-02/E1/7 leaf-02--mesh--leaf-03
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.13
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.13
+  - config:
+      description: Mesh leaf-02/E1/8 leaf-02--mesh--leaf-03
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.15
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.15
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.2
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.2
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.2
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.2
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.9
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.9
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1003
+    config:
+      description: Bundled server-06 server-06--bundled--leaf-03
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: VPC vpc-03/subnet-01
+      enabled: true
+      name: Vlan1003
+    name: Vlan1003
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.3.1/24
+  - config:
+      description: External ext-bgp-01 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-03 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-03
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfEext-bgp-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet0.10
+        id: Ethernet0.10
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfEext-bgp-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-03
+                    policy-name: ext-import--ext-bgp-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - ext-inbound--ext-bgp-01
+            config:
+              as: 65103
+              network-import-check: true
+              router-id: 172.30.8.2
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - ext-outbound--ext-bgp-01
+                      import-policy:
+                      - ext-inbound--ext-bgp-01
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: External attach leaf-03--ext-bgp-01
+                enabled: true
+                neighbor-address: 100.1.10.6
+                peer-as: 64102
+              neighbor-address: 100.1.10.6
+        identifier: BGP
+        name: bgp
+  - config:
+      enabled: true
+      name: VrfVvpc-03
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1003
+        id: Vlan1003
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-03
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1003
+              interface-id: Vlan1003
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfEext-bgp-01
+                    policy-name: import-vrf--vpc-03
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65103
+              network-import-check: true
+              router-id: 172.30.8.2
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-03
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-03
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.2/32
+                    prefix: 172.30.8.2/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65103
+              network-import-check: true
+              router-id: 172.30.8.2
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/7 leaf-02--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.12
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.12
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/8 leaf-02--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.14
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.14
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/6 leaf-01--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.6
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.6
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/7 leaf-01--mesh--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.8
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.8
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-01 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65101
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-02 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65102
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.2
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1003
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: ext-inbound--ext-bgp-01
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: ext-inbound--ext-bgp-01
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-03
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-03
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ext-import--ext-bgp-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 100
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 100
+        name: ext-import--ext-bgp-01
+      - config:
+          mode: IPV4
+          name: import-vrf--vpc-03--ext-bgp-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 101
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 101
+        name: import-vrf--vpc-03--ext-bgp-01
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.2/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.2/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 101
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 101
+        name: vpc-ext-prefixes--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-03
+        name: vpc-peers--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-03
+        name: vpc-static-ext-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-03
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: ext-import--ext-bgp-01
+      name: ext-import--ext-bgp-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ext-import--ext-bgp-01
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: ext-inbound--ext-bgp-01
+      name: ext-inbound--ext-bgp-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--ext-bgp-01
+          config:
+            name: "15"
+          name: "15"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              match-as-path-set:
+                config:
+                  as-path-set: fabric-gw-aspath
+                  match-set-options: ANY
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: ext-outbound--ext-bgp-01
+      name: ext-outbound--ext-bgp-01
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - 64102:1000
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - 64102:1000
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-gw-prios
+          config:
+            name: "20"
+          name: "20"
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-03
+      name: import-vrf--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-03
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-03
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--ext-bgp-01
+            match-prefix-set:
+              config:
+                prefix-set: import-vrf--vpc-03--ext-bgp-01
+          config:
+            name: "50010"
+          name: "50010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+            match-src-network-instance:
+              config:
+                name: VrfEext-bgp-01
+          config:
+            name: "5010"
+          name: "5010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-03
+      name: vpc-redistribute-connected--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:4"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-03
+      name: vpc-redistribute-static--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-03
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 100
+      vrf_name: VrfEext-bgp-01
+    - vni: 400
+      vrf_name: VrfVvpc-03
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1003
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.2
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_100_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 100
+    - mapname: map_400_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 400
+    - mapname: map_401_Vlan1003
+      name: vtepfabric
+      vlan: Vlan1003
+      vni: 401
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-03
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.gnmi.expected.yaml
@@ -1,0 +1,1919 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: PC251 MCLAG session leaf-02/E1/1
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        aggregate-id: PortChannel251
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC251 MCLAG session leaf-02/E1/2
+      enabled: true
+      name: Ethernet1
+    ethernet:
+      config:
+        aggregate-id: PortChannel251
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Fabric spine-02/E1/2 spine-02--fabric--leaf-01
+      enabled: true
+      name: Ethernet10
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet10
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.25
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.25
+  - config:
+      description: PC250 MCLAG peer leaf-02/E1/3
+      enabled: true
+      name: Ethernet2
+    ethernet:
+      config:
+        aggregate-id: PortChannel250
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC250 MCLAG peer leaf-02/E1/4
+      enabled: true
+      name: Ethernet3
+    ethernet:
+      config:
+        aggregate-id: PortChannel250
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 MCLAG server-01 server-01--mclag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet4
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC2 MCLAG server-02 server-02--mclag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet5
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Unbundled server-03 server-03--unbundled--leaf-01
+      enabled: true
+      mtu: 9036
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1003
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Fabric spine-01/E1/1 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.1
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.1
+  - config:
+      description: Fabric spine-01/E1/2 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet8
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet8
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.3
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.3
+  - config:
+      description: Fabric spine-02/E1/1 spine-02--fabric--leaf-01
+      enabled: true
+      name: Ethernet9
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet9
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.23
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.23
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.2
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.2
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.0
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.9
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.9
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1001
+    config:
+      description: MCLAG server-01 server-01--mclag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1002
+    config:
+      description: MCLAG server-02 server-02--mclag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel2
+    name: PortChannel2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 2..4094
+    config:
+      description: MCLAG peer leaf-02
+      enabled: true
+      name: PortChannel250
+    name: PortChannel250
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: MCLAG session leaf-02
+      enabled: true
+      name: PortChannel251
+    name: PortChannel251
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.95.0
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.95.0
+  - config:
+      description: VPC vpc-01/subnet-01
+      enabled: true
+      name: Vlan1001
+    name: Vlan1001
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.1.1/24
+  - config:
+      description: VPC vpc-01/subnet-02
+      enabled: true
+      name: Vlan1002
+    name: Vlan1002
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.2.1/24
+  - config:
+      description: VPC vpc-02/subnet-01
+      enabled: true
+      name: Vlan1003
+    name: Vlan1003
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.3.1/24
+  - config:
+      description: VPC vpc-02/subnet-02
+      enabled: true
+      name: Vlan1004
+    name: Vlan1004
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.4.1/24
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-02 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-01
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+lst:
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet10
+      id: Ethernet10
+      interface-ref:
+        config:
+          interface: Ethernet10
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet7
+      id: Ethernet7
+      interface-ref:
+        config:
+          interface: Ethernet7
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet8
+      id: Ethernet8
+      interface-ref:
+        config:
+          interface: Ethernet8
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet9
+      id: Ethernet9
+      interface-ref:
+        config:
+          interface: Ethernet9
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  lst-groups:
+    lst-group:
+    - config:
+        all-mclags-downstream: true
+        name: spinelink
+        timeout: 5
+      name: spinelink
+mclag:
+  interfaces:
+    interface:
+    - config:
+        mclag-domain-id: 100
+      name: PortChannel1
+    - config:
+        mclag-domain-id: 100
+      name: PortChannel2
+  mclag-domains:
+    mclag-domain:
+    - config:
+        domain-id: 100
+        peer-address: 172.30.95.1
+        peer-link: PortChannel250
+        source-address: 172.30.95.0
+      domain-id: 100
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1001
+        id: Vlan1001
+      - config:
+          id: Vlan1002
+        id: Vlan1002
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1001
+              interface-id: Vlan1001
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1002
+              interface-id: Vlan1002
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-02
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-02
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1003
+        id: Vlan1003
+      - config:
+          id: Vlan1004
+        id: Vlan1004
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-02
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1003
+              interface-id: Vlan1003
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1004
+              interface-id: Vlan1004
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    policy-name: import-vrf--vpc-02
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-02
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-02
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.2/32
+                    prefix: 172.30.8.2/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.2
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/1 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.0
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/2 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.2
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/1 spine-02--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.22
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.22
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/2 spine-02--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.24
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.24
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65100
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65100
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: MCLAG session leaf-02
+                enabled: true
+                neighbor-address: 172.30.95.1
+                peer-type: INTERNAL
+              neighbor-address: 172.30.95.1
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1001
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1002
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1003
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1004
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:5"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-02
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:5"
+            community-set-name: vpc-peers--vpc-02
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.2/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.2/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-02
+        name: vpc-ext-prefixes--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.4.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.4.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 501
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 501
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.4.0/24
+              masklength-range: 24..32
+              sequence-number: 502
+            ip-prefix: 10.0.4.0/24
+            masklength-range: 24..32
+            sequence-number: 502
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 201
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 201
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 202
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 202
+        name: vpc-peers--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-02
+        name: vpc-static-ext-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.3.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.3.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.4.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.4.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-02
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-02
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-02
+          config:
+            name: "10005"
+          name: "10005"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-02
+      name: import-vrf--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-01
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-01
+          config:
+            name: "10002"
+          name: "10002"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-02
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-02
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:2"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-02
+      name: vpc-redistribute-connected--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:5"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-02
+      name: vpc-redistribute-static--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-02
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+    - fallback: false
+      name: PortChannel2
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 200
+      vrf_name: VrfVvpc-01
+    - vni: 500
+      vrf_name: VrfVvpc-02
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1001
+      suppress: "on"
+    - name: Vlan1002
+      suppress: "on"
+    - name: Vlan1003
+      suppress: "on"
+    - name: Vlan1004
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.0
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_200_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 200
+    - mapname: map_201_Vlan1001
+      name: vtepfabric
+      vlan: Vlan1001
+      vni: 201
+    - mapname: map_202_Vlan1002
+      name: vtepfabric
+      vlan: Vlan1002
+      vni: 202
+    - mapname: map_500_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 500
+    - mapname: map_501_Vlan1003
+      name: vtepfabric
+      vlan: Vlan1003
+      vni: 501
+    - mapname: map_502_Vlan1004
+      name: vtepfabric
+      vlan: Vlan1004
+      vni: 502
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-01
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
@@ -1,0 +1,2471 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 10
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+          sequence-id: 10
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: ipns-egress--default
+        name: ipns-egress--default
+        type: ACL_IPV4
+      name: ipns-egress--default
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet0.10
+      egress-acl-sets:
+        egress-acl-set:
+        - config:
+            set-name: ipns-egress--default
+            type: ACL_IPV4
+          set-name: ipns-egress--default
+          type: ACL_IPV4
+      id: Ethernet0.10
+      interface-ref:
+        config:
+          interface: Ethernet0
+          subinterface: 10
+    - config:
+        id: Vlan3003
+      id: Vlan3003
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: no-ipns-peering--default
+            type: ACL_IPV4
+          set-name: no-ipns-peering--default
+          type: ACL_IPV4
+      interface-ref:
+        config:
+          interface: Vlan3003
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: External leaf-03--external
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 10
+        index: 10
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 100.1.10.1
+                prefix-length: 24
+                secondary: false
+              ip: 100.1.10.1
+        vlan:
+          config:
+            vlan-id: 10
+  - config:
+      description: PC2 ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Unbundled server-07 server-07--unbundled--leaf-03
+      enabled: true
+      mtu: 9036
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1007
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.9
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.9
+  - config:
+      description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.11
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.11
+  - config:
+      description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.31
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.31
+  - config:
+      description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.33
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.33
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.4
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.4
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.1
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.1
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.11
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.11
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1006
+    config:
+      description: ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1005
+    config:
+      description: ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: PortChannel2
+    name: PortChannel2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: VPC vpc-03/subnet-01
+      enabled: true
+      name: Vlan1005
+    name: Vlan1005
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.5.1/24
+  - config:
+      description: VPC vpc-03/subnet-02
+      enabled: true
+      name: Vlan1006
+    name: Vlan1006
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.6.1/24
+  - config:
+      description: VPC vpc-04/subnet-01
+      enabled: true
+      name: Vlan1007
+    name: Vlan1007
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.7.1/24
+  - config:
+      description: VPC vpc-04 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+  - config:
+      description: VPC vpc-03 IRB
+      enabled: true
+      name: Vlan3002
+    name: Vlan3002
+  - config:
+      description: External external-01 IRB
+      enabled: true
+      name: Vlan3003
+    name: Vlan3003
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-03
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+lst:
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet7
+      id: Ethernet7
+      interface-ref:
+        config:
+          interface: Ethernet7
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  lst-groups:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfEexternal-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet0.10
+        id: Ethernet0.10
+      - config:
+          id: Vlan3003
+        id: Vlan3003
+    name: VrfEexternal-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    - VrfVvpc-03
+                    policy-name: ext-import--external-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - ext-inbound--external-01
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - ext-outbound--external-01
+                      import-policy:
+                      - ext-inbound--external-01
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: External attach leaf-03--external-01
+                enabled: true
+                neighbor-address: 100.1.10.6
+                peer-as: 64102
+              neighbor-address: 100.1.10.6
+        identifier: BGP
+        name: bgp
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfEexternal-01
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-03
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1005
+        id: Vlan1005
+      - config:
+          id: Vlan1006
+        id: Vlan1006
+      - config:
+          id: Vlan3002
+        id: Vlan3002
+    name: VrfVvpc-03
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1005
+              interface-id: Vlan1005
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1006
+              interface-id: Vlan1006
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfEexternal-01
+                    - VrfVvpc-04
+                    policy-name: import-vrf--vpc-03
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-03
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-03
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-04
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1007
+        id: Vlan1007
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-04
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1007
+              interface-id: Vlan1007
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-03
+                    policy-name: import-vrf--vpc-04
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-04
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-04
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    evpn:
+      ethernet-segments:
+        ethernet-segment:
+        - config:
+            esi: 00f20000f20000000002
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel1
+            name: PortChannel1
+          name: PortChannel1
+        - config:
+            esi: 00f20000f20000000001
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel2
+            name: PortChannel2
+          name: PortChannel2
+      evpn-mh:
+        config:
+          mac-holdtime: 60
+          startup-delay: 60
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.4/32
+                    prefix: 172.30.8.4/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.10
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.10
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.30
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.30
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.32
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.32
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.8
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.8
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65100
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65100
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.4
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1005
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1006
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1007
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: ext-inbound--external-01
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: ext-inbound--external-01
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-03
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-03
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-04
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-04
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ext-import--external-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 103
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 103
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 105
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 105
+        name: ext-import--external-01
+      - config:
+          mode: IPV4
+          name: import-vrf--vpc-01--external-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: import-vrf--vpc-01--external-01
+      - config:
+          mode: IPV4
+          name: import-vrf--vpc-03--external-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: import-vrf--vpc-03--external-01
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.4/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.4/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: vpc-ext-prefixes--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-04
+        name: vpc-ext-prefixes--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 401
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 401
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 402
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 402
+        name: vpc-peers--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 302
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 302
+        name: vpc-peers--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-03
+        name: vpc-static-ext-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-04
+        name: vpc-static-ext-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-04
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: ext-import--external-01
+      name: ext-import--external-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ext-import--external-01
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: ext-inbound--external-01
+      name: ext-inbound--external-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--external-01
+          config:
+            name: "15"
+          name: "15"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              match-as-path-set:
+                config:
+                  as-path-set: fabric-gw-aspath
+                  match-set-options: ANY
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: ext-outbound--external-01
+      name: ext-outbound--external-01
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - 64102:1000
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - 64102:1000
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-gw-prios
+          config:
+            name: "20"
+          name: "20"
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--external-01
+            match-prefix-set:
+              config:
+                prefix-set: import-vrf--vpc-01--external-01
+          config:
+            name: "50010"
+          name: "50010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+            match-src-network-instance:
+              config:
+                name: VrfEexternal-01
+          config:
+            name: "5010"
+          name: "5010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-03
+      name: import-vrf--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-04
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-04
+          config:
+            name: "10004"
+          name: "10004"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-03
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-03
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--external-01
+            match-prefix-set:
+              config:
+                prefix-set: import-vrf--vpc-03--external-01
+          config:
+            name: "50010"
+          name: "50010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+            match-src-network-instance:
+              config:
+                name: VrfEexternal-01
+          config:
+            name: "5010"
+          name: "5010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-04
+      name: import-vrf--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-03
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-03
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-04
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-04
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:2"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-03
+      name: vpc-redistribute-connected--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-04
+      name: vpc-redistribute-connected--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:4"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-04
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-04
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-03
+      name: vpc-redistribute-static--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-03
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-04
+      name: vpc-redistribute-static--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-04
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-04
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+      system_mac: f2:00:00:00:00:02
+    - fallback: false
+      name: PortChannel2
+      system_mac: f2:00:00:00:00:01
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 100
+      vrf_name: VrfEexternal-01
+    - vni: 200
+      vrf_name: VrfVvpc-01
+    - vni: 300
+      vrf_name: VrfVvpc-03
+    - vni: 400
+      vrf_name: VrfVvpc-04
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1005
+      suppress: "on"
+    - name: Vlan1006
+      suppress: "on"
+    - name: Vlan1007
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+    - name: Vlan3002
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.1
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_100_Vlan3003
+      name: vtepfabric
+      vlan: Vlan3003
+      vni: 100
+    - mapname: map_200_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 200
+    - mapname: map_300_Vlan3002
+      name: vtepfabric
+      vlan: Vlan3002
+      vni: 300
+    - mapname: map_301_Vlan1006
+      name: vtepfabric
+      vlan: Vlan1006
+      vni: 301
+    - mapname: map_302_Vlan1005
+      name: vtepfabric
+      vlan: Vlan1005
+      vni: 302
+    - mapname: map_400_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 400
+    - mapname: map_401_Vlan1007
+      name: vtepfabric
+      vlan: Vlan1007
+      vni: 401
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-03
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.gnmi.expected.yaml
@@ -1,0 +1,1816 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: PC2 ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet0
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC3 Bundled server-08 server-08--bundled--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        aggregate-id: PortChannel3
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC3 Bundled server-08 server-08--bundled--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet3
+    ethernet:
+      config:
+        aggregate-id: PortChannel3
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Fabric spine-01/E1/7 spine-01--fabric--leaf-04
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.13
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.13
+  - config:
+      description: Fabric spine-01/E1/8 spine-01--fabric--leaf-04
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.15
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.15
+  - config:
+      description: Fabric spine-02/E1/7 spine-02--fabric--leaf-04
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.35
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.35
+  - config:
+      description: Fabric spine-02/E1/8 spine-02--fabric--leaf-04
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.37
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.37
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.5
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.5
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.2
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.2
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.12
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.12
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1006
+    config:
+      description: ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1005
+    config:
+      description: ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: PortChannel2
+    name: PortChannel2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1008
+    config:
+      description: Bundled server-08 server-08--bundled--leaf-04
+      enabled: true
+      mtu: 9036
+      name: PortChannel3
+    name: PortChannel3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: VPC vpc-03/subnet-01
+      enabled: true
+      name: Vlan1005
+    name: Vlan1005
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.5.1/24
+  - config:
+      description: VPC vpc-03/subnet-02
+      enabled: true
+      name: Vlan1006
+    name: Vlan1006
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.6.1/24
+  - config:
+      description: VPC vpc-04/subnet-02
+      enabled: true
+      name: Vlan1008
+    name: Vlan1008
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.8.1/24
+  - config:
+      description: VPC vpc-04 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-03 IRB
+      enabled: true
+      name: Vlan3002
+    name: Vlan3002
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-04
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+lst:
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet7
+      id: Ethernet7
+      interface-ref:
+        config:
+          interface: Ethernet7
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  lst-groups:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfVvpc-03
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1005
+        id: Vlan1005
+      - config:
+          id: Vlan1006
+        id: Vlan1006
+      - config:
+          id: Vlan3002
+        id: Vlan3002
+    name: VrfVvpc-03
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1005
+              interface-id: Vlan1005
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1006
+              interface-id: Vlan1006
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-04
+                    policy-name: import-vrf--vpc-03
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65103
+              network-import-check: true
+              router-id: 172.30.8.5
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-03
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-03
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-04
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1008
+        id: Vlan1008
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-04
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1008
+              interface-id: Vlan1008
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-03
+                    policy-name: import-vrf--vpc-04
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65103
+              network-import-check: true
+              router-id: 172.30.8.5
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-04
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-04
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    evpn:
+      ethernet-segments:
+        ethernet-segment:
+        - config:
+            esi: 00f20000f20000000002
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel1
+            name: PortChannel1
+          name: PortChannel1
+        - config:
+            esi: 00f20000f20000000001
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel2
+            name: PortChannel2
+          name: PortChannel2
+      evpn-mh:
+        config:
+          mac-holdtime: 60
+          startup-delay: 60
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.5/32
+                    prefix: 172.30.8.5/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65103
+              network-import-check: true
+              router-id: 172.30.8.5
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/7 spine-01--fabric--leaf-04
+                enabled: true
+                neighbor-address: 172.30.128.12
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.12
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-01/E1/8 spine-01--fabric--leaf-04
+                enabled: true
+                neighbor-address: 172.30.128.14
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.14
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/7 spine-02--fabric--leaf-04
+                enabled: true
+                neighbor-address: 172.30.128.34
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.34
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric spine-02/E1/8 spine-02--fabric--leaf-04
+                enabled: true
+                neighbor-address: 172.30.128.36
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.36
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65100
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.5
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65100
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.5
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1005
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1006
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1008
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-03
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-03
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-04
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-04
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.5/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.5/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-03
+        name: vpc-ext-prefixes--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-04
+        name: vpc-ext-prefixes--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 401
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 401
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 402
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 402
+        name: vpc-peers--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 302
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 302
+        name: vpc-peers--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-03
+        name: vpc-static-ext-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-04
+        name: vpc-static-ext-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-04
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-03
+      name: import-vrf--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-04
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-04
+          config:
+            name: "10004"
+          name: "10004"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-03
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-03
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-04
+      name: import-vrf--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-03
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-03
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-04
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-04
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-03
+      name: vpc-redistribute-connected--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-04
+      name: vpc-redistribute-connected--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:4"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-04
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-04
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-03
+      name: vpc-redistribute-static--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-03
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-04
+      name: vpc-redistribute-static--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-04
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-04
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+      system_mac: f2:00:00:00:00:02
+    - fallback: false
+      name: PortChannel2
+      system_mac: f2:00:00:00:00:01
+    - fallback: false
+      name: PortChannel3
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 300
+      vrf_name: VrfVvpc-03
+    - vni: 400
+      vrf_name: VrfVvpc-04
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1005
+      suppress: "on"
+    - name: Vlan1006
+      suppress: "on"
+    - name: Vlan1008
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3002
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.2
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_300_Vlan3002
+      name: vtepfabric
+      vlan: Vlan3002
+      vni: 300
+    - mapname: map_301_Vlan1006
+      name: vtepfabric
+      vlan: Vlan1006
+      vni: 301
+    - mapname: map_302_Vlan1005
+      name: vtepfabric
+      vlan: Vlan1005
+      vni: 302
+    - mapname: map_400_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 400
+    - mapname: map_402_Vlan1008
+      name: vtepfabric
+      vlan: Vlan1008
+      vni: 402
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-04
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.gnmi.expected.yaml
@@ -1,0 +1,1020 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: true
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+interfaces:
+  interface:
+  - config:
+      description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.0
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.0
+  - config:
+      description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet1
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.2
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.2
+  - config:
+      description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+      enabled: true
+      name: Ethernet10
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet10
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.20
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.20
+  - config:
+      description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet2
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.4
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.4
+  - config:
+      description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.6
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.6
+  - config:
+      description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.8
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.8
+  - config:
+      description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.10
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.10
+  - config:
+      description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.12
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.12
+  - config:
+      description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.14
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.14
+  - config:
+      description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+      enabled: true
+      name: Ethernet8
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet8
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.16
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.16
+  - config:
+      description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+      enabled: true
+      name: Ethernet9
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet9
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.18
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.18
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.0
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.7
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.7
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: spine-01
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: default
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.0/32
+                    prefix: 172.30.8.0/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65100
+              network-import-check: true
+              router-id: 172.30.8.0
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.1
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.1
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.11
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.11
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+                enabled: true
+                neighbor-address: 172.30.128.13
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.13
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+                enabled: true
+                neighbor-address: 172.30.128.15
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.15
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+                enabled: true
+                neighbor-address: 172.30.128.17
+                peer-as: 65104
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.17
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+                enabled: true
+                neighbor-address: 172.30.128.19
+                peer-as: 65104
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.19
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+                enabled: true
+                neighbor-address: 172.30.128.21
+                peer-as: 65534
+              neighbor-address: 172.30.128.21
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: 172.30.128.3
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.3
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.5
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.5
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: 172.30.128.7
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.7
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: 172.30.128.9
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.9
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.2
+                peer-as: 65101
+              neighbor-address: 172.30.8.2
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.3
+                peer-as: 65101
+              neighbor-address: 172.30.8.3
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-03 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.4
+                peer-as: 65102
+              neighbor-address: 172.30.8.4
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-04 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.5
+                peer-as: 65103
+              neighbor-address: 172.30.8.5
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-05 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.6
+                peer-as: 65104
+              neighbor-address: 172.30.8.6
+              transport:
+                config:
+                  local-address: 172.30.8.0
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.0/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.0/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: spine-01
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false


### PR DESCRIPTION
Even if gNMI mock isn't very accurate it gives us a roundtrip testing which would help avoiding situations like missing some of a new fields in loading actual state while having them used in marshal path.