### PR TITLE
fix(inspect): sort bgp and mac output by port in natural order

### DIFF
--- a/pkg/hhfctl/inspect/bgp.go
+++ b/pkg/hhfctl/inspect/bgp.go
@@ -81,6 +81,18 @@ func (out *BGPOut) MarshalText(_ BGPIn, now time.Time) (string, error) {
 			}
 		}
 
+		// sort by port, then vrf, then neighbor name for stable output
+		slices.SortFunc(data, func(a, b []string) int {
+			if c := comparePortNames(a[1], b[1]); c != 0 {
+				return c
+			}
+			if c := strings.Compare(a[2], b[2]); c != 0 {
+				return c
+			}
+
+			return strings.Compare(a[3], b[3])
+		})
+
 		str.WriteString(RenderTable(
 			[]string{"Type", "Port", "VRF", "Neighbor", "RemoteName", "Connection", "State", "LastEstablished"},
 			data,

--- a/pkg/hhfctl/inspect/inspect.go
+++ b/pkg/hhfctl/inspect/inspect.go
@@ -202,3 +202,19 @@ func RenderTable(headers []string, data [][]string) string {
 func HumanizeTime(now, then time.Time) string {
 	return humanize.RelTime(then, now, "ago", "from now")
 }
+
+// comparePortNames is a safe wrapper around wiringapi.ComparePortNames that
+// handles empty port names (e.g. BGP neighbors without an associated port),
+// sorting empty names last.
+func comparePortNames(a, b string) int {
+	switch {
+	case a == b:
+		return 0
+	case a == "":
+		return 1
+	case b == "":
+		return -1
+	}
+
+	return wiringapi.ComparePortNames(a, b)
+}

--- a/pkg/hhfctl/inspect/inspect_test.go
+++ b/pkg/hhfctl/inspect/inspect_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package inspect
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComparePortNames(t *testing.T) {
+	sign := func(n int) int {
+		switch {
+		case n < 0:
+			return -1
+		case n > 0:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	for _, tt := range []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"Ethernet1", "Ethernet1", 0},
+		{"Ethernet1", "", -1},           // empty sorts last
+		{"", "Ethernet1", 1},            // empty sorts last
+		{"Ethernet2", "Ethernet10", -1}, // natural, not lexical
+		{"Ethernet10", "Ethernet2", 1},
+		{"M1", "Ethernet1", -1}, // management port has priority
+		{"Ethernet1", "M1", 1},
+	} {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			require.Equal(t, tt.want, sign(comparePortNames(tt.a, tt.b)))
+		})
+	}
+
+	t.Run("full sort", func(t *testing.T) {
+		got := []string{"Ethernet10", "", "Ethernet2", "M1", "Ethernet1"}
+		slices.SortFunc(got, comparePortNames)
+		require.Equal(t, []string{"M1", "Ethernet1", "Ethernet2", "Ethernet10", ""}, got)
+	})
+}

--- a/pkg/hhfctl/inspect/mac.go
+++ b/pkg/hhfctl/inspect/mac.go
@@ -87,19 +87,7 @@ func MAC(ctx context.Context, kube kclient.Reader, in MACIn) (*MACOut, error) {
 		}
 	}
 
-	// ports are formatted as "agentName/ifaceName"; sort by agent first, then
-	// by the port component so management ports keep their priority within a
-	// switch (agentName never contains "/", so cut on the first separator)
-	slices.SortFunc(out.Ports, func(a, b string) int {
-		aAgent, aPort, _ := strings.Cut(a, "/")
-		bAgent, bPort, _ := strings.Cut(b, "/")
-
-		if c := comparePortNames(aAgent, bAgent); c != 0 {
-			return c
-		}
-
-		return comparePortNames(aPort, bPort)
-	})
+	slices.SortFunc(out.Ports, compareMACPorts)
 
 	dhcpSubnets := &dhcpapi.DHCPSubnetList{}
 	if err := kube.List(ctx, dhcpSubnets); err != nil {
@@ -125,4 +113,20 @@ func MAC(ctx context.Context, kube kclient.Reader, in MACIn) (*MACOut, error) {
 	})
 
 	return out, nil
+}
+
+// compareMACPorts orders MAC port entries formatted as "agentName/ifaceName".
+// It sorts by agent name first, then by the interface component, so management
+// ports keep their priority within a switch. agentName never contains "/", so
+// it cuts on the first separator; a value without "/" sorts by the whole string
+// with an empty port component.
+func compareMACPorts(a, b string) int {
+	aAgent, aPort, _ := strings.Cut(a, "/")
+	bAgent, bPort, _ := strings.Cut(b, "/")
+
+	if c := comparePortNames(aAgent, bAgent); c != 0 {
+		return c
+	}
+
+	return comparePortNames(aPort, bPort)
 }

--- a/pkg/hhfctl/inspect/mac.go
+++ b/pkg/hhfctl/inspect/mac.go
@@ -87,7 +87,19 @@ func MAC(ctx context.Context, kube kclient.Reader, in MACIn) (*MACOut, error) {
 		}
 	}
 
-	slices.Sort(out.Ports)
+	// ports are formatted as "agentName/ifaceName"; sort by agent first, then
+	// by the port component so management ports keep their priority within a
+	// switch (agentName never contains "/", so cut on the first separator)
+	slices.SortFunc(out.Ports, func(a, b string) int {
+		aAgent, aPort, _ := strings.Cut(a, "/")
+		bAgent, bPort, _ := strings.Cut(b, "/")
+
+		if c := comparePortNames(aAgent, bAgent); c != 0 {
+			return c
+		}
+
+		return comparePortNames(aPort, bPort)
+	})
 
 	dhcpSubnets := &dhcpapi.DHCPSubnetList{}
 	if err := kube.List(ctx, dhcpSubnets); err != nil {

--- a/pkg/hhfctl/inspect/mac_test.go
+++ b/pkg/hhfctl/inspect/mac_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package inspect
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareMACPorts(t *testing.T) {
+	// MAC ports are "agentName/ifaceName". Sorting must group by switch
+	// (natural order on the agent name) and, within a switch, keep management
+	// ports first and order data ports naturally (Ethernet2 before Ethernet10).
+	// A plain lexical sort would put leaf-10 before leaf-2 and Ethernet10
+	// before Ethernet2.
+	got := []string{
+		"leaf-10/Ethernet2",
+		"leaf-2/Ethernet1",
+		"leaf-2/Ethernet10",
+		"leaf-2/Ethernet2",
+		"leaf-2/M1",
+		"leaf-10/Ethernet1",
+	}
+
+	slices.SortFunc(got, compareMACPorts)
+
+	require.Equal(t, []string{
+		"leaf-2/M1",
+		"leaf-2/Ethernet1",
+		"leaf-2/Ethernet2",
+		"leaf-2/Ethernet10",
+		"leaf-10/Ethernet1",
+		"leaf-10/Ethernet2",
+	}, got)
+}


### PR DESCRIPTION
inspect bgp built its table rows by ranging over neighbor maps, producing non-deterministic row order between runs. Sort the rows by port (natural order), then VRF, then neighbor name for stable output.

inspect mac used a plain lexical sort, ordering ports as Ethernet1, Ethernet10, Ethernet2; switch it to natural port-name order.

Add a shared comparePortNames helper wrapping wiringapi.ComparePortNames that tolerates empty port names (e.g. loopback/MCLAG BGP sessions), sorting them last.

Closes #1425