### PR TITLE
ci: add trivy iac config scan workflow

### DIFF
--- a/.github/workflows/trivy-iac-scan.yaml
+++ b/.github/workflows/trivy-iac-scan.yaml
@@ -1,0 +1,74 @@
+name: Trivy IaC Scan
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy-iac:
+    # Skip on fork PRs: GITHUB_TOKEN lacks security-events:write, so SARIF upload would fail.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run Trivy config scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-iac.sarif
+          severity: CRITICAL,HIGH,MEDIUM
+          exit-code: "0"
+          skip-dirs: "vendor,.claude"
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-iac.sarif
+          category: trivy-iac
+
+      - name: Write summary
+        if: always() && hashFiles('trivy-iac.sarif') != ''
+        run: |
+          sev_rules() {
+            jq --arg sev "$1" '[.runs[0].tool.driver.rules[]? | select(.properties.tags | contains([$sev]))] | length' trivy-iac.sarif 2>/dev/null || echo 0
+          }
+          sev_inst() {
+            jq --arg sev "$1" '[.runs[0].results[]? | select((.message.text // "") | contains($sev))] | length' trivy-iac.sarif 2>/dev/null || echo 0
+          }
+          files=$(jq '[.runs[0].results[]? | .locations[0].physicalLocation.artifactLocation.uri] | unique | length' trivy-iac.sarif 2>/dev/null || echo 0)
+          total=$(jq '.runs[0].results | length' trivy-iac.sarif 2>/dev/null || echo 0)
+          crit_rules=$(sev_rules CRITICAL); high_rules=$(sev_rules HIGH)
+          med_rules=$(sev_rules MEDIUM); low_rules=$(sev_rules LOW)
+          crit_inst=$(sev_inst CRITICAL); high_inst=$(sev_inst HIGH)
+          med_inst=$(sev_inst MEDIUM); low_inst=$(sev_inst LOW)
+
+          {
+            echo "## IaC Scan Summary"
+            echo "- **Files with findings:** $files"
+            echo "- **Unique Critical vulnerability rules:** $crit_rules"
+            echo "- **Unique High vulnerability rules:** $high_rules"
+            echo "- **Unique Medium vulnerability rules:** $med_rules"
+            echo "- **Unique Low vulnerability rules:** $low_rules"
+            echo "- **Critical vulnerability instances:** $crit_inst"
+            echo "- **High vulnerability instances:** $high_inst"
+            echo "- **Medium vulnerability instances:** $med_inst"
+            echo "- **Low vulnerability instances:** $low_inst"
+            echo "- **Total vulnerability instances:** $total"
+            echo ""
+            echo "Check the [Security tab](https://github.com/$GITHUB_REPOSITORY/security/code-scanning?query=is%3Aopen+category%3Atrivy-iac) for detailed findings."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Mirrors the Trivy IaC scan workflow added in [githedgehog/fabricator#1735](https://github.com/githedgehog/fabricator/pull/1735) onto this repo. Scans Dockerfiles (`config/docker/*`) and helm charts (`config/helm/*`) for misconfigurations on every PR, master push, and nightly cron, and uploads SARIF to code scanning under category `trivy-iac`.

Part of the security-posture rollout tracked in [githedgehog/internal#388](https://github.com/githedgehog/internal/issues/388).

## What it does
- Triggers: `push` to master, `pull_request`, cron (05:00 UTC), `workflow_dispatch`
- `aquasecurity/trivy-action@v0.36.0` config-mode against repo root, severity `CRITICAL,HIGH,MEDIUM`
- Skips `vendor` and `.claude` directories
- Uploads SARIF under category `trivy-iac`
- Writes a step summary with per-severity unique-rule + instance counts
- Fork-PR guard: skips the job on fork PRs (no `security-events: write` token)

Findings in: https://github.com/githedgehog/fabric/security/code-scanning?query=is%3Aopen+pr%3A1459