### PR TITLE
More ACL goodies

### DIFF
--- a/api/vpc/v1beta1/externalattachment_types.go
+++ b/api/vpc/v1beta1/externalattachment_types.go
@@ -33,13 +33,18 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type ACLProtocol string
+type ACLAction string
 
 const (
-	ACLProtocolIP   ACLProtocol = "ip"
-	ACLProtocolTCP  ACLProtocol = "tcp"
-	ACLProtocolUDP  ACLProtocol = "udp"
-	ACLProtocolICMP ACLProtocol = "icmp"
-	ACLAny                      = "any"
+	ACLProtocolIP    ACLProtocol = "ip"
+	ACLProtocolTCP   ACLProtocol = "tcp"
+	ACLProtocolUDP   ACLProtocol = "udp"
+	ACLProtocolICMP  ACLProtocol = "icmp"
+	ACLAny                       = "any"
+	ACLActionPermit  ACLAction   = "permit"
+	ACLActionDeny    ACLAction   = "deny"
+	ACLActionDiscard ACLAction   = "discard"
+	ACLActionTransit ACLAction   = "transit"
 	// ACLUserMinSeq is the minimum sequence number allowed for user-defined ACL rules.
 	// Sequence numbers below this are reserved for hardcoded security rules.
 	ACLUserMinSeq = 10
@@ -50,6 +55,13 @@ var ACLProtocols = []ACLProtocol{
 	ACLProtocolTCP,
 	ACLProtocolUDP,
 	ACLProtocolICMP,
+}
+
+var ACLActions = []ACLAction{
+	ACLActionDeny,
+	ACLActionDiscard,
+	ACLActionPermit,
+	ACLActionTransit,
 }
 
 type ACLTCPFilters struct {
@@ -70,7 +82,7 @@ type ACLTCPFilters struct {
 
 type ACLStatement struct {
 	Seq            uint16         `json:"seq"`
-	Permit         bool           `json:"permit"`
+	Action         ACLAction      `json:"action"`
 	Protocol       ACLProtocol    `json:"protocol"`
 	SrcPrefix      string         `json:"srcPrefix"`
 	DstPrefix      string         `json:"dstPrefix"`
@@ -100,6 +112,10 @@ func (spec *ACLSpec) Validate() (admission.Warnings, error) {
 			return nil, errors.Errorf("duplicate sequence number %d", stmt.Seq)
 		}
 		seqNos[stmt.Seq] = true
+
+		if !slices.Contains(ACLActions, stmt.Action) {
+			return nil, errors.Errorf("invalid action %q in statement %d", stmt.Action, stmt.Seq)
+		}
 
 		if !slices.Contains(ACLProtocols, stmt.Protocol) {
 			return nil, errors.Errorf("invalid protocol %q in statement %d", stmt.Protocol, stmt.Seq)

--- a/api/vpc/v1beta1/externalattachment_types_test.go
+++ b/api/vpc/v1beta1/externalattachment_types_test.go
@@ -199,7 +199,7 @@ func TestExternalAttachmentValidation(t *testing.T) {
 					Statements: []v1beta1.ACLStatement{
 						{
 							Seq:       10,
-							Permit:    true,
+							Action:    v1beta1.ACLActionPermit,
 							Protocol:  v1beta1.ACLProtocolIP,
 							SrcPrefix: v1beta1.ACLAny,
 							DstPrefix: v1beta1.ACLAny,
@@ -216,7 +216,7 @@ func TestExternalAttachmentValidation(t *testing.T) {
 					Statements: []v1beta1.ACLStatement{
 						{
 							Seq:       10,
-							Permit:    true,
+							Action:    v1beta1.ACLActionPermit,
 							Protocol:  "gre",
 							SrcPrefix: v1beta1.ACLAny,
 							DstPrefix: v1beta1.ACLAny,
@@ -265,7 +265,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "valid TCP statement",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:       10,
-				Permit:    true,
+				Action:    v1beta1.ACLActionPermit,
 				Protocol:  v1beta1.ACLProtocolTCP,
 				SrcPrefix: "10.0.0.0/8",
 				DstPrefix: v1beta1.ACLAny,
@@ -275,7 +275,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "valid UDP statement with port range",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:            10,
-				Permit:         true,
+				Action:         v1beta1.ACLActionDiscard,
 				Protocol:       v1beta1.ACLProtocolUDP,
 				SrcPrefix:      v1beta1.ACLAny,
 				DstPrefix:      "192.168.0.0/16",
@@ -287,7 +287,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "valid ICMP statement with type and code",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:       10,
-				Permit:    false,
+				Action:    v1beta1.ACLActionDeny,
 				Protocol:  v1beta1.ACLProtocolICMP,
 				SrcPrefix: v1beta1.ACLAny,
 				DstPrefix: v1beta1.ACLAny,
@@ -299,7 +299,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "valid IP statement with any prefixes",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:       10,
-				Permit:    true,
+				Action:    v1beta1.ACLActionPermit,
 				Protocol:  v1beta1.ACLProtocolIP,
 				SrcPrefix: v1beta1.ACLAny,
 				DstPrefix: v1beta1.ACLAny,
@@ -309,7 +309,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "valid TCP statement with TCP filters",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:        10,
-				Permit:     true,
+				Action:     v1beta1.ACLActionPermit,
 				Protocol:   v1beta1.ACLProtocolTCP,
 				SrcPrefix:  v1beta1.ACLAny,
 				DstPrefix:  v1beta1.ACLAny,
@@ -320,7 +320,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "invalid TCP statement with illegal TCP filter combo",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:        10,
-				Permit:     true,
+				Action:     v1beta1.ACLActionPermit,
 				Protocol:   v1beta1.ACLProtocolTCP,
 				SrcPrefix:  v1beta1.ACLAny,
 				DstPrefix:  v1beta1.ACLAny,
@@ -337,15 +337,15 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 		{
 			name: "valid multiple statements",
 			extAtt: extAttWithACL(
-				v1beta1.ACLStatement{Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: v1beta1.ACLAny, DstPrefix: v1beta1.ACLAny},
-				v1beta1.ACLStatement{Seq: 20, Permit: false, Protocol: v1beta1.ACLProtocolUDP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny},
+				v1beta1.ACLStatement{Seq: 10, Action: v1beta1.ACLActionTransit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: v1beta1.ACLAny, DstPrefix: v1beta1.ACLAny},
+				v1beta1.ACLStatement{Seq: 20, Action: v1beta1.ACLActionDeny, Protocol: v1beta1.ACLProtocolUDP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny},
 			),
 		},
 		{
 			name: "duplicate sequence numbers",
 			extAtt: extAttWithACL(
-				v1beta1.ACLStatement{Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: v1beta1.ACLAny, DstPrefix: v1beta1.ACLAny},
-				v1beta1.ACLStatement{Seq: 10, Permit: false, Protocol: v1beta1.ACLProtocolUDP, SrcPrefix: v1beta1.ACLAny, DstPrefix: v1beta1.ACLAny},
+				v1beta1.ACLStatement{Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: v1beta1.ACLAny, DstPrefix: v1beta1.ACLAny},
+				v1beta1.ACLStatement{Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolUDP, SrcPrefix: v1beta1.ACLAny, DstPrefix: v1beta1.ACLAny},
 			),
 			err: true,
 		},
@@ -353,7 +353,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "sequence number below minimum",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:       9,
-				Permit:    true,
+				Action:    v1beta1.ACLActionPermit,
 				Protocol:  v1beta1.ACLProtocolTCP,
 				SrcPrefix: v1beta1.ACLAny,
 				DstPrefix: v1beta1.ACLAny,
@@ -361,23 +361,30 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			err: true,
 		},
 		{
+			name: "invalid action",
+			extAtt: extAttWithACL(v1beta1.ACLStatement{
+				Seq: 10, Action: "drop", Protocol: v1beta1.ACLProtocolIP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
+			}),
+			err: true,
+		},
+		{
 			name: "invalid protocol",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: "gre", SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: "gre", SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
 			}),
 			err: true,
 		},
 		{
 			name: "invalid srcPrefix",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "not-a-cidr", DstPrefix: v1beta1.ACLAny,
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "not-a-cidr", DstPrefix: v1beta1.ACLAny,
 			}),
 			err: true,
 		},
 		{
 			name: "invalid dstPrefix",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: "300.0.0.0/8",
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: "300.0.0.0/8",
 			}),
 			err: true,
 		},
@@ -385,7 +392,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "TCP filters on UDP protocol",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:        10,
-				Permit:     true,
+				Action:     v1beta1.ACLActionPermit,
 				Protocol:   v1beta1.ACLProtocolUDP,
 				SrcPrefix:  "10.0.0.0/8",
 				DstPrefix:  v1beta1.ACLAny,
@@ -396,7 +403,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 		{
 			name: "ICMP type on TCP protocol",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
 				ICMPType: ptr[uint8](8),
 			}),
 			err: true,
@@ -404,7 +411,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 		{
 			name: "ICMP code on UDP protocol",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolUDP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolUDP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
 				ICMPCode: ptr[uint8](0),
 			}),
 			err: true,
@@ -413,7 +420,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "port range on IP protocol",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:            10,
-				Permit:         true,
+				Action:         v1beta1.ACLActionPermit,
 				Protocol:       v1beta1.ACLProtocolIP,
 				SrcPrefix:      "10.0.0.0/8",
 				DstPrefix:      v1beta1.ACLAny,
@@ -426,7 +433,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "port range begin greater than end",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:            10,
-				Permit:         true,
+				Action:         v1beta1.ACLActionPermit,
 				Protocol:       v1beta1.ACLProtocolTCP,
 				SrcPrefix:      "10.0.0.0/8",
 				DstPrefix:      v1beta1.ACLAny,
@@ -439,7 +446,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "port range on ICMP protocol",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:            10,
-				Permit:         true,
+				Action:         v1beta1.ACLActionPermit,
 				Protocol:       v1beta1.ACLProtocolICMP,
 				SrcPrefix:      "10.0.0.0/8",
 				DstPrefix:      v1beta1.ACLAny,
@@ -451,21 +458,21 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 		{
 			name: "empty srcPrefix",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "", DstPrefix: v1beta1.ACLAny,
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "", DstPrefix: v1beta1.ACLAny,
 			}),
 			err: true,
 		},
 		{
 			name: "empty dstPrefix",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: "",
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: "",
 			}),
 			err: true,
 		},
 		{
 			name: "port range begin is zero",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
-				Seq: 10, Permit: true, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
+				Seq: 10, Action: v1beta1.ACLActionPermit, Protocol: v1beta1.ACLProtocolTCP, SrcPrefix: "10.0.0.0/8", DstPrefix: v1beta1.ACLAny,
 				PortRangeEnd: 80,
 			}),
 			err: true,
@@ -474,7 +481,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "contradictory TCP flags fin and notFin",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:        10,
-				Permit:     true,
+				Action:     v1beta1.ACLActionPermit,
 				Protocol:   v1beta1.ACLProtocolTCP,
 				SrcPrefix:  "10.0.0.0/8",
 				DstPrefix:  v1beta1.ACLAny,
@@ -486,7 +493,7 @@ func TestExternalAttachmentInboundACLValidation(t *testing.T) {
 			name: "contradictory TCP flags syn and notSyn",
 			extAtt: extAttWithACL(v1beta1.ACLStatement{
 				Seq:        10,
-				Permit:     true,
+				Action:     v1beta1.ACLActionPermit,
 				Protocol:   v1beta1.ACLProtocolTCP,
 				SrcPrefix:  "10.0.0.0/8",
 				DstPrefix:  v1beta1.ACLAny,

--- a/config/crd/bases/agent.githedgehog.com_agents.yaml
+++ b/config/crd/bases/agent.githedgehog.com_agents.yaml
@@ -970,14 +970,14 @@ spec:
                         statements:
                           items:
                             properties:
+                              action:
+                                type: string
                               dstPrefix:
                                 type: string
                               icmpCode:
                                 type: integer
                               icmpType:
                                 type: integer
-                              permit:
-                                type: boolean
                               portRangeBegin:
                                 type: integer
                               portRangeEnd:
@@ -1018,8 +1018,8 @@ spec:
                                     type: boolean
                                 type: object
                             required:
+                            - action
                             - dstPrefix
-                            - permit
                             - protocol
                             - seq
                             - srcPrefix

--- a/config/crd/bases/vpc.githedgehog.com_externalattachments.yaml
+++ b/config/crd/bases/vpc.githedgehog.com_externalattachments.yaml
@@ -88,14 +88,14 @@ spec:
                   statements:
                     items:
                       properties:
+                        action:
+                          type: string
                         dstPrefix:
                           type: string
                         icmpCode:
                           type: integer
                         icmpType:
                           type: integer
-                        permit:
-                          type: boolean
                         portRangeBegin:
                           type: integer
                         portRangeEnd:
@@ -136,8 +136,8 @@ spec:
                               type: boolean
                           type: object
                       required:
+                      - action
                       - dstPrefix
-                      - permit
                       - protocol
                       - seq
                       - srcPrefix

--- a/docs/api.md
+++ b/docs/api.md
@@ -1627,6 +1627,25 @@ and Externals APIs. Intended to be used by the user.
 
 
 
+#### ACLAction
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [ACLStatement](#aclstatement)
+
+| Field | Description |
+| --- | --- |
+| `permit` |  |
+| `deny` |  |
+| `discard` |  |
+| `transit` |  |
+
+
 #### ACLProtocol
 
 _Underlying type:_ _string_
@@ -1676,7 +1695,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `seq` _integer_ |  |  |  |
-| `permit` _boolean_ |  |  |  |
+| `action` _[ACLAction](#aclaction)_ |  |  |  |
 | `protocol` _[ACLProtocol](#aclprotocol)_ |  |  |  |
 | `srcPrefix` _string_ |  |  |  |
 | `dstPrefix` _string_ |  |  |  |

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -1488,6 +1488,12 @@ func planHardenedInboundACL(spec *dozer.Spec, attachName string, switchIP string
 			DestinationPort:    pointer.To(uint16(4789)),
 			Action:             dozer.SpecACLEntryActionDiscard,
 		},
+		6: {
+			Protocol:           dozer.SpecACLEntryProtocolTCP,
+			DestinationAddress: pointer.To(dstAddr),
+			DestinationPort:    pointer.To(uint16(22)),
+			Action:             dozer.SpecACLEntryActionDiscard,
+		},
 	}
 
 	if userACL != nil {

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -1355,10 +1355,17 @@ func planExternals(agent *agentapi.Agent, spec *dozer.Spec) error {
 func aclStatementToEntry(stmt vpcapi.ACLStatement) (*dozer.SpecACLEntry, error) {
 	entry := &dozer.SpecACLEntry{}
 
-	if stmt.Permit {
+	switch stmt.Action {
+	case vpcapi.ACLActionPermit:
 		entry.Action = dozer.SpecACLEntryActionAccept
-	} else {
+	case vpcapi.ACLActionDeny:
 		entry.Action = dozer.SpecACLEntryActionDrop
+	case vpcapi.ACLActionTransit:
+		entry.Action = dozer.SpecACLEntryActionTransit
+	case vpcapi.ACLActionDiscard:
+		entry.Action = dozer.SpecACLEntryActionDiscard
+	default:
+		return nil, errors.Errorf("unknown ACL action %q in statement %d", stmt.Action, stmt.Seq)
 	}
 
 	switch stmt.Protocol {

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.in.agent.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.in.agent.yaml
@@ -176,6 +176,32 @@ spec:
         remoteIP: 100.1.20.1
         vlan: 20
       switch: {}
+      inboundACL:
+        statements:
+          - seq: 15
+            action: permit
+            protocol: tcp
+            srcPrefix: any
+            dstPrefix: 10.50.10.3/32
+            portRangeBegin: 22
+            portRangeEnd: 22
+          - seq: 20
+            action: deny
+            protocol: udp
+            srcPrefix: any
+            dstPrefix: 10.50.10.3/32
+            portRangeBegin: 4789
+            portRangeEnd: 4789
+          - seq: 25
+            action: discard
+            protocol: tcp
+            srcPrefix: any
+            dstPrefix: 10.50.10.3/32
+          - seq: 30
+            action: transit
+            protocol: udp
+            srcPrefix: any
+            dstPrefix: 10.50.10.3/32
     leaf-01--ext-sp-01:
       connection: leaf-01--external
       external: ext-sp-01

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
@@ -3252,7 +3252,7 @@
           destination-port: 22
   weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
-  summary: Create ACL entry 65535
+  summary: Create ACL entry 15
   type: update
   value:
     acl-entry:
@@ -3260,8 +3260,66 @@
         config:
           forwarding-action: ACCEPT
       config:
-        sequence-id: 65535
-      sequence-id: 65535
+        sequence-id: 15
+      ipv4:
+        config:
+          destination-address: 10.50.10.3/32
+          protocol: IP_TCP
+      sequence-id: 15
+      transport:
+        config:
+          destination-port: 22
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 20
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 20
+      ipv4:
+        config:
+          destination-address: 10.50.10.3/32
+          protocol: IP_UDP
+      sequence-id: 20
+      transport:
+        config:
+          destination-port: 4789
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 25
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 25
+      ipv4:
+        config:
+          destination-address: 10.50.10.3/32
+          protocol: IP_TCP
+      sequence-id: 25
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 30
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: TRANSIT
+      config:
+        sequence-id: 30
+      ipv4:
+        config:
+          destination-address: 10.50.10.3/32
+          protocol: IP_UDP
+      sequence-id: 30
   weight: 76
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
@@ -3233,6 +3233,25 @@
           destination-port: 4789
   weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 6
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 6
+      ipv4:
+        config:
+          destination-address: 100.1.20.2/32
+          protocol: IP_TCP
+      sequence-id: 6
+      transport:
+        config:
+          destination-port: 22
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
   value:

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
@@ -18,6 +18,19 @@ acl:
               destination-port: 443
         - actions:
             config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 15
+          ipv4:
+            config:
+              destination-address: 10.50.10.3/32
+              protocol: IP_TCP
+          sequence-id: 15
+          transport:
+            config:
+              destination-port: 22
+        - actions:
+            config:
               forwarding-action: DISCARD
           config:
             sequence-id: 2
@@ -31,6 +44,29 @@ acl:
               destination-port: 8080
         - actions:
             config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 20
+          ipv4:
+            config:
+              destination-address: 10.50.10.3/32
+              protocol: IP_UDP
+          sequence-id: 20
+          transport:
+            config:
+              destination-port: 4789
+        - actions:
+            config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 25
+          ipv4:
+            config:
+              destination-address: 10.50.10.3/32
+              protocol: IP_TCP
+          sequence-id: 25
+        - actions:
+            config:
               forwarding-action: DISCARD
           config:
             sequence-id: 3
@@ -42,6 +78,16 @@ acl:
           transport:
             config:
               destination-port: 67
+        - actions:
+            config:
+              forwarding-action: TRANSIT
+          config:
+            sequence-id: 30
+          ipv4:
+            config:
+              destination-address: 10.50.10.3/32
+              protocol: IP_UDP
+          sequence-id: 30
         - actions:
             config:
               forwarding-action: DISCARD
@@ -81,12 +127,6 @@ acl:
           transport:
             config:
               destination-port: 22
-        - actions:
-            config:
-              forwarding-action: ACCEPT
-          config:
-            sequence-id: 65535
-          sequence-id: 65535
       config:
         description: Inbound ACL leaf-01--ext-snp-02
         name: ext-inbound--leaf-01--ext-snp-02

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
@@ -70,6 +70,19 @@ acl:
               destination-port: 4789
         - actions:
             config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 6
+          ipv4:
+            config:
+              destination-address: 100.1.20.2/32
+              protocol: IP_TCP
+          sequence-id: 6
+          transport:
+            config:
+              destination-port: 22
+        - actions:
+            config:
               forwarding-action: ACCEPT
           config:
             sequence-id: 65535

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
@@ -39,9 +39,24 @@ acls:
         destinationAddress: 100.1.20.2/32
         destinationPort: 22
         protocol: TCP
-      "65535":
+      "15":
         action: ACCEPT
-        protocol: IP
+        destinationAddress: 10.50.10.3/32
+        destinationPort: 22
+        protocol: TCP
+      "20":
+        action: DROP
+        destinationAddress: 10.50.10.3/32
+        destinationPort: 4789
+        protocol: UDP
+      "25":
+        action: DISCARD
+        destinationAddress: 10.50.10.3/32
+        protocol: TCP
+      "30":
+        action: TRANSIT
+        destinationAddress: 10.50.10.3/32
+        protocol: UDP
   ipns-egress--default:
     entries:
       "10":

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
@@ -34,6 +34,11 @@ acls:
         destinationAddress: 100.1.20.2/32
         destinationPort: 4789
         protocol: UDP
+      "6":
+        action: DISCARD
+        destinationAddress: 100.1.20.2/32
+        destinationPort: 22
+        protocol: TCP
       "65535":
         action: ACCEPT
         protocol: IP

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
@@ -2172,6 +2172,25 @@
           destination-port: 4789
   weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 6
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 6
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 6
+      transport:
+        config:
+          destination-port: 22
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
   value:

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
@@ -70,6 +70,19 @@ acl:
               destination-port: 4789
         - actions:
             config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 6
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 6
+          transport:
+            config:
+              destination-port: 22
+        - actions:
+            config:
               forwarding-action: ACCEPT
           config:
             sequence-id: 65535

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
@@ -33,6 +33,11 @@ acls:
         destinationAddress: 100.1.10.1/32
         destinationPort: 4789
         protocol: UDP
+      "6":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 22
+        protocol: TCP
       "65535":
         action: ACCEPT
         protocol: IP

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
@@ -3479,6 +3479,25 @@
           destination-port: 4789
   weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 6
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 6
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 6
+      transport:
+        config:
+          destination-port: 22
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
   value:

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
@@ -70,6 +70,19 @@ acl:
               destination-port: 4789
         - actions:
             config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 6
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 6
+          transport:
+            config:
+              destination-port: 22
+        - actions:
+            config:
               forwarding-action: ACCEPT
           config:
             sequence-id: 65535

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
@@ -33,6 +33,11 @@ acls:
         destinationAddress: 100.1.10.1/32
         destinationPort: 4789
         protocol: UDP
+      "6":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 22
+        protocol: TCP
       "65535":
         action: ACCEPT
         protocol: IP


### PR DESCRIPTION
- add TCP/22 to the hardcoded blocked ports on externals
- extend ACL APIs to support all 4 actions (i.e. permit/deny/discard/transit)

Fix #1447 
Fix #1448 