### PR TITLE
feat(agent): hardcode inboundACL on ext attachment

### DIFF
--- a/api/vpc/v1beta1/externalattachment_types.go
+++ b/api/vpc/v1beta1/externalattachment_types.go
@@ -40,6 +40,9 @@ const (
 	ACLProtocolUDP  ACLProtocol = "udp"
 	ACLProtocolICMP ACLProtocol = "icmp"
 	ACLAny                      = "any"
+	// ACLUserMinSeq is the minimum sequence number allowed for user-defined ACL rules.
+	// Sequence numbers below this are reserved for hardcoded security rules.
+	ACLUserMinSeq = 10
 )
 
 var ACLProtocols = []ACLProtocol{
@@ -90,6 +93,9 @@ func (spec *ACLSpec) Validate() (admission.Warnings, error) {
 
 	seqNos := map[uint16]bool{}
 	for _, stmt := range spec.Statements {
+		if stmt.Seq < ACLUserMinSeq {
+			return nil, errors.Errorf("sequence number %d is reserved for security rules (user-defined rules must use seq >= %d)", stmt.Seq, ACLUserMinSeq)
+		}
 		if seqNos[stmt.Seq] {
 			return nil, errors.Errorf("duplicate sequence number %d", stmt.Seq)
 		}

--- a/api/vpc/v1beta1/externalattachment_types_test.go
+++ b/api/vpc/v1beta1/externalattachment_types_test.go
@@ -350,6 +350,17 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			err: true,
 		},
 		{
+			name: "sequence number below minimum",
+			extAtt: extAttWithACL(v1beta1.ACLStatement{
+				Seq:       9,
+				Permit:    true,
+				Protocol:  v1beta1.ACLProtocolTCP,
+				SrcPrefix: v1beta1.ACLAny,
+				DstPrefix: v1beta1.ACLAny,
+			}),
+			err: true,
+		},
+		{
 			name: "invalid protocol",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq: 10, Permit: true, Protocol: "gre", SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -1209,11 +1209,15 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 				vlan = pointer.To(attach.Switch.VLAN)
 			}
 
-			ip, ipNet, err := net.ParseCIDR(attach.Switch.IP)
+			ipNet, err := netip.ParsePrefix(attach.Switch.IP)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse external attach switch ip %s", attach.Switch.IP)
 			}
-			prefixLength, _ := ipNet.Mask.Size()
+			prefixLength := ipNet.Bits()
+			ip := ipNet.Addr()
+			if !ip.Is4() {
+				return fmt.Errorf("invalid external attach switch ip %s, expected IPv4", attach.Switch.IP) //nolint:err113
+			}
 
 			spec.Interfaces[port].Subinterfaces[uint32(attach.Switch.VLAN)] = &dozer.SpecSubinterface{
 				VLAN: vlan,
@@ -1240,16 +1244,13 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 				IPv4UnicastExportPolicies: []string{extOutboundRouteMapName(attach.External)},
 			}
 
-			aclIface := &dozer.SpecACLInterface{
-				Egress: pointer.To(ipnsEgressAccessList(ipns)),
+			if err := planHardenedInboundACL(spec, name, ip.String(), attach.InboundACL); err != nil {
+				return errors.Wrapf(err, "failed to plan inbound ACL for external attach %s", name)
 			}
-			if attach.InboundACL != nil {
-				if err := planInboundACL(spec, name, attach.InboundACL); err != nil {
-					return errors.Wrapf(err, "failed to plan inbound ACL for external attach %s", name)
-				}
-				aclIface.Ingress = pointer.To(extInboundACLName(name))
+			spec.ACLInterfaces[ifaceName] = &dozer.SpecACLInterface{
+				Egress:  pointer.To(ipnsEgressAccessList(ipns)),
+				Ingress: pointer.To(extInboundACLName(name)),
 			}
-			spec.ACLInterfaces[ifaceName] = aclIface
 		} else {
 			// static attachment
 			ifaceName := port
@@ -1291,6 +1292,9 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 				if err != nil {
 					return errors.Wrapf(err, "failed to parse static external attach IP %s", attach.Static.IP)
 				}
+				if !fabricEdgeIP.Addr().Is4() {
+					return fmt.Errorf("invalid static external attach IP %s, expected IPv4", attach.Static.IP) //nolint:err113
+				}
 			}
 			prefixLen := uint8(fabricEdgeIP.Bits()) //nolint:gosec
 			switchIP := fabricEdgeIP.Addr().String()
@@ -1327,7 +1331,14 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 				}
 			}
 
-			if attach.InboundACL != nil {
+			if !attach.Static.Proxy {
+				if err := planHardenedInboundACL(spec, name, switchIP, attach.InboundACL); err != nil {
+					return errors.Wrapf(err, "failed to plan inbound ACL for external attach %s", name)
+				}
+				spec.ACLInterfaces[ifaceName] = &dozer.SpecACLInterface{
+					Ingress: pointer.To(extInboundACLName(name)),
+				}
+			} else if attach.InboundACL != nil {
 				if err := planInboundACL(spec, name, attach.InboundACL); err != nil {
 					return errors.Wrapf(err, "failed to plan inbound ACL for external attach %s", name)
 				}
@@ -1341,89 +1352,159 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 	return nil
 }
 
+func aclStatementToEntry(stmt vpcapi.ACLStatement) (*dozer.SpecACLEntry, error) {
+	entry := &dozer.SpecACLEntry{}
+
+	if stmt.Permit {
+		entry.Action = dozer.SpecACLEntryActionAccept
+	} else {
+		entry.Action = dozer.SpecACLEntryActionDrop
+	}
+
+	switch stmt.Protocol {
+	case vpcapi.ACLProtocolIP:
+		entry.Protocol = dozer.SpecACLEntryProtocolIP
+	case vpcapi.ACLProtocolTCP:
+		entry.Protocol = dozer.SpecACLEntryProtocolTCP
+	case vpcapi.ACLProtocolUDP:
+		entry.Protocol = dozer.SpecACLEntryProtocolUDP
+	case vpcapi.ACLProtocolICMP:
+		entry.Protocol = dozer.SpecACLEntryProtocolICMP
+	default:
+		return nil, errors.Errorf("unknown ACL protocol %q in statement %d", stmt.Protocol, stmt.Seq)
+	}
+
+	if stmt.SrcPrefix != vpcapi.ACLAny {
+		entry.SourceAddress = pointer.To(stmt.SrcPrefix)
+	}
+	if stmt.DstPrefix != vpcapi.ACLAny {
+		entry.DestinationAddress = pointer.To(stmt.DstPrefix)
+	}
+
+	if stmt.PortRangeBegin > 0 || stmt.PortRangeEnd > 0 {
+		if stmt.PortRangeBegin == stmt.PortRangeEnd {
+			entry.DestinationPort = pointer.To(stmt.PortRangeBegin)
+		} else {
+			entry.DestinationPortRange = pointer.To(fmt.Sprintf("%d..%d", stmt.PortRangeBegin, stmt.PortRangeEnd))
+		}
+	}
+
+	if stmt.TCPFilters != nil {
+		if stmt.TCPFilters.Established {
+			entry.TCPSessionEstablished = pointer.To(true)
+		}
+		var flags []dozer.SpecACLEntryTCPFlag
+		for _, mapping := range []struct {
+			set  bool
+			flag dozer.SpecACLEntryTCPFlag
+		}{
+			{stmt.TCPFilters.Fin, dozer.SpecACLEntryTCPFlagFin},
+			{stmt.TCPFilters.NotFin, dozer.SpecACLEntryTCPFlagNotFin},
+			{stmt.TCPFilters.Syn, dozer.SpecACLEntryTCPFlagSyn},
+			{stmt.TCPFilters.NotSyn, dozer.SpecACLEntryTCPFlagNotSyn},
+			{stmt.TCPFilters.Rst, dozer.SpecACLEntryTCPFlagRst},
+			{stmt.TCPFilters.NotRst, dozer.SpecACLEntryTCPFlagNotRst},
+			{stmt.TCPFilters.Psh, dozer.SpecACLEntryTCPFlagPsh},
+			{stmt.TCPFilters.NotPsh, dozer.SpecACLEntryTCPFlagNotPsh},
+			{stmt.TCPFilters.Ack, dozer.SpecACLEntryTCPFlagAck},
+			{stmt.TCPFilters.NotAck, dozer.SpecACLEntryTCPFlagNotAck},
+			{stmt.TCPFilters.Urg, dozer.SpecACLEntryTCPFlagUrg},
+			{stmt.TCPFilters.NotUrg, dozer.SpecACLEntryTCPFlagNotUrg},
+		} {
+			if mapping.set {
+				flags = append(flags, mapping.flag)
+			}
+		}
+		if len(flags) > 0 {
+			entry.TCPFlags = flags
+		}
+	}
+
+	entry.ICMPType = stmt.ICMPType
+	entry.ICMPCode = stmt.ICMPCode
+
+	return entry, nil
+}
+
 func planInboundACL(spec *dozer.Spec, attachName string, aclSpec *vpcapi.ACLSpec) error {
 	dozerName := extInboundACLName(attachName)
 	if _, exists := spec.ACLs[dozerName]; exists {
-		return nil // already planned
+		return nil
 	}
 
 	entries := map[uint32]*dozer.SpecACLEntry{}
 	for _, stmt := range aclSpec.Statements {
-		entry := &dozer.SpecACLEntry{}
-
-		if stmt.Permit {
-			entry.Action = dozer.SpecACLEntryActionAccept
-		} else {
-			entry.Action = dozer.SpecACLEntryActionDrop
+		entry, err := aclStatementToEntry(stmt)
+		if err != nil {
+			return err
 		}
-
-		switch stmt.Protocol {
-		case vpcapi.ACLProtocolIP:
-			entry.Protocol = dozer.SpecACLEntryProtocolIP
-		case vpcapi.ACLProtocolTCP:
-			entry.Protocol = dozer.SpecACLEntryProtocolTCP
-		case vpcapi.ACLProtocolUDP:
-			entry.Protocol = dozer.SpecACLEntryProtocolUDP
-		case vpcapi.ACLProtocolICMP:
-			entry.Protocol = dozer.SpecACLEntryProtocolICMP
-		default:
-			return errors.Errorf("unknown ACL protocol %q in statement %d", stmt.Protocol, stmt.Seq)
-		}
-
-		if stmt.SrcPrefix != vpcapi.ACLAny {
-			entry.SourceAddress = pointer.To(stmt.SrcPrefix)
-		}
-		if stmt.DstPrefix != vpcapi.ACLAny {
-			entry.DestinationAddress = pointer.To(stmt.DstPrefix)
-		}
-
-		if stmt.PortRangeBegin > 0 || stmt.PortRangeEnd > 0 {
-			if stmt.PortRangeBegin == stmt.PortRangeEnd {
-				entry.DestinationPort = pointer.To(stmt.PortRangeBegin)
-			} else {
-				entry.DestinationPortRange = pointer.To(fmt.Sprintf("%d..%d", stmt.PortRangeBegin, stmt.PortRangeEnd))
-			}
-		}
-
-		if stmt.TCPFilters != nil {
-			if stmt.TCPFilters.Established {
-				entry.TCPSessionEstablished = pointer.To(true)
-			}
-			var flags []dozer.SpecACLEntryTCPFlag
-			for _, mapping := range []struct {
-				set  bool
-				flag dozer.SpecACLEntryTCPFlag
-			}{
-				{stmt.TCPFilters.Fin, dozer.SpecACLEntryTCPFlagFin},
-				{stmt.TCPFilters.NotFin, dozer.SpecACLEntryTCPFlagNotFin},
-				{stmt.TCPFilters.Syn, dozer.SpecACLEntryTCPFlagSyn},
-				{stmt.TCPFilters.NotSyn, dozer.SpecACLEntryTCPFlagNotSyn},
-				{stmt.TCPFilters.Rst, dozer.SpecACLEntryTCPFlagRst},
-				{stmt.TCPFilters.NotRst, dozer.SpecACLEntryTCPFlagNotRst},
-				{stmt.TCPFilters.Psh, dozer.SpecACLEntryTCPFlagPsh},
-				{stmt.TCPFilters.NotPsh, dozer.SpecACLEntryTCPFlagNotPsh},
-				{stmt.TCPFilters.Ack, dozer.SpecACLEntryTCPFlagAck},
-				{stmt.TCPFilters.NotAck, dozer.SpecACLEntryTCPFlagNotAck},
-				{stmt.TCPFilters.Urg, dozer.SpecACLEntryTCPFlagUrg},
-				{stmt.TCPFilters.NotUrg, dozer.SpecACLEntryTCPFlagNotUrg},
-			} {
-				if mapping.set {
-					flags = append(flags, mapping.flag)
-				}
-			}
-			if len(flags) > 0 {
-				entry.TCPFlags = flags
-			}
-		}
-
-		if stmt.ICMPType != nil {
-			entry.ICMPType = pointer.To(*stmt.ICMPType)
-		}
-		if stmt.ICMPCode != nil {
-			entry.ICMPCode = pointer.To(*stmt.ICMPCode)
-		}
-
 		entries[uint32(stmt.Seq)] = entry
+	}
+
+	spec.ACLs[dozerName] = &dozer.SpecACL{
+		Description: pointer.To(fmt.Sprintf("Inbound ACL %s", attachName)),
+		Entries:     entries,
+	}
+
+	return nil
+}
+
+func planHardenedInboundACL(spec *dozer.Spec, attachName string, switchIP string, userACL *vpcapi.ACLSpec) error {
+	dozerName := extInboundACLName(attachName)
+	if _, exists := spec.ACLs[dozerName]; exists {
+		return nil
+	}
+
+	dstAddr := switchIP + "/32"
+
+	entries := map[uint32]*dozer.SpecACLEntry{
+		1: {
+			Protocol:           dozer.SpecACLEntryProtocolTCP,
+			DestinationAddress: pointer.To(dstAddr),
+			DestinationPort:    pointer.To(uint16(443)),
+			Action:             dozer.SpecACLEntryActionDrop,
+		},
+		2: {
+			Protocol:           dozer.SpecACLEntryProtocolTCP,
+			DestinationAddress: pointer.To(dstAddr),
+			DestinationPort:    pointer.To(uint16(8080)),
+			Action:             dozer.SpecACLEntryActionDrop,
+		},
+		3: {
+			Protocol:           dozer.SpecACLEntryProtocolUDP,
+			DestinationAddress: pointer.To(dstAddr),
+			DestinationPort:    pointer.To(uint16(67)),
+			Action:             dozer.SpecACLEntryActionDrop,
+		},
+		4: {
+			Protocol:           dozer.SpecACLEntryProtocolUDP,
+			DestinationAddress: pointer.To(dstAddr),
+			DestinationPort:    pointer.To(uint16(161)),
+			Action:             dozer.SpecACLEntryActionDrop,
+		},
+		5: {
+			Protocol:           dozer.SpecACLEntryProtocolUDP,
+			DestinationAddress: pointer.To(dstAddr),
+			DestinationPort:    pointer.To(uint16(4789)),
+			Action:             dozer.SpecACLEntryActionDrop,
+		},
+	}
+
+	if userACL != nil {
+		for _, stmt := range userACL.Statements {
+			if stmt.Seq < 10 {
+				return fmt.Errorf("invalid user ACL statement with sequence number %d in the reserved range", stmt.Seq) //nolint:err113
+			}
+			entry, err := aclStatementToEntry(stmt)
+			if err != nil {
+				return err
+			}
+			entries[uint32(stmt.Seq)] = entry
+		}
+	} else {
+		entries[65535] = &dozer.SpecACLEntry{
+			Action: dozer.SpecACLEntryActionAccept,
+		}
 	}
 
 	spec.ACLs[dozerName] = &dozer.SpecACL{

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
@@ -3102,6 +3102,18 @@
       vni: 500
   weight: 73
 - path: /acl/acl-sets/acl-set
+  summary: Create ACL ext-inbound--leaf-01--ext-snp-02 base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: Inbound ACL leaf-01--ext-snp-02
+        name: ext-inbound--leaf-01--ext-snp-02
+        type: ACL_IPV4
+      name: ext-inbound--leaf-01--ext-snp-02
+      type: ACL_IPV4
+  weight: 74
+- path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
   value:
@@ -3125,6 +3137,113 @@
       name: no-ipns-peering--default
       type: ACL_IPV4
   weight: 74
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 1
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 1
+      ipv4:
+        config:
+          destination-address: 100.1.20.2/32
+          protocol: IP_TCP
+      sequence-id: 1
+      transport:
+        config:
+          destination-port: 443
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 2
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 2
+      ipv4:
+        config:
+          destination-address: 100.1.20.2/32
+          protocol: IP_TCP
+      sequence-id: 2
+      transport:
+        config:
+          destination-port: 8080
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 3
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 3
+      ipv4:
+        config:
+          destination-address: 100.1.20.2/32
+          protocol: IP_UDP
+      sequence-id: 3
+      transport:
+        config:
+          destination-port: 67
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 4
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 4
+      ipv4:
+        config:
+          destination-address: 100.1.20.2/32
+          protocol: IP_UDP
+      sequence-id: 4
+      transport:
+        config:
+          destination-port: 161
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 5
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 5
+      ipv4:
+        config:
+          destination-address: 100.1.20.2/32
+          protocol: IP_UDP
+      sequence-id: 5
+      transport:
+        config:
+          destination-port: 4789
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -3180,6 +3299,30 @@
         sequence-id: 65535
       sequence-id: 65535
   weight: 76
+- path: /acl/interfaces/interface[id=Ethernet0.20]
+  summary: Create ACL interface Ethernet0.20
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet0.20
+      id: Ethernet0.20
+      interface-ref:
+        config:
+          interface: Ethernet0
+          subinterface: 20
+  weight: 77
+- path: /acl/interfaces/interface[id=Ethernet0.20]/ingress-acl-sets/ingress-acl-set
+  summary: Update ACL interface Ethernet0.20 ingress
+  type: update
+  value:
+    ingress-acl-set:
+    - config:
+        set-name: ext-inbound--leaf-01--ext-snp-02
+        type: ACL_IPV4
+      set-name: ext-inbound--leaf-01--ext-snp-02
+      type: ACL_IPV4
+  weight: 77
 - path: /acl/interfaces/interface[id=Vlan3000]
   summary: Create ACL interface Vlan3000
   type: update

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
@@ -7,6 +7,85 @@ acl:
             config:
               forwarding-action: DROP
           config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 100.1.20.2/32
+              protocol: IP_TCP
+          sequence-id: 1
+          transport:
+            config:
+              destination-port: 443
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 2
+          ipv4:
+            config:
+              destination-address: 100.1.20.2/32
+              protocol: IP_TCP
+          sequence-id: 2
+          transport:
+            config:
+              destination-port: 8080
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 3
+          ipv4:
+            config:
+              destination-address: 100.1.20.2/32
+              protocol: IP_UDP
+          sequence-id: 3
+          transport:
+            config:
+              destination-port: 67
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 4
+          ipv4:
+            config:
+              destination-address: 100.1.20.2/32
+              protocol: IP_UDP
+          sequence-id: 4
+          transport:
+            config:
+              destination-port: 161
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 5
+          ipv4:
+            config:
+              destination-address: 100.1.20.2/32
+              protocol: IP_UDP
+          sequence-id: 5
+          transport:
+            config:
+              destination-port: 4789
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Inbound ACL leaf-01--ext-snp-02
+        name: ext-inbound--leaf-01--ext-snp-02
+        type: ACL_IPV4
+      name: ext-inbound--leaf-01--ext-snp-02
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
             sequence-id: 10
           ipv4:
             config:
@@ -50,6 +129,20 @@ acl:
       type: ACL_IPV4
   interfaces:
     interface:
+    - config:
+        id: Ethernet0.20
+      id: Ethernet0.20
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: ext-inbound--leaf-01--ext-snp-02
+            type: ACL_IPV4
+          set-name: ext-inbound--leaf-01--ext-snp-02
+          type: ACL_IPV4
+      interface-ref:
+        config:
+          interface: Ethernet0
+          subinterface: 20
     - config:
         id: Vlan3000
       id: Vlan3000

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
@@ -1,9 +1,42 @@
 aclInterfaces:
+  Ethernet0.20:
+    ingress: ext-inbound--leaf-01--ext-snp-02
   Vlan3000:
     ingress: no-ipns-peering--default
   Vlan3001:
     ingress: no-ipns-peering--default
 acls:
+  ext-inbound--leaf-01--ext-snp-02:
+    description: Inbound ACL leaf-01--ext-snp-02
+    entries:
+      "1":
+        action: DROP
+        destinationAddress: 100.1.20.2/32
+        destinationPort: 443
+        protocol: TCP
+      "2":
+        action: DROP
+        destinationAddress: 100.1.20.2/32
+        destinationPort: 8080
+        protocol: TCP
+      "3":
+        action: DROP
+        destinationAddress: 100.1.20.2/32
+        destinationPort: 67
+        protocol: UDP
+      "4":
+        action: DROP
+        destinationAddress: 100.1.20.2/32
+        destinationPort: 161
+        protocol: UDP
+      "5":
+        action: DROP
+        destinationAddress: 100.1.20.2/32
+        destinationPort: 4789
+        protocol: UDP
+      "65535":
+        action: ACCEPT
+        protocol: IP
   ipns-egress--default:
     entries:
       "10":

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
@@ -2041,6 +2041,18 @@
       vni: 401
   weight: 73
 - path: /acl/acl-sets/acl-set
+  summary: Create ACL ext-inbound--leaf-03--ext-bgp-01 base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: Inbound ACL leaf-03--ext-bgp-01
+        name: ext-inbound--leaf-03--ext-bgp-01
+        type: ACL_IPV4
+      name: ext-inbound--leaf-03--ext-bgp-01
+      type: ACL_IPV4
+  weight: 74
+- path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
   value:
@@ -2064,6 +2076,113 @@
       name: no-ipns-peering--default
       type: ACL_IPV4
   weight: 74
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 1
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 1
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 1
+      transport:
+        config:
+          destination-port: 443
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 2
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 2
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 2
+      transport:
+        config:
+          destination-port: 8080
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 3
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 3
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 3
+      transport:
+        config:
+          destination-port: 67
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 4
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 4
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 4
+      transport:
+        config:
+          destination-port: 161
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 5
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 5
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 5
+      transport:
+        config:
+          destination-port: 4789
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -2138,6 +2257,17 @@
         config:
           interface: Ethernet0
           subinterface: 10
+  weight: 77
+- path: /acl/interfaces/interface[id=Ethernet0.10]/ingress-acl-sets/ingress-acl-set
+  summary: Update ACL interface Ethernet0.10 ingress
+  type: update
+  value:
+    ingress-acl-set:
+    - config:
+        set-name: ext-inbound--leaf-03--ext-bgp-01
+        type: ACL_IPV4
+      set-name: ext-inbound--leaf-03--ext-bgp-01
+      type: ACL_IPV4
   weight: 77
 - path: /acl/interfaces/interface[id=Vlan3000]
   summary: Create ACL interface Vlan3000

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
@@ -7,6 +7,85 @@ acl:
             config:
               forwarding-action: DROP
           config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 1
+          transport:
+            config:
+              destination-port: 443
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 2
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 2
+          transport:
+            config:
+              destination-port: 8080
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 3
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 3
+          transport:
+            config:
+              destination-port: 67
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 4
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 4
+          transport:
+            config:
+              destination-port: 161
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 5
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 5
+          transport:
+            config:
+              destination-port: 4789
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Inbound ACL leaf-03--ext-bgp-01
+        name: ext-inbound--leaf-03--ext-bgp-01
+        type: ACL_IPV4
+      name: ext-inbound--leaf-03--ext-bgp-01
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
             sequence-id: 10
           ipv4:
             config:
@@ -60,6 +139,13 @@ acl:
           set-name: ipns-egress--default
           type: ACL_IPV4
       id: Ethernet0.10
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: ext-inbound--leaf-03--ext-bgp-01
+            type: ACL_IPV4
+          set-name: ext-inbound--leaf-03--ext-bgp-01
+          type: ACL_IPV4
       interface-ref:
         config:
           interface: Ethernet0

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
@@ -1,9 +1,41 @@
 aclInterfaces:
   Ethernet0.10:
     egress: ipns-egress--default
+    ingress: ext-inbound--leaf-03--ext-bgp-01
   Vlan3000:
     ingress: no-ipns-peering--default
 acls:
+  ext-inbound--leaf-03--ext-bgp-01:
+    description: Inbound ACL leaf-03--ext-bgp-01
+    entries:
+      "1":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 443
+        protocol: TCP
+      "2":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 8080
+        protocol: TCP
+      "3":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 67
+        protocol: UDP
+      "4":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 161
+        protocol: UDP
+      "5":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 4789
+        protocol: UDP
+      "65535":
+        action: ACCEPT
+        protocol: IP
   ipns-egress--default:
     entries:
       "10":

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
@@ -3348,6 +3348,18 @@
       vni: 401
   weight: 73
 - path: /acl/acl-sets/acl-set
+  summary: Create ACL ext-inbound--leaf-03--external-01 base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: Inbound ACL leaf-03--external-01
+        name: ext-inbound--leaf-03--external-01
+        type: ACL_IPV4
+      name: ext-inbound--leaf-03--external-01
+      type: ACL_IPV4
+  weight: 74
+- path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
   value:
@@ -3371,6 +3383,113 @@
       name: no-ipns-peering--default
       type: ACL_IPV4
   weight: 74
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 1
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 1
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 1
+      transport:
+        config:
+          destination-port: 443
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 2
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 2
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 2
+      transport:
+        config:
+          destination-port: 8080
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 3
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 3
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 3
+      transport:
+        config:
+          destination-port: 67
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 4
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 4
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 4
+      transport:
+        config:
+          destination-port: 161
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 5
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 5
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 5
+      transport:
+        config:
+          destination-port: 4789
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -3445,6 +3564,17 @@
         config:
           interface: Ethernet0
           subinterface: 10
+  weight: 77
+- path: /acl/interfaces/interface[id=Ethernet0.10]/ingress-acl-sets/ingress-acl-set
+  summary: Update ACL interface Ethernet0.10 ingress
+  type: update
+  value:
+    ingress-acl-set:
+    - config:
+        set-name: ext-inbound--leaf-03--external-01
+        type: ACL_IPV4
+      set-name: ext-inbound--leaf-03--external-01
+      type: ACL_IPV4
   weight: 77
 - path: /acl/interfaces/interface[id=Vlan3003]
   summary: Create ACL interface Vlan3003

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
@@ -7,6 +7,85 @@ acl:
             config:
               forwarding-action: DROP
           config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 1
+          transport:
+            config:
+              destination-port: 443
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 2
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 2
+          transport:
+            config:
+              destination-port: 8080
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 3
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 3
+          transport:
+            config:
+              destination-port: 67
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 4
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 4
+          transport:
+            config:
+              destination-port: 161
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 5
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 5
+          transport:
+            config:
+              destination-port: 4789
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Inbound ACL leaf-03--external-01
+        name: ext-inbound--leaf-03--external-01
+        type: ACL_IPV4
+      name: ext-inbound--leaf-03--external-01
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
             sequence-id: 10
           ipv4:
             config:
@@ -60,6 +139,13 @@ acl:
           set-name: ipns-egress--default
           type: ACL_IPV4
       id: Ethernet0.10
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: ext-inbound--leaf-03--external-01
+            type: ACL_IPV4
+          set-name: ext-inbound--leaf-03--external-01
+          type: ACL_IPV4
       interface-ref:
         config:
           interface: Ethernet0

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
@@ -1,9 +1,41 @@
 aclInterfaces:
   Ethernet0.10:
     egress: ipns-egress--default
+    ingress: ext-inbound--leaf-03--external-01
   Vlan3003:
     ingress: no-ipns-peering--default
 acls:
+  ext-inbound--leaf-03--external-01:
+    description: Inbound ACL leaf-03--external-01
+    entries:
+      "1":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 443
+        protocol: TCP
+      "2":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 8080
+        protocol: TCP
+      "3":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 67
+        protocol: UDP
+      "4":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 161
+        protocol: UDP
+      "5":
+        action: DROP
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 4789
+        protocol: UDP
+      "65535":
+        action: ACCEPT
+        protocol: IP
   ipns-egress--default:
     entries:
       "10":


### PR DESCRIPTION
Drop TCP 443/8080 and UDP 67/161/4789 destined to the border leaf's own interface IP on all non-proxied external attachments (BGP and static). These rules are injected unconditionally by the planner and cannot be removed by the user. User-defined inbound ACL rules are merged in after the security entries (seq >= 10; seq 1–9 are reserved).

Proxied static externals are excluded since their interface IP is dynamically assigned from the proxy subnet.

Fix https://github.com/githedgehog/internal/issues/373
Related to https://github.com/githedgehog/internal/issues/362