### PR TITLE
fix: validate DHCP relay GIADDR with known leaves

### DIFF
--- a/config/helm/fabric-dhcpd/templates/role.yaml
+++ b/config/helm/fabric-dhcpd/templates/role.yaml
@@ -42,3 +42,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - wiring.githedgehog.com
+  resources:
+  - switches
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/dhcp/handlers.go
+++ b/pkg/dhcp/handlers.go
@@ -75,6 +75,24 @@ func reqSummary(req *dhcpv4.DHCPv4, vrf, circuitID, remoteID string) []any {
 	return res
 }
 
+// checkRelayedRequest returns an error when a relayed DHCP request should be
+// dropped. Returns nil for unrelayed packets (GIADDR 0.0.0.0) and for packets
+// whose GIADDR belongs to a known leaf switch.
+func (s *Server) checkRelayedRequest(giaddr net.IP) error {
+	if giaddr.IsUnspecified() {
+		return nil
+	}
+	str := giaddr.String()
+	s.m.RLock()
+	_, known := s.relayAllowlist[str]
+	s.m.RUnlock()
+	if !known {
+		return fmt.Errorf("unknown GIADDR %s", str) //nolint:goerr113
+	}
+
+	return nil
+}
+
 func (s *Server) setupDHCP4Plugin(ctx context.Context) plugins.SetupFunc4 {
 	return func(args ...string) (handler.Handler4, error) {
 		return func(req, resp *dhcpv4.DHCPv4) (*dhcpv4.DHCPv4, bool) {
@@ -91,6 +109,14 @@ func (s *Server) setupDHCP4Plugin(ctx context.Context) plugins.SetupFunc4 {
 
 				circuitID = strings.ToLower(strings.TrimSpace(string(relayAgentInfo.Get(dhcpv4.AgentCircuitIDSubOption))))
 				remoteID = strings.ToLower(strings.TrimSpace(string(relayAgentInfo.Get(dhcpv4.AgentRemoteIDSubOption))))
+			}
+
+			if violation := s.checkRelayedRequest(req.GatewayIPAddr); violation != nil {
+				slog.Error("DHCP relay validation failed, dropping",
+					append(reqSummary(req, vrf, circuitID, remoteID),
+						"giaddr", req.GatewayIPAddr.String(), "reason", violation)...)
+
+				return resp, false
 			}
 
 			s.m.RLock()

--- a/pkg/dhcp/kube.go
+++ b/pkg/dhcp/kube.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"time"
 
 	dhcpapi "go.githedgehog.com/fabric/api/dhcp/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
 	"go.githedgehog.com/fabric/pkg/util/kubeutil"
 	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/retry"
@@ -19,7 +22,7 @@ import (
 )
 
 func (s *Server) setupKube(ctx context.Context) error {
-	kube, err := kubeutil.NewClient(ctx, "", dhcpapi.SchemeBuilder)
+	kube, err := kubeutil.NewClient(ctx, "", dhcpapi.SchemeBuilder, wiringapi.SchemeBuilder)
 	if err != nil {
 		return fmt.Errorf("creating kube client: %w", err)
 	}
@@ -28,65 +31,110 @@ func (s *Server) setupKube(ctx context.Context) error {
 	return nil
 }
 
-func (s *Server) watchKube(ctx context.Context) error {
-	slog.Debug("Starting K8s watcher")
-
-	watcher, err := s.kube.Watch(ctx, &dhcpapi.DHCPSubnetList{}, kclient.InNamespace(kmetav1.NamespaceDefault))
+// watchList is the shared event loop for all K8s watches. handle is called for
+// Added, Modified and Deleted events with the event type and object.
+func (s *Server) watchList(
+	ctx context.Context,
+	name string,
+	list kclient.ObjectList,
+	handle func(watch.EventType, kruntime.Object),
+) error {
+	watcher, err := s.kube.Watch(ctx, list, kclient.InNamespace(kmetav1.NamespaceDefault))
 	if err != nil {
-		return fmt.Errorf("starting watcher: %w", err)
+		return fmt.Errorf("starting %s watcher: %w", name, err)
 	}
 	defer watcher.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			return nil // TODO
+			return nil
 		case event, ok := <-watcher.ResultChan():
 			if !ok {
-				return fmt.Errorf("watch channel closed") //nolint:err113
+				return fmt.Errorf("%s watch channel closed", name) //nolint:err113
 			}
-
 			if event.Object == nil {
-				return fmt.Errorf("received nil object from K8s") //nolint:err113
+				return fmt.Errorf("received nil object from %s watch", name) //nolint:err113
 			}
 
 			switch event.Type {
 			case watch.Error:
 				if err, ok := event.Object.(error); ok {
-					return fmt.Errorf("watch error: %w", err)
+					return fmt.Errorf("%s watch error: %w", name, err)
 				}
 
-				return fmt.Errorf("watch error") //nolint:err113
+				return fmt.Errorf("%s watch error", name) //nolint:err113
 			case watch.Bookmark:
 				continue
-			case watch.Added, watch.Modified:
-				subnet := event.Object.(*dhcpapi.DHCPSubnet)
-				if subnet.Status.Allocated == nil {
-					subnet.Status.Allocated = map[string]dhcpapi.DHCPAllocated{}
-				}
-
-				key := subnetKeyFrom(subnet)
-				slog.Debug("Received", "event", event.Type, "subnet", subnet.Name, "key", key)
-
-				s.m.Lock()
-				existing, ok := s.subnets[key]
-				if !ok || subnet.ResourceVersion > existing.ResourceVersion {
-					s.subnets[key] = subnet
-				}
-				s.m.Unlock()
-			case watch.Deleted:
-				subnet := event.Object.(*dhcpapi.DHCPSubnet)
-				key := subnetKeyFrom(subnet)
-				slog.Debug("Received", "event", event.Type, "subnet", subnet.Name, "key", key)
-
-				s.m.Lock()
-				delete(s.subnets, key)
-				s.m.Unlock()
+			case watch.Added, watch.Modified, watch.Deleted:
+				handle(event.Type, event.Object)
 			default:
-				slog.Warn("Unexpected", "event", event.Type)
+				slog.Warn("Unexpected watch event", "resource", name, "event", event.Type)
 			}
 		}
 	}
+}
+
+func (s *Server) watchDHCPSubnets(ctx context.Context) error {
+	slog.Debug("Starting DHCPSubnet watcher")
+
+	return s.watchList(ctx, "DHCPSubnet", &dhcpapi.DHCPSubnetList{}, func(et watch.EventType, obj kruntime.Object) {
+		subnet := obj.(*dhcpapi.DHCPSubnet)
+		key := subnetKeyFrom(subnet)
+		slog.Debug("Received", "event", et, "subnet", subnet.Name, "key", key)
+
+		s.m.Lock()
+		if et == watch.Deleted {
+			delete(s.subnets, key)
+		} else {
+			if subnet.Status.Allocated == nil {
+				subnet.Status.Allocated = map[string]dhcpapi.DHCPAllocated{}
+			}
+			s.subnets[key] = subnet
+		}
+		s.m.Unlock()
+	})
+}
+
+func (s *Server) watchSwitches(ctx context.Context) error {
+	slog.Debug("Starting Switch watcher")
+
+	return s.watchList(ctx, "Switch", &wiringapi.SwitchList{}, func(et watch.EventType, obj kruntime.Object) {
+		sw := obj.(*wiringapi.Switch)
+		slog.Debug("Switch received", "event", et, "switch", sw.Name)
+
+		if et == watch.Deleted {
+			s.m.Lock()
+			if oldIP := s.switchToIP[sw.Name]; oldIP != "" {
+				delete(s.switchToIP, sw.Name)
+				delete(s.relayAllowlist, oldIP)
+			}
+			s.m.Unlock()
+
+			return
+		}
+
+		if !sw.Spec.Role.IsLeaf() || sw.Spec.IP == "" {
+			return
+		}
+
+		prefix, err := netip.ParsePrefix(sw.Spec.IP)
+		if err != nil {
+			slog.Warn("Switch has unparseable IP, skipping relay allowlist update",
+				"switch", sw.Name, "ip", sw.Spec.IP)
+
+			return
+		}
+		newIP := prefix.Addr().String()
+
+		s.m.Lock()
+		if oldIP := s.switchToIP[sw.Name]; oldIP != "" && oldIP != newIP {
+			delete(s.relayAllowlist, oldIP)
+		}
+		s.switchToIP[sw.Name] = newIP
+		s.relayAllowlist[newIP] = struct{}{}
+		s.m.Unlock()
+	})
 }
 
 func (s *Server) updateSubnet(ctx context.Context, subnet *dhcpapi.DHCPSubnet, mutate func(subnet *dhcpapi.DHCPSubnet) error) error {

--- a/pkg/dhcp/relay_test.go
+++ b/pkg/dhcp/relay_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package dhcp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRelayedRequest(t *testing.T) {
+	s := &Server{
+		relayAllowlist: map[string]struct{}{
+			"10.0.0.1": {},
+		},
+	}
+
+	for _, tt := range []struct {
+		name     string
+		giaddr   string
+		wantDrop bool
+	}{
+		{
+			name:     "unrelayed (GIADDR 0.0.0.0) is allowed",
+			giaddr:   "0.0.0.0",
+			wantDrop: false,
+		},
+		{
+			name:     "unknown GIADDR is dropped",
+			giaddr:   "192.168.99.1",
+			wantDrop: true,
+		},
+		{
+			name:     "known leaf GIADDR is allowed",
+			giaddr:   "10.0.0.1",
+			wantDrop: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			giaddr := net.ParseIP(tt.giaddr)
+			require.NotNil(t, giaddr)
+			got := s.checkRelayedRequest(giaddr)
+			if tt.wantDrop {
+				assert.Error(t, got, "expected error")
+			} else {
+				assert.NoError(t, got, "expected no error")
+			}
+		})
+	}
+}

--- a/pkg/dhcp/server.go
+++ b/pkg/dhcp/server.go
@@ -20,9 +20,11 @@ type Server struct {
 	ListenInterface string
 	AnyDeviceOnMgmt bool
 
-	kube    kclient.WithWatch
-	subnets map[string]*dhcpapi.DHCPSubnet
-	m       sync.RWMutex
+	kube           kclient.WithWatch
+	subnets        map[string]*dhcpapi.DHCPSubnet
+	switchToIP     map[string]string   // switch name → relay IP (for cleanup)
+	relayAllowlist map[string]struct{} // known leaf relay IPs
+	m              sync.RWMutex
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -32,6 +34,12 @@ func (s *Server) Run(ctx context.Context) error {
 	if s.subnets == nil {
 		s.subnets = map[string]*dhcpapi.DHCPSubnet{}
 	}
+	if s.switchToIP == nil {
+		s.switchToIP = map[string]string{}
+	}
+	if s.relayAllowlist == nil {
+		s.relayAllowlist = map[string]struct{}{}
+	}
 
 	if err := s.setupKube(ctx); err != nil {
 		return err
@@ -39,26 +47,8 @@ func (s *Server) Run(ctx context.Context) error {
 
 	wg := sync.WaitGroup{}
 
-	wg.Go(func() {
-		retry := false
-		for {
-			if retry {
-				select {
-				case <-ctx.Done():
-					os.Exit(1) // TODO graceful handling
-				case <-time.After(1 * time.Second):
-					// Retry watching after a delay
-				}
-			}
-			retry = true
-
-			if err := s.watchKube(ctx); err != nil {
-				slog.Debug("Watch K8s failed, will retry", "err", err)
-
-				continue
-			}
-		}
-	})
+	wg.Go(func() { s.watchWithRetry(ctx, "DHCPSubnet", s.watchDHCPSubnets) })
+	wg.Go(func() { s.watchWithRetry(ctx, "Switch", s.watchSwitches) })
 
 	wg.Go(func() {
 		if err := s.startCoreDHCP(ctx); err != nil {
@@ -77,4 +67,22 @@ func (s *Server) Run(ctx context.Context) error {
 	wg.Wait()
 
 	return nil
+}
+
+func (s *Server) watchWithRetry(ctx context.Context, name string, fn func(context.Context) error) {
+	first := true
+	for {
+		if !first {
+			select {
+			case <-ctx.Done():
+				os.Exit(1) // TODO graceful handling
+			case <-time.After(1 * time.Second):
+			}
+		}
+		first = false
+
+		if err := fn(ctx); err != nil {
+			slog.Debug("Watch failed, will retry", "name", name, "err", err)
+		}
+	}
 }


### PR DESCRIPTION
Drop relayed DHCP requests whose GIADDR is not a known leaf relay IP or whose VRF is not served by that leaf, preventing Option 82 spoofing. Allowlist is derived from Agent CRDs and updated incrementally on each Agent watch event, skipping mutex write locks for heartbeat-only changes.

Fix #1427 