### PR TITLE
fix(agent): order switched VLAN ops around subinterface create/delete

### DIFF
--- a/pkg/agent/dozer/bcm/enforcer.go
+++ b/pkg/agent/dozer/bcm/enforcer.go
@@ -93,8 +93,6 @@ const (
 	ActionWeightInterfacePortChannelSwitchedAccessUpdate
 	ActionWeightInterfacePortChannelSwitchedTrunkUpdate
 	ActionWeightInterfaceEthernetBaseUpdate
-	ActionWeightInterfaceEthernetSwitchedAccessUpdate
-	ActionWeightInterfaceEthernetSwitchedTrunkUpdate
 	ActionWeightInterfaceVLANAnycastGatewayUpdate
 	ActionWeightInterfaceNATZoneUpdate
 	ActionWeightPortChannelConfigMACUpdate
@@ -109,6 +107,15 @@ const (
 	ActionWeightACLInterfaceDelete
 	ActionWeightVRFBGPNeighborDelete
 	ActionWeightInterfaceSubinterfaceDelete
+	// Ethernet switched VLAN ops sit between subinterface delete and subinterface create so a VLAN
+	// is never on a port's switched-vlan and on a subinterface of that port at once (SONiC rejects
+	// either op while the other holds the VLAN):
+	//   - removing hostBGP (true->false): delete the subinterface, then add the access/trunk VLAN.
+	//   - adding hostBGP (false->true): delete the access/trunk VLAN, then create the subinterface.
+	ActionWeightInterfaceEthernetSwitchedAccessDelete
+	ActionWeightInterfaceEthernetSwitchedTrunkDelete
+	ActionWeightInterfaceEthernetSwitchedAccessUpdate
+	ActionWeightInterfaceEthernetSwitchedTrunkUpdate
 	ActionWeightInterfaceSubinterfaceUpdate
 	ActionWeightInterfaceVLANStaticARPUpdate
 	ActionWeightInterfaceSubinterfaceStaticARPUpdate
@@ -209,8 +216,6 @@ const (
 
 	ActionWeightPortChannelConfigMACDelete
 	ActionWeightPortChannelConfigFallbackDelete
-	ActionWeightInterfaceEthernetSwitchedAccessDelete
-	ActionWeightInterfaceEthernetSwitchedTrunkDelete
 	ActionWeightInterfaceEthernetBaseDelete
 	ActionWeightInterfacePortChannelSwitchedAccessDelete
 	ActionWeightInterfacePortChannelSwitchedTrunkDelete

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
@@ -2342,40 +2342,40 @@
       config:
         auto-negotiate: false
   weight: 25
-- path: /interfaces/interface[name=Ethernet1]/ethernet/switched-vlan/config/trunk-vlans
-  summary: Create Interface Ethernet1 Switched Trunk VLANs
-  type: update
-  value:
-    trunk-vlans:
-    - 1003
-  weight: 27
 - path: /interfaces/interface[name=Vlan1003]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1003 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.3.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3001 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3002 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3003]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3003 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3004]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3004 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
+- path: /interfaces/interface[name=Ethernet1]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet1 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1003
+  weight: 42
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2384,7 +2384,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]
   summary: Create Subinterface Base 10
   type: update
@@ -2396,7 +2396,7 @@
       vlan:
         config:
           vlan-id: 10
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=20]
   summary: Create Subinterface Base 20
   type: update
@@ -2408,7 +2408,7 @@
       vlan:
         config:
           vlan-id: 20
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2417,7 +2417,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2426,7 +2426,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2438,7 +2438,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2450,7 +2450,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2459,7 +2459,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2471,7 +2471,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2483,7 +2483,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2492,7 +2492,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2501,7 +2501,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2510,7 +2510,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2519,7 +2519,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2528,7 +2528,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2537,7 +2537,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2546,7 +2546,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/interfaces/interface[id=Ethernet0.20]
   summary: Create VRF interface Ethernet0.20
   type: update
@@ -2555,7 +2555,7 @@
     - config:
         id: Ethernet0.20
       id: Ethernet0.20
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2564,7 +2564,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/interfaces/interface[id=Ethernet0.10]
   summary: Create VRF interface Ethernet0.10
   type: update
@@ -2573,7 +2573,7 @@
     - config:
         id: Ethernet0.10
       id: Ethernet0.10
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2582,7 +2582,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet2.1001]
   summary: Create VRF interface Ethernet2.1001
   type: update
@@ -2591,7 +2591,7 @@
     - config:
         id: Ethernet2.1001
       id: Ethernet2.1001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet3.1001]
   summary: Create VRF interface Ethernet3.1001
   type: update
@@ -2600,7 +2600,7 @@
     - config:
         id: Ethernet3.1001
       id: Ethernet3.1001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2609,7 +2609,7 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet2.1002]
   summary: Create VRF interface Ethernet2.1002
   type: update
@@ -2618,7 +2618,7 @@
     - config:
         id: Ethernet2.1002
       id: Ethernet2.1002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet3.1002]
   summary: Create VRF interface Ethernet3.1002
   type: update
@@ -2627,7 +2627,7 @@
     - config:
         id: Ethernet3.1002
       id: Ethernet3.1002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3003]
   summary: Create VRF interface Vlan3003
   type: update
@@ -2636,7 +2636,7 @@
     - config:
         id: Vlan3003
       id: Vlan3003
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1003]
   summary: Create VRF interface Vlan1003
   type: update
@@ -2645,7 +2645,7 @@
     - config:
         id: Vlan1003
       id: Vlan1003
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3004]
   summary: Create VRF interface Vlan3004
   type: update
@@ -2654,83 +2654,83 @@
     - config:
         id: Vlan3004
       id: Vlan3004
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv6/config/enabled
   summary: Create Subinterface 10 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=20]/ipv6/config/enabled
   summary: Create Subinterface 20 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1003]
   summary: Create VRF attached host
   type: update
@@ -2741,7 +2741,7 @@
         address-family: IPV4
         interface-id: Vlan1003
       interface-id: Vlan1003
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.16.0
   type: update
@@ -2752,7 +2752,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.16.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=20]/ipv4/addresses/address
   summary: Create Subinterface IP 100.1.20.2
   type: update
@@ -2763,7 +2763,7 @@
         prefix-length: 24
         secondary: false
       ip: 100.1.20.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.1
   type: update
@@ -2774,7 +2774,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.3
   type: update
@@ -2785,7 +2785,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.3
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.11
   type: update
@@ -2796,7 +2796,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.11
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.13
   type: update
@@ -2807,7 +2807,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.13
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.2
   type: update
@@ -2818,7 +2818,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.0
   type: update
@@ -2829,7 +2829,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.9
   type: update
@@ -2840,14 +2840,14 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.9
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/proxy-arp/config
   summary: Create Subinterface 10 Proxy-ARP
   type: update
   value:
     config:
       mode: REMOTE_ONLY
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2855,7 +2855,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2865,7 +2865,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1003
   type: update
@@ -2873,7 +2873,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -2881,7 +2881,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3003
   type: update
@@ -2889,7 +2889,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3004
   type: update
@@ -2897,7 +2897,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3004
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=0.0.0.0/0]
   summary: Create VRF static route 0.0.0.0/0
   type: update
@@ -2915,7 +2915,7 @@
             config:
               interface: Eth0.20
       prefix: 0.0.0.0/0
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=100.1.20.1/32]
   summary: Create VRF static route 100.1.20.1/32
   type: update
@@ -2932,7 +2932,7 @@
             config:
               interface: Eth0.20
       prefix: 100.1.20.1/32
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=0.0.0.0/0]
   summary: Create VRF static route 0.0.0.0/0
   type: update
@@ -2950,7 +2950,7 @@
             config:
               interface: Eth0.10
       prefix: 0.0.0.0/0
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=100.1.10.1/32]
   summary: Create VRF static route 100.1.10.1/32
   type: update
@@ -2967,73 +2967,73 @@
             config:
               interface: Eth0.10
       prefix: 100.1.10.1/32
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/global-sag/config
   summary: Create VRF VrfEext-snp-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/global-sag/config
   summary: Create VRF VrfEext-sp-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/evpn/evpn-mh/config
   summary: Create VRF VrfEext-snp-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/evpn/evpn-mh/config
   summary: Create VRF VrfEext-sp-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -3042,7 +3042,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.0
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -3050,7 +3050,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_100_Vlan3000
   type: update
@@ -3060,7 +3060,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 100
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3001
   type: update
@@ -3070,7 +3070,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3002
   type: update
@@ -3080,7 +3080,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3003
   type: update
@@ -3090,7 +3090,7 @@
       name: vtepfabric
       vlan: Vlan3003
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_500_Vlan3004
   type: update
@@ -3100,7 +3100,7 @@
       name: vtepfabric
       vlan: Vlan3004
       vni: 500
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ext-inbound--leaf-01--ext-snp-02 base
   type: update
@@ -3112,7 +3112,7 @@
         type: ACL_IPV4
       name: ext-inbound--leaf-01--ext-snp-02
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
@@ -3124,7 +3124,7 @@
         type: ACL_IPV4
       name: ipns-egress--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -3136,7 +3136,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3155,7 +3155,7 @@
       transport:
         config:
           destination-port: 443
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 2
   type: update
@@ -3174,7 +3174,7 @@
       transport:
         config:
           destination-port: 8080
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 3
   type: update
@@ -3193,7 +3193,7 @@
       transport:
         config:
           destination-port: 67
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 4
   type: update
@@ -3212,7 +3212,7 @@
       transport:
         config:
           destination-port: 161
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 5
   type: update
@@ -3231,7 +3231,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 6
   type: update
@@ -3250,7 +3250,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 15
   type: update
@@ -3269,7 +3269,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 20
   type: update
@@ -3288,7 +3288,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 25
   type: update
@@ -3304,7 +3304,7 @@
           destination-address: 10.50.10.3/32
           protocol: IP_TCP
       sequence-id: 25
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 30
   type: update
@@ -3320,7 +3320,7 @@
           destination-address: 10.50.10.3/32
           protocol: IP_UDP
       sequence-id: 30
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -3335,7 +3335,7 @@
         config:
           destination-address: 10.0.0.0/16
       sequence-id: 10
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3347,7 +3347,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3363,7 +3363,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3375,7 +3375,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/interfaces/interface[id=Ethernet0.20]
   summary: Create ACL interface Ethernet0.20
   type: update
@@ -3388,7 +3388,7 @@
         config:
           interface: Ethernet0
           subinterface: 20
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Ethernet0.20]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Ethernet0.20 ingress
   type: update
@@ -3399,7 +3399,7 @@
         type: ACL_IPV4
       set-name: ext-inbound--leaf-01--ext-snp-02
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]
   summary: Create ACL interface Vlan3000
   type: update
@@ -3411,7 +3411,7 @@
       interface-ref:
         config:
           interface: Vlan3000
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3000 ingress
   type: update
@@ -3422,7 +3422,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3001]
   summary: Create ACL interface Vlan3001
   type: update
@@ -3434,7 +3434,7 @@
       interface-ref:
         config:
           interface: Vlan3001
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3001]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3001 ingress
   type: update
@@ -3445,7 +3445,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEext-snp-02 BGP base
   type: update
@@ -3465,7 +3465,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEext-sp-01 BGP base
   type: update
@@ -3485,7 +3485,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -3505,7 +3505,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -3525,7 +3525,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -3545,7 +3545,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -3565,7 +3565,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEext-snp-02 BGP L2VPN
   type: update
@@ -3580,7 +3580,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEext-sp-01 BGP L2VPN
   type: update
@@ -3595,7 +3595,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -3610,7 +3610,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -3625,7 +3625,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -3640,7 +3640,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -3654,7 +3654,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -3668,7 +3668,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -3677,7 +3677,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -3688,7 +3688,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -3699,7 +3699,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -3710,7 +3710,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -3721,7 +3721,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1001]
   summary: Create VRF BGP neighbor Ethernet2.1001
   type: update
@@ -3748,7 +3748,7 @@
         neighbor-address: Ethernet2.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1001
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3.1001]
   summary: Create VRF BGP neighbor Ethernet3.1001
   type: update
@@ -3775,7 +3775,7 @@
         neighbor-address: Ethernet3.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet3.1001
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1002]
   summary: Create VRF BGP neighbor Ethernet2.1002
   type: update
@@ -3802,7 +3802,7 @@
         neighbor-address: Ethernet2.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1002
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3.1002]
   summary: Create VRF BGP neighbor Ethernet3.1002
   type: update
@@ -3829,7 +3829,7 @@
         neighbor-address: Ethernet3.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet3.1002
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.0]
   summary: Create VRF BGP neighbor 172.30.128.0
   type: update
@@ -3858,7 +3858,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.10]
   summary: Create VRF BGP neighbor 172.30.128.10
   type: update
@@ -3887,7 +3887,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.10
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -3916,7 +3916,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -3945,7 +3945,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3982,7 +3982,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -4019,7 +4019,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -4028,7 +4028,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4041,7 +4041,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4054,7 +4054,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4067,7 +4067,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4082,7 +4082,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4097,7 +4097,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4110,7 +4110,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4125,7 +4125,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4140,7 +4140,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4153,7 +4153,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4168,7 +4168,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4183,7 +4183,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4196,7 +4196,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4209,65 +4209,65 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-snp-02
   type: update
   value:
     policy-name: ext-import--ext-snp-02
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-sp-01
   type: update
   value:
     policy-name: ext-import--ext-sp-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEext-snp-02
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfEext-snp-02
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -4282,7 +4282,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
@@ -2107,32 +2107,32 @@
       config:
         auto-negotiate: false
   weight: 25
-- path: /interfaces/interface[name=Ethernet0]/ethernet/switched-vlan/config/trunk-vlans
-  summary: Create Interface Ethernet0 Switched Trunk VLANs
-  type: update
-  value:
-    trunk-vlans:
-    - 1003
-  weight: 27
 - path: /interfaces/interface[name=Vlan1003]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1003 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.3.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3001 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3002 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
+- path: /interfaces/interface[name=Ethernet0]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet0 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1003
+  weight: 42
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2141,7 +2141,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2150,7 +2150,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2162,7 +2162,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2174,7 +2174,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2183,7 +2183,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2195,7 +2195,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2207,7 +2207,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2216,7 +2216,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2225,7 +2225,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2234,7 +2234,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2243,7 +2243,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2252,7 +2252,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2261,7 +2261,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2270,7 +2270,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet1.1001]
   summary: Create VRF interface Ethernet1.1001
   type: update
@@ -2279,7 +2279,7 @@
     - config:
         id: Ethernet1.1001
       id: Ethernet1.1001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet2.1001]
   summary: Create VRF interface Ethernet2.1001
   type: update
@@ -2288,7 +2288,7 @@
     - config:
         id: Ethernet2.1001
       id: Ethernet2.1001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2297,7 +2297,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet1.1002]
   summary: Create VRF interface Ethernet1.1002
   type: update
@@ -2306,7 +2306,7 @@
     - config:
         id: Ethernet1.1002
       id: Ethernet1.1002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet2.1002]
   summary: Create VRF interface Ethernet2.1002
   type: update
@@ -2315,7 +2315,7 @@
     - config:
         id: Ethernet2.1002
       id: Ethernet2.1002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2324,7 +2324,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1003]
   summary: Create VRF interface Vlan1003
   type: update
@@ -2333,7 +2333,7 @@
     - config:
         id: Vlan1003
       id: Vlan1003
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2342,71 +2342,71 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1003]
   summary: Create VRF attached host
   type: update
@@ -2417,7 +2417,7 @@
         address-family: IPV4
         interface-id: Vlan1003
       interface-id: Vlan1003
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.5
   type: update
@@ -2428,7 +2428,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.5
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.7
   type: update
@@ -2439,7 +2439,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.7
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.15
   type: update
@@ -2450,7 +2450,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.15
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.17
   type: update
@@ -2461,7 +2461,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.17
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.3
   type: update
@@ -2472,7 +2472,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.3
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.1
   type: update
@@ -2483,7 +2483,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.10
   type: update
@@ -2494,7 +2494,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.10
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2502,7 +2502,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2512,7 +2512,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1003
   type: update
@@ -2520,7 +2520,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2528,7 +2528,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -2536,7 +2536,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -2544,51 +2544,51 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2597,7 +2597,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.1
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2605,7 +2605,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3000
   type: update
@@ -2615,7 +2615,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3001
   type: update
@@ -2625,7 +2625,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_500_Vlan3002
   type: update
@@ -2635,7 +2635,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 500
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2647,7 +2647,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2663,7 +2663,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2675,7 +2675,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -2695,7 +2695,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -2715,7 +2715,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -2735,7 +2735,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2755,7 +2755,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -2770,7 +2770,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -2785,7 +2785,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -2800,7 +2800,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2814,7 +2814,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2828,7 +2828,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2837,7 +2837,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -2848,7 +2848,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2859,7 +2859,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2870,7 +2870,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2881,7 +2881,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet1.1001]
   summary: Create VRF BGP neighbor Ethernet1.1001
   type: update
@@ -2908,7 +2908,7 @@
         neighbor-address: Ethernet1.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet1.1001
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1001]
   summary: Create VRF BGP neighbor Ethernet2.1001
   type: update
@@ -2935,7 +2935,7 @@
         neighbor-address: Ethernet2.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1001
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet1.1002]
   summary: Create VRF BGP neighbor Ethernet1.1002
   type: update
@@ -2962,7 +2962,7 @@
         neighbor-address: Ethernet1.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet1.1002
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1002]
   summary: Create VRF BGP neighbor Ethernet2.1002
   type: update
@@ -2989,7 +2989,7 @@
         neighbor-address: Ethernet2.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1002
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -3018,7 +3018,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.16]
   summary: Create VRF BGP neighbor 172.30.128.16
   type: update
@@ -3047,7 +3047,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.16
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.4]
   summary: Create VRF BGP neighbor 172.30.128.4
   type: update
@@ -3076,7 +3076,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.4
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.6]
   summary: Create VRF BGP neighbor 172.30.128.6
   type: update
@@ -3105,7 +3105,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.6
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3142,7 +3142,7 @@
       transport:
         config:
           local-address: 172.30.8.3
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -3179,7 +3179,7 @@
       transport:
         config:
           local-address: 172.30.8.3
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.3/32]
   summary: Create VRF BGP network 172.30.8.3/32
   type: update
@@ -3188,7 +3188,7 @@
     - config:
         prefix: 172.30.8.3/32
       prefix: 172.30.8.3/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3201,7 +3201,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3216,7 +3216,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3231,7 +3231,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3244,7 +3244,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3259,7 +3259,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3274,7 +3274,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3287,7 +3287,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3302,7 +3302,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3317,7 +3317,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3330,7 +3330,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3343,39 +3343,39 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -3390,7 +3390,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.actions.expected.yaml
@@ -524,7 +524,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -533,7 +533,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -542,7 +542,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -551,7 +551,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -560,7 +560,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -569,7 +569,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -578,35 +578,35 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.0
   type: update
@@ -617,7 +617,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.2
   type: update
@@ -628,7 +628,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.4
   type: update
@@ -639,7 +639,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.4
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.6
   type: update
@@ -650,7 +650,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.6
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.8
   type: update
@@ -661,7 +661,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.8
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.0
   type: update
@@ -672,7 +672,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.7
   type: update
@@ -683,7 +683,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.7
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -691,7 +691,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -701,18 +701,18 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -724,7 +724,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -740,7 +740,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -752,7 +752,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -772,7 +772,7 @@
           as: 65100
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -786,7 +786,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -800,7 +800,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -809,7 +809,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet0]/link-flap
   summary: Create ErrDisable Interface Ethernet0
   type: update
@@ -820,7 +820,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet1]/link-flap
   summary: Create ErrDisable Interface Ethernet1
   type: update
@@ -831,7 +831,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet2]/link-flap
   summary: Create ErrDisable Interface Ethernet2
   type: update
@@ -842,7 +842,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -853,7 +853,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -864,7 +864,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
   summary: Create VRF BGP neighbor 172.30.128.1
   type: update
@@ -893,7 +893,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -922,7 +922,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -951,7 +951,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -980,7 +980,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -1013,7 +1013,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -1050,7 +1050,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.3]
   summary: Create VRF BGP neighbor 172.30.8.3
   type: update
@@ -1087,7 +1087,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -1096,7 +1096,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -1109,7 +1109,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -1122,7 +1122,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.actions.expected.yaml
@@ -1739,59 +1739,59 @@
       config:
         auto-negotiate: false
   weight: 25
-- path: /interfaces/interface[name=Ethernet2]/ethernet/switched-vlan/config/trunk-vlans
-  summary: Create Interface Ethernet2 Switched Trunk VLANs
-  type: update
-  value:
-    trunk-vlans:
-    - 1002
-  weight: 27
 - path: /interfaces/interface[name=Vlan1001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1001 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.1.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1002 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.2.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3001 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/system_mac
   summary: Create PortChannel System MAC PortChannel1
   type: update
   value:
     system_mac: f2:00:00:00:00:02
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/system_mac
   summary: Create PortChannel System MAC PortChannel2
   type: update
   value:
     system_mac: f2:00:00:00:00:01
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
   summary: Create PortChannel Fallback PortChannel1
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/fallback
   summary: Create PortChannel Fallback PortChannel2
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
+- path: /interfaces/interface[name=Ethernet2]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet2 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1002
+  weight: 42
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1800,7 +1800,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1809,7 +1809,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1818,7 +1818,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1827,7 +1827,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1836,7 +1836,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1845,7 +1845,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1854,7 +1854,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1863,7 +1863,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1872,7 +1872,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1881,7 +1881,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1890,7 +1890,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1899,7 +1899,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1908,7 +1908,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan1001]
   summary: Create VRF interface Vlan1001
   type: update
@@ -1917,7 +1917,7 @@
     - config:
         id: Vlan1001
       id: Vlan1001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -1926,7 +1926,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan1002]
   summary: Create VRF interface Vlan1002
   type: update
@@ -1935,7 +1935,7 @@
     - config:
         id: Vlan1002
       id: Vlan1002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -1944,59 +1944,59 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1001]
   summary: Create VRF attached host
   type: update
@@ -2007,7 +2007,7 @@
         address-family: IPV4
         interface-id: Vlan1001
       interface-id: Vlan1001
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1002]
   summary: Create VRF attached host
   type: update
@@ -2018,7 +2018,7 @@
         address-family: IPV4
         interface-id: Vlan1002
       interface-id: Vlan1002
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.2
   type: update
@@ -2029,7 +2029,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.4
   type: update
@@ -2040,7 +2040,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.4
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.6
   type: update
@@ -2051,7 +2051,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.6
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.8
   type: update
@@ -2062,7 +2062,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.8
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.0
   type: update
@@ -2073,7 +2073,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.0
   type: update
@@ -2084,7 +2084,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.0
   type: update
@@ -2095,7 +2095,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.7
   type: update
@@ -2106,7 +2106,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.7
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2114,7 +2114,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2124,7 +2124,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1001
   type: update
@@ -2132,7 +2132,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1002
   type: update
@@ -2140,7 +2140,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2148,7 +2148,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -2156,36 +2156,36 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -2193,7 +2193,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -2205,7 +2205,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -2217,7 +2217,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -2228,7 +2228,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet3]
   summary: Create LST Interface Ethernet3
   type: update
@@ -2245,7 +2245,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -2262,7 +2262,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -2279,7 +2279,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -2296,7 +2296,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2305,7 +2305,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.0
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2313,7 +2313,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3000
   type: update
@@ -2323,7 +2323,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_201_Vlan1001
   type: update
@@ -2333,7 +2333,7 @@
       name: vtepfabric
       vlan: Vlan1001
       vni: 201
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3001
   type: update
@@ -2343,7 +2343,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1002
   type: update
@@ -2353,7 +2353,7 @@
       name: vtepfabric
       vlan: Vlan1002
       vni: 301
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2365,7 +2365,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2381,7 +2381,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2393,7 +2393,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -2413,7 +2413,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -2433,7 +2433,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2453,7 +2453,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -2470,7 +2470,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -2487,7 +2487,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2501,7 +2501,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2515,7 +2515,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2524,7 +2524,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -2535,7 +2535,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2546,7 +2546,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2557,7 +2557,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2568,7 +2568,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2579,7 +2579,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
   summary: Create VRF BGP neighbor 172.30.128.1
   type: update
@@ -2612,7 +2612,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -2641,7 +2641,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -2670,7 +2670,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -2699,7 +2699,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -2728,7 +2728,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2765,7 +2765,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -2802,7 +2802,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -2811,7 +2811,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2824,7 +2824,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2839,7 +2839,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2854,7 +2854,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2867,7 +2867,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2882,7 +2882,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2897,7 +2897,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2910,7 +2910,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2923,33 +2923,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -2964,7 +2964,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -2979,7 +2979,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.actions.expected.yaml
@@ -1786,52 +1786,52 @@
   value:
     static-anycast-gateway:
     - 10.0.1.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1002 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.2.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3001 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/system_mac
   summary: Create PortChannel System MAC PortChannel1
   type: update
   value:
     system_mac: f2:00:00:00:00:02
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/system_mac
   summary: Create PortChannel System MAC PortChannel2
   type: update
   value:
     system_mac: f2:00:00:00:00:01
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
   summary: Create PortChannel Fallback PortChannel1
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/fallback
   summary: Create PortChannel Fallback PortChannel2
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel3]/fallback
   summary: Create PortChannel Fallback PortChannel3
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1840,7 +1840,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1849,7 +1849,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1858,7 +1858,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1867,7 +1867,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1876,7 +1876,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1885,7 +1885,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1894,7 +1894,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1903,7 +1903,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1912,7 +1912,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1921,7 +1921,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1930,7 +1930,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1939,7 +1939,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1948,7 +1948,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1957,7 +1957,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1966,7 +1966,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan1001]
   summary: Create VRF interface Vlan1001
   type: update
@@ -1975,7 +1975,7 @@
     - config:
         id: Vlan1001
       id: Vlan1001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -1984,7 +1984,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan1002]
   summary: Create VRF interface Vlan1002
   type: update
@@ -1993,7 +1993,7 @@
     - config:
         id: Vlan1002
       id: Vlan1002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2002,67 +2002,67 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1001]
   summary: Create VRF attached host
   type: update
@@ -2073,7 +2073,7 @@
         address-family: IPV4
         interface-id: Vlan1001
       interface-id: Vlan1001
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1002]
   summary: Create VRF attached host
   type: update
@@ -2084,7 +2084,7 @@
         address-family: IPV4
         interface-id: Vlan1002
       interface-id: Vlan1002
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.3
   type: update
@@ -2095,7 +2095,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.3
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.5
   type: update
@@ -2106,7 +2106,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.5
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.12
   type: update
@@ -2117,7 +2117,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.12
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.14
   type: update
@@ -2128,7 +2128,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.14
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.10
   type: update
@@ -2139,7 +2139,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.10
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.1
   type: update
@@ -2150,7 +2150,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.1
   type: update
@@ -2161,7 +2161,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.8
   type: update
@@ -2172,7 +2172,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.8
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2180,7 +2180,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2190,7 +2190,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1001
   type: update
@@ -2198,7 +2198,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1002
   type: update
@@ -2206,7 +2206,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2214,7 +2214,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -2222,36 +2222,36 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -2259,7 +2259,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -2271,7 +2271,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -2283,7 +2283,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -2294,7 +2294,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -2311,7 +2311,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -2328,7 +2328,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -2345,7 +2345,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet7]
   summary: Create LST Interface Ethernet7
   type: update
@@ -2362,7 +2362,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2371,7 +2371,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.1
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2379,7 +2379,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3000
   type: update
@@ -2389,7 +2389,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_201_Vlan1001
   type: update
@@ -2399,7 +2399,7 @@
       name: vtepfabric
       vlan: Vlan1001
       vni: 201
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3001
   type: update
@@ -2409,7 +2409,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1002
   type: update
@@ -2419,7 +2419,7 @@
       name: vtepfabric
       vlan: Vlan1002
       vni: 301
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2431,7 +2431,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2447,7 +2447,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2459,7 +2459,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -2479,7 +2479,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.1
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -2499,7 +2499,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.1
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2519,7 +2519,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.1
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -2536,7 +2536,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -2553,7 +2553,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2567,7 +2567,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2581,7 +2581,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2590,7 +2590,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2601,7 +2601,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2612,7 +2612,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2623,7 +2623,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2634,7 +2634,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet8]/link-flap
   summary: Create ErrDisable Interface Ethernet8
   type: update
@@ -2645,7 +2645,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.11]
   summary: Create VRF BGP neighbor 172.30.128.11
   type: update
@@ -2678,7 +2678,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.11
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.13]
   summary: Create VRF BGP neighbor 172.30.128.13
   type: update
@@ -2707,7 +2707,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.13
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.15]
   summary: Create VRF BGP neighbor 172.30.128.15
   type: update
@@ -2736,7 +2736,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.15
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -2765,7 +2765,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.4]
   summary: Create VRF BGP neighbor 172.30.128.4
   type: update
@@ -2794,7 +2794,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.4
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2831,7 +2831,7 @@
       transport:
         config:
           local-address: 172.30.8.1
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -2868,7 +2868,7 @@
       transport:
         config:
           local-address: 172.30.8.1
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.1/32]
   summary: Create VRF BGP network 172.30.8.1/32
   type: update
@@ -2877,7 +2877,7 @@
     - config:
         prefix: 172.30.8.1/32
       prefix: 172.30.8.1/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2890,7 +2890,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2905,7 +2905,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2920,7 +2920,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2933,7 +2933,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2948,7 +2948,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2963,7 +2963,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2976,7 +2976,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2989,33 +2989,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -3030,7 +3030,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -3045,7 +3045,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
@@ -1591,34 +1591,34 @@
       config:
         auto-negotiate: false
   weight: 25
-- path: /interfaces/interface[name=Ethernet1]/ethernet/switched-vlan/config/trunk-vlans
-  summary: Create Interface Ethernet1 Switched Trunk VLANs
-  type: update
-  value:
-    trunk-vlans:
-    - 1003
-  weight: 27
 - path: /interfaces/interface[name=Vlan1003]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1003 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.3.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3001 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
   summary: Create PortChannel Fallback PortChannel1
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
+- path: /interfaces/interface[name=Ethernet1]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet1 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1003
+  weight: 42
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1627,7 +1627,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]
   summary: Create Subinterface Base 10
   type: update
@@ -1639,7 +1639,7 @@
       vlan:
         config:
           vlan-id: 10
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1648,7 +1648,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1657,7 +1657,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1666,7 +1666,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1675,7 +1675,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1684,7 +1684,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1693,7 +1693,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1702,7 +1702,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1711,7 +1711,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1720,7 +1720,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1729,7 +1729,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1738,7 +1738,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/interfaces/interface[id=Ethernet0.10]
   summary: Create VRF interface Ethernet0.10
   type: update
@@ -1747,7 +1747,7 @@
     - config:
         id: Ethernet0.10
       id: Ethernet0.10
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -1756,7 +1756,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1003]
   summary: Create VRF interface Vlan1003
   type: update
@@ -1765,7 +1765,7 @@
     - config:
         id: Vlan1003
       id: Vlan1003
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -1774,59 +1774,59 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv6/config/enabled
   summary: Create Subinterface 10 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1003]
   summary: Create VRF attached host
   type: update
@@ -1837,7 +1837,7 @@
         address-family: IPV4
         interface-id: Vlan1003
       interface-id: Vlan1003
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/addresses/address
   summary: Create Subinterface IP 100.1.10.1
   type: update
@@ -1848,7 +1848,7 @@
         prefix-length: 24
         secondary: false
       ip: 100.1.10.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.7
   type: update
@@ -1859,7 +1859,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.7
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.9
   type: update
@@ -1870,7 +1870,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.9
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.13
   type: update
@@ -1881,7 +1881,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.13
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.15
   type: update
@@ -1892,7 +1892,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.15
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.2
   type: update
@@ -1903,7 +1903,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.2
   type: update
@@ -1914,7 +1914,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.9
   type: update
@@ -1925,7 +1925,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.9
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -1933,7 +1933,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -1943,7 +1943,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1003
   type: update
@@ -1951,7 +1951,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -1959,40 +1959,40 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/global-sag/config
   summary: Create VRF VrfEext-bgp-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/evpn/evpn-mh/config
   summary: Create VRF VrfEext-bgp-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2001,7 +2001,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.2
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2009,7 +2009,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_100_Vlan3000
   type: update
@@ -2019,7 +2019,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 100
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3001
   type: update
@@ -2029,7 +2029,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_401_Vlan1003
   type: update
@@ -2039,7 +2039,7 @@
       name: vtepfabric
       vlan: Vlan1003
       vni: 401
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ext-inbound--leaf-03--ext-bgp-01 base
   type: update
@@ -2051,7 +2051,7 @@
         type: ACL_IPV4
       name: ext-inbound--leaf-03--ext-bgp-01
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
@@ -2063,7 +2063,7 @@
         type: ACL_IPV4
       name: ipns-egress--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2075,7 +2075,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2094,7 +2094,7 @@
       transport:
         config:
           destination-port: 443
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 2
   type: update
@@ -2113,7 +2113,7 @@
       transport:
         config:
           destination-port: 8080
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 3
   type: update
@@ -2132,7 +2132,7 @@
       transport:
         config:
           destination-port: 67
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 4
   type: update
@@ -2151,7 +2151,7 @@
       transport:
         config:
           destination-port: 161
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 5
   type: update
@@ -2170,7 +2170,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 6
   type: update
@@ -2189,7 +2189,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2201,7 +2201,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -2216,7 +2216,7 @@
         config:
           destination-address: 10.0.0.0/16
       sequence-id: 10
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2228,7 +2228,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2244,7 +2244,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2256,7 +2256,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/interfaces/interface[id=Ethernet0.10]
   summary: Create ACL interface Ethernet0.10
   type: update
@@ -2276,7 +2276,7 @@
         config:
           interface: Ethernet0
           subinterface: 10
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Ethernet0.10]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Ethernet0.10 ingress
   type: update
@@ -2287,7 +2287,7 @@
         type: ACL_IPV4
       set-name: ext-inbound--leaf-03--ext-bgp-01
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]
   summary: Create ACL interface Vlan3000
   type: update
@@ -2299,7 +2299,7 @@
       interface-ref:
         config:
           interface: Vlan3000
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3000 ingress
   type: update
@@ -2310,7 +2310,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEext-bgp-01 BGP base
   type: update
@@ -2330,7 +2330,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -2350,7 +2350,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2370,7 +2370,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEext-bgp-01 BGP L2VPN
   type: update
@@ -2387,7 +2387,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - ext-inbound--ext-bgp-01
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -2404,7 +2404,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2418,7 +2418,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2432,7 +2432,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2441,7 +2441,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2452,7 +2452,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2463,7 +2463,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2474,7 +2474,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2485,7 +2485,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=100.1.10.6]
   summary: Create VRF BGP neighbor 100.1.10.6
   type: update
@@ -2512,7 +2512,7 @@
         neighbor-address: 100.1.10.6
         peer-as: 64102
       neighbor-address: 100.1.10.6
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -2541,7 +2541,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -2570,7 +2570,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.6]
   summary: Create VRF BGP neighbor 172.30.128.6
   type: update
@@ -2599,7 +2599,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.6
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.8]
   summary: Create VRF BGP neighbor 172.30.128.8
   type: update
@@ -2628,7 +2628,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.8
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2665,7 +2665,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2702,7 +2702,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -2711,7 +2711,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2724,7 +2724,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2739,7 +2739,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2754,7 +2754,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2767,7 +2767,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2780,33 +2780,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-bgp-01
   type: update
   value:
     policy-name: ext-import--ext-bgp-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEext-bgp-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfEext-bgp-01
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -2821,7 +2821,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.actions.expected.yaml
@@ -1935,61 +1935,61 @@
       config:
         auto-negotiate: false
   weight: 25
-- path: /interfaces/interface[name=Ethernet6]/ethernet/switched-vlan/config/trunk-vlans
-  summary: Create Interface Ethernet6 Switched Trunk VLANs
-  type: update
-  value:
-    trunk-vlans:
-    - 1003
-  weight: 27
 - path: /interfaces/interface[name=Vlan1001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1001 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.1.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1002 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.2.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1003]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1003 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.3.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1004]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1004 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.4.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3001 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
   summary: Create PortChannel Fallback PortChannel1
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/fallback
   summary: Create PortChannel Fallback PortChannel2
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
+- path: /interfaces/interface[name=Ethernet6]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet6 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1003
+  weight: 42
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1998,7 +1998,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2007,7 +2007,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2016,7 +2016,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2025,7 +2025,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2034,7 +2034,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2043,7 +2043,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2052,7 +2052,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2061,7 +2061,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2070,7 +2070,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2079,7 +2079,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2088,7 +2088,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2097,7 +2097,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2106,7 +2106,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2115,7 +2115,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2124,7 +2124,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2133,7 +2133,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel250]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2142,7 +2142,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel251]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2151,7 +2151,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan1001]
   summary: Create VRF interface Vlan1001
   type: update
@@ -2160,7 +2160,7 @@
     - config:
         id: Vlan1001
       id: Vlan1001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan1002]
   summary: Create VRF interface Vlan1002
   type: update
@@ -2169,7 +2169,7 @@
     - config:
         id: Vlan1002
       id: Vlan1002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2178,7 +2178,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan1003]
   summary: Create VRF interface Vlan1003
   type: update
@@ -2187,7 +2187,7 @@
     - config:
         id: Vlan1003
       id: Vlan1003
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan1004]
   summary: Create VRF interface Vlan1004
   type: update
@@ -2196,7 +2196,7 @@
     - config:
         id: Vlan1004
       id: Vlan1004
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2205,79 +2205,79 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel250]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel251]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1001]
   summary: Create VRF attached host
   type: update
@@ -2288,7 +2288,7 @@
         address-family: IPV4
         interface-id: Vlan1001
       interface-id: Vlan1001
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1002]
   summary: Create VRF attached host
   type: update
@@ -2299,7 +2299,7 @@
         address-family: IPV4
         interface-id: Vlan1002
       interface-id: Vlan1002
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1003]
   summary: Create VRF attached host
   type: update
@@ -2310,7 +2310,7 @@
         address-family: IPV4
         interface-id: Vlan1003
       interface-id: Vlan1003
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1004]
   summary: Create VRF attached host
   type: update
@@ -2321,7 +2321,7 @@
         address-family: IPV4
         interface-id: Vlan1004
       interface-id: Vlan1004
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.25
   type: update
@@ -2332,7 +2332,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.25
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.1
   type: update
@@ -2343,7 +2343,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.3
   type: update
@@ -2354,7 +2354,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.3
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.23
   type: update
@@ -2365,7 +2365,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.23
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.2
   type: update
@@ -2376,7 +2376,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.0
   type: update
@@ -2387,7 +2387,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.9
   type: update
@@ -2398,7 +2398,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.9
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=PortChannel251]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.95.0
   type: update
@@ -2409,7 +2409,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.95.0
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2417,7 +2417,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2427,7 +2427,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /mclag/mclag-domains/mclag-domain[domain-id=100]
   summary: Create MCLAG domain 100
   type: update
@@ -2439,7 +2439,7 @@
         peer-link: PortChannel250
         source-address: 172.30.95.0
       domain-id: 100
-  weight: 53
+  weight: 55
 - path: /mclag/interfaces/interface[name=PortChannel1]
   summary: Create MCLAG interface PortChannel1
   type: update
@@ -2448,7 +2448,7 @@
     - config:
         mclag-domain-id: 100
       name: PortChannel1
-  weight: 54
+  weight: 56
 - path: /mclag/interfaces/interface[name=PortChannel2]
   summary: Create MCLAG interface PortChannel2
   type: update
@@ -2457,7 +2457,7 @@
     - config:
         mclag-domain-id: 100
       name: PortChannel2
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1001
   type: update
@@ -2465,7 +2465,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1002
   type: update
@@ -2473,7 +2473,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1003
   type: update
@@ -2481,7 +2481,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1004
   type: update
@@ -2489,7 +2489,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1004
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2497,7 +2497,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -2505,40 +2505,40 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -2549,7 +2549,7 @@
         name: spinelink
         timeout: 5
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet10]
   summary: Create LST Interface Ethernet10
   type: update
@@ -2566,7 +2566,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet7]
   summary: Create LST Interface Ethernet7
   type: update
@@ -2583,7 +2583,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet8]
   summary: Create LST Interface Ethernet8
   type: update
@@ -2600,7 +2600,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet9]
   summary: Create LST Interface Ethernet9
   type: update
@@ -2617,7 +2617,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2626,7 +2626,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.0
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2634,7 +2634,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3000
   type: update
@@ -2644,7 +2644,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_201_Vlan1001
   type: update
@@ -2654,7 +2654,7 @@
       name: vtepfabric
       vlan: Vlan1001
       vni: 201
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_202_Vlan1002
   type: update
@@ -2664,7 +2664,7 @@
       name: vtepfabric
       vlan: Vlan1002
       vni: 202
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_500_Vlan3001
   type: update
@@ -2674,7 +2674,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 500
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_501_Vlan1003
   type: update
@@ -2684,7 +2684,7 @@
       name: vtepfabric
       vlan: Vlan1003
       vni: 501
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_502_Vlan1004
   type: update
@@ -2694,7 +2694,7 @@
       name: vtepfabric
       vlan: Vlan1004
       vni: 502
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2706,7 +2706,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2722,7 +2722,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2734,7 +2734,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -2754,7 +2754,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -2774,7 +2774,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2794,7 +2794,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -2811,7 +2811,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -2828,7 +2828,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2842,7 +2842,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2856,7 +2856,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2865,7 +2865,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet10]/link-flap
   summary: Create ErrDisable Interface Ethernet10
   type: update
@@ -2876,7 +2876,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2887,7 +2887,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet8]/link-flap
   summary: Create ErrDisable Interface Ethernet8
   type: update
@@ -2898,7 +2898,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet9]/link-flap
   summary: Create ErrDisable Interface Ethernet9
   type: update
@@ -2909,7 +2909,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.0]
   summary: Create VRF BGP neighbor 172.30.128.0
   type: update
@@ -2938,7 +2938,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -2967,7 +2967,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.22]
   summary: Create VRF BGP neighbor 172.30.128.22
   type: update
@@ -2996,7 +2996,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.22
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.24]
   summary: Create VRF BGP neighbor 172.30.128.24
   type: update
@@ -3025,7 +3025,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.24
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3062,7 +3062,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -3099,7 +3099,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.95.1]
   summary: Create VRF BGP neighbor 172.30.95.1
   type: update
@@ -3120,7 +3120,7 @@
         neighbor-address: 172.30.95.1
         peer-type: INTERNAL
       neighbor-address: 172.30.95.1
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -3129,7 +3129,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3142,7 +3142,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3157,7 +3157,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3172,7 +3172,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3185,7 +3185,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3200,7 +3200,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3215,7 +3215,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3228,7 +3228,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3241,33 +3241,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -3282,7 +3282,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -3297,7 +3297,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -3312,7 +3312,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1004]
   summary: Create DHCP relay Vlan1004
   type: update
@@ -3327,7 +3327,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1004
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
@@ -2586,74 +2586,74 @@
       config:
         auto-negotiate: false
   weight: 25
-- path: /interfaces/interface[name=Ethernet3]/ethernet/switched-vlan/config/trunk-vlans
-  summary: Create Interface Ethernet3 Switched Trunk VLANs
-  type: update
-  value:
-    trunk-vlans:
-    - 1007
-  weight: 27
 - path: /interfaces/interface[name=Vlan1005]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1005 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.5.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1006]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1006 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.6.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1007]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1007 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.7.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3001 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3002 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3003]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3003 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/system_mac
   summary: Create PortChannel System MAC PortChannel1
   type: update
   value:
     system_mac: f2:00:00:00:00:02
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/system_mac
   summary: Create PortChannel System MAC PortChannel2
   type: update
   value:
     system_mac: f2:00:00:00:00:01
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
   summary: Create PortChannel Fallback PortChannel1
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/fallback
   summary: Create PortChannel Fallback PortChannel2
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
+- path: /interfaces/interface[name=Ethernet3]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet3 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1007
+  weight: 42
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2662,7 +2662,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]
   summary: Create Subinterface Base 10
   type: update
@@ -2674,7 +2674,7 @@
       vlan:
         config:
           vlan-id: 10
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2683,7 +2683,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2692,7 +2692,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2701,7 +2701,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2710,7 +2710,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2719,7 +2719,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2728,7 +2728,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2737,7 +2737,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2746,7 +2746,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2755,7 +2755,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2764,7 +2764,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2773,7 +2773,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2782,7 +2782,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfEexternal-01]/interfaces/interface[id=Ethernet0.10]
   summary: Create VRF interface Ethernet0.10
   type: update
@@ -2791,7 +2791,7 @@
     - config:
         id: Ethernet0.10
       id: Ethernet0.10
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfEexternal-01]/interfaces/interface[id=Vlan3003]
   summary: Create VRF interface Vlan3003
   type: update
@@ -2800,7 +2800,7 @@
     - config:
         id: Vlan3003
       id: Vlan3003
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2809,7 +2809,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1005]
   summary: Create VRF interface Vlan1005
   type: update
@@ -2818,7 +2818,7 @@
     - config:
         id: Vlan1005
       id: Vlan1005
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1006]
   summary: Create VRF interface Vlan1006
   type: update
@@ -2827,7 +2827,7 @@
     - config:
         id: Vlan1006
       id: Vlan1006
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2836,7 +2836,7 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan1007]
   summary: Create VRF interface Vlan1007
   type: update
@@ -2845,7 +2845,7 @@
     - config:
         id: Vlan1007
       id: Vlan1007
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2854,63 +2854,63 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv6/config/enabled
   summary: Create Subinterface 10 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1005]
   summary: Create VRF attached host
   type: update
@@ -2921,7 +2921,7 @@
         address-family: IPV4
         interface-id: Vlan1005
       interface-id: Vlan1005
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1006]
   summary: Create VRF attached host
   type: update
@@ -2932,7 +2932,7 @@
         address-family: IPV4
         interface-id: Vlan1006
       interface-id: Vlan1006
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1007]
   summary: Create VRF attached host
   type: update
@@ -2943,7 +2943,7 @@
         address-family: IPV4
         interface-id: Vlan1007
       interface-id: Vlan1007
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/addresses/address
   summary: Create Subinterface IP 100.1.10.1
   type: update
@@ -2954,7 +2954,7 @@
         prefix-length: 24
         secondary: false
       ip: 100.1.10.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.9
   type: update
@@ -2965,7 +2965,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.9
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.11
   type: update
@@ -2976,7 +2976,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.11
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.31
   type: update
@@ -2987,7 +2987,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.31
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.33
   type: update
@@ -2998,7 +2998,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.33
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.4
   type: update
@@ -3009,7 +3009,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.4
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.1
   type: update
@@ -3020,7 +3020,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.1
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.11
   type: update
@@ -3031,7 +3031,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.11
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -3039,7 +3039,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -3049,7 +3049,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1005
   type: update
@@ -3057,7 +3057,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1005
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1006
   type: update
@@ -3065,7 +3065,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1006
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1007
   type: update
@@ -3073,7 +3073,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1007
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -3081,7 +3081,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -3089,7 +3089,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -3097,58 +3097,58 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfEexternal-01]/global-sag/config
   summary: Create VRF VrfEexternal-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-04]/global-sag/config
   summary: Create VRF VrfVvpc-04 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEexternal-01]/evpn/evpn-mh/config
   summary: Create VRF VrfEexternal-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-04]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-04 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -3156,7 +3156,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -3168,7 +3168,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -3180,7 +3180,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -3191,7 +3191,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -3208,7 +3208,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -3225,7 +3225,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -3242,7 +3242,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet7]
   summary: Create LST Interface Ethernet7
   type: update
@@ -3259,7 +3259,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -3268,7 +3268,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.1
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -3276,7 +3276,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_100_Vlan3003
   type: update
@@ -3286,7 +3286,7 @@
       name: vtepfabric
       vlan: Vlan3003
       vni: 100
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3001
   type: update
@@ -3296,7 +3296,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3002
   type: update
@@ -3306,7 +3306,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1006
   type: update
@@ -3316,7 +3316,7 @@
       name: vtepfabric
       vlan: Vlan1006
       vni: 301
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_302_Vlan1005
   type: update
@@ -3326,7 +3326,7 @@
       name: vtepfabric
       vlan: Vlan1005
       vni: 302
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3000
   type: update
@@ -3336,7 +3336,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_401_Vlan1007
   type: update
@@ -3346,7 +3346,7 @@
       name: vtepfabric
       vlan: Vlan1007
       vni: 401
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ext-inbound--leaf-03--external-01 base
   type: update
@@ -3358,7 +3358,7 @@
         type: ACL_IPV4
       name: ext-inbound--leaf-03--external-01
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
@@ -3370,7 +3370,7 @@
         type: ACL_IPV4
       name: ipns-egress--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -3382,7 +3382,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3401,7 +3401,7 @@
       transport:
         config:
           destination-port: 443
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 2
   type: update
@@ -3420,7 +3420,7 @@
       transport:
         config:
           destination-port: 8080
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 3
   type: update
@@ -3439,7 +3439,7 @@
       transport:
         config:
           destination-port: 67
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 4
   type: update
@@ -3458,7 +3458,7 @@
       transport:
         config:
           destination-port: 161
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 5
   type: update
@@ -3477,7 +3477,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 6
   type: update
@@ -3496,7 +3496,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3508,7 +3508,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -3523,7 +3523,7 @@
         config:
           destination-address: 10.0.0.0/16
       sequence-id: 10
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3535,7 +3535,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3551,7 +3551,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3563,7 +3563,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/interfaces/interface[id=Ethernet0.10]
   summary: Create ACL interface Ethernet0.10
   type: update
@@ -3583,7 +3583,7 @@
         config:
           interface: Ethernet0
           subinterface: 10
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Ethernet0.10]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Ethernet0.10 ingress
   type: update
@@ -3594,7 +3594,7 @@
         type: ACL_IPV4
       set-name: ext-inbound--leaf-03--external-01
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3003]
   summary: Create ACL interface Vlan3003
   type: update
@@ -3606,7 +3606,7 @@
       interface-ref:
         config:
           interface: Vlan3003
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3003]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3003 ingress
   type: update
@@ -3617,7 +3617,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEexternal-01 BGP base
   type: update
@@ -3637,7 +3637,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -3657,7 +3657,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -3677,7 +3677,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-04 BGP base
   type: update
@@ -3697,7 +3697,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -3717,7 +3717,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEexternal-01 BGP L2VPN
   type: update
@@ -3734,7 +3734,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - ext-inbound--external-01
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -3751,7 +3751,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -3768,7 +3768,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-04 BGP L2VPN
   type: update
@@ -3785,7 +3785,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -3799,7 +3799,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -3813,7 +3813,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -3822,7 +3822,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -3833,7 +3833,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -3844,7 +3844,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -3855,7 +3855,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -3866,7 +3866,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=100.1.10.6]
   summary: Create VRF BGP neighbor 100.1.10.6
   type: update
@@ -3893,7 +3893,7 @@
         neighbor-address: 100.1.10.6
         peer-as: 64102
       neighbor-address: 100.1.10.6
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.10]
   summary: Create VRF BGP neighbor 172.30.128.10
   type: update
@@ -3922,7 +3922,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.10
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.30]
   summary: Create VRF BGP neighbor 172.30.128.30
   type: update
@@ -3951,7 +3951,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.30
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.32]
   summary: Create VRF BGP neighbor 172.30.128.32
   type: update
@@ -3980,7 +3980,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.32
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.8]
   summary: Create VRF BGP neighbor 172.30.128.8
   type: update
@@ -4009,7 +4009,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.8
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -4046,7 +4046,7 @@
       transport:
         config:
           local-address: 172.30.8.4
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -4083,7 +4083,7 @@
       transport:
         config:
           local-address: 172.30.8.4
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.4/32]
   summary: Create VRF BGP network 172.30.8.4/32
   type: update
@@ -4092,7 +4092,7 @@
     - config:
         prefix: 172.30.8.4/32
       prefix: 172.30.8.4/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4105,7 +4105,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4120,7 +4120,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4135,7 +4135,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4148,7 +4148,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4163,7 +4163,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4178,7 +4178,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4191,7 +4191,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4206,7 +4206,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4221,7 +4221,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4234,7 +4234,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4247,31 +4247,31 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEexternal-01
   type: update
   value:
     policy-name: ext-import--external-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-04
   type: update
   value:
     policy-name: import-vrf--vpc-04
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEexternal-01
   type: update
@@ -4279,14 +4279,14 @@
     name:
     - VrfVvpc-01
     - VrfVvpc-03
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfEexternal-01
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
@@ -4294,14 +4294,14 @@
     name:
     - VrfEexternal-01
     - VrfVvpc-04
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-04
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1005]
   summary: Create DHCP relay Vlan1005
   type: update
@@ -4316,7 +4316,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1005
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1006]
   summary: Create DHCP relay Vlan1006
   type: update
@@ -4331,7 +4331,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1006
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1007]
   summary: Create DHCP relay Vlan1007
   type: update
@@ -4346,7 +4346,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1007
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
@@ -1863,59 +1863,59 @@
   value:
     static-anycast-gateway:
     - 10.0.5.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1006]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1006 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.6.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan1008]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1008 VLAN Anycast Gateway
   type: update
   value:
     static-anycast-gateway:
     - 10.0.8.1/24
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3000 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /interfaces/interface[name=Vlan3002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan3002 VLAN Anycast Gateway
   type: update
-  weight: 28
+  weight: 26
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/system_mac
   summary: Create PortChannel System MAC PortChannel1
   type: update
   value:
     system_mac: f2:00:00:00:00:02
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/system_mac
   summary: Create PortChannel System MAC PortChannel2
   type: update
   value:
     system_mac: f2:00:00:00:00:01
-  weight: 30
+  weight: 28
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
   summary: Create PortChannel Fallback PortChannel1
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/fallback
   summary: Create PortChannel Fallback PortChannel2
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel3]/fallback
   summary: Create PortChannel Fallback PortChannel3
   type: update
   value:
     fallback: false
-  weight: 31
+  weight: 29
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1924,7 +1924,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1933,7 +1933,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1942,7 +1942,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1951,7 +1951,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1960,7 +1960,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1969,7 +1969,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1978,7 +1978,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1987,7 +1987,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1996,7 +1996,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2005,7 +2005,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2014,7 +2014,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2023,7 +2023,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2032,7 +2032,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=PortChannel3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2041,7 +2041,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1005]
   summary: Create VRF interface Vlan1005
   type: update
@@ -2050,7 +2050,7 @@
     - config:
         id: Vlan1005
       id: Vlan1005
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1006]
   summary: Create VRF interface Vlan1006
   type: update
@@ -2059,7 +2059,7 @@
     - config:
         id: Vlan1006
       id: Vlan1006
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2068,7 +2068,7 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan1008]
   summary: Create VRF interface Vlan1008
   type: update
@@ -2077,7 +2077,7 @@
     - config:
         id: Vlan1008
       id: Vlan1008
-  weight: 44
+  weight: 46
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2086,63 +2086,63 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 44
+  weight: 46
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=PortChannel3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1005]
   summary: Create VRF attached host
   type: update
@@ -2153,7 +2153,7 @@
         address-family: IPV4
         interface-id: Vlan1005
       interface-id: Vlan1005
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1006]
   summary: Create VRF attached host
   type: update
@@ -2164,7 +2164,7 @@
         address-family: IPV4
         interface-id: Vlan1006
       interface-id: Vlan1006
-  weight: 46
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1008]
   summary: Create VRF attached host
   type: update
@@ -2175,7 +2175,7 @@
         address-family: IPV4
         interface-id: Vlan1008
       interface-id: Vlan1008
-  weight: 46
+  weight: 48
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.13
   type: update
@@ -2186,7 +2186,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.13
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.15
   type: update
@@ -2197,7 +2197,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.15
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.35
   type: update
@@ -2208,7 +2208,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.35
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.37
   type: update
@@ -2219,7 +2219,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.37
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.5
   type: update
@@ -2230,7 +2230,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.5
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.2
   type: update
@@ -2241,7 +2241,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.12
   type: update
@@ -2252,7 +2252,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.12
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2260,7 +2260,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2270,7 +2270,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1005
   type: update
@@ -2278,7 +2278,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1005
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1006
   type: update
@@ -2286,7 +2286,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1006
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1008
   type: update
@@ -2294,7 +2294,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1008
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2302,7 +2302,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -2310,36 +2310,36 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-04]/global-sag/config
   summary: Create VRF VrfVvpc-04 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-04]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-04 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -2347,7 +2347,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -2359,7 +2359,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -2371,7 +2371,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -2382,7 +2382,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -2399,7 +2399,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -2416,7 +2416,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -2433,7 +2433,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet7]
   summary: Create LST Interface Ethernet7
   type: update
@@ -2450,7 +2450,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2459,7 +2459,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.2
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2467,7 +2467,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3002
   type: update
@@ -2477,7 +2477,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1006
   type: update
@@ -2487,7 +2487,7 @@
       name: vtepfabric
       vlan: Vlan1006
       vni: 301
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_302_Vlan1005
   type: update
@@ -2497,7 +2497,7 @@
       name: vtepfabric
       vlan: Vlan1005
       vni: 302
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3000
   type: update
@@ -2507,7 +2507,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_402_Vlan1008
   type: update
@@ -2517,7 +2517,7 @@
       name: vtepfabric
       vlan: Vlan1008
       vni: 402
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2529,7 +2529,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2545,7 +2545,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2557,7 +2557,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -2577,7 +2577,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.5
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-04 BGP base
   type: update
@@ -2597,7 +2597,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.5
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2617,7 +2617,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.5
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -2634,7 +2634,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-04 BGP L2VPN
   type: update
@@ -2651,7 +2651,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2665,7 +2665,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2679,7 +2679,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2688,7 +2688,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2699,7 +2699,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2710,7 +2710,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2721,7 +2721,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2732,7 +2732,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -2761,7 +2761,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -2790,7 +2790,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.34]
   summary: Create VRF BGP neighbor 172.30.128.34
   type: update
@@ -2819,7 +2819,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.34
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.36]
   summary: Create VRF BGP neighbor 172.30.128.36
   type: update
@@ -2848,7 +2848,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.36
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2885,7 +2885,7 @@
       transport:
         config:
           local-address: 172.30.8.5
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2922,7 +2922,7 @@
       transport:
         config:
           local-address: 172.30.8.5
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.5/32]
   summary: Create VRF BGP network 172.30.8.5/32
   type: update
@@ -2931,7 +2931,7 @@
     - config:
         prefix: 172.30.8.5/32
       prefix: 172.30.8.5/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2944,7 +2944,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2959,7 +2959,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2974,7 +2974,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2987,7 +2987,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3002,7 +3002,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3017,7 +3017,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3030,7 +3030,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3043,33 +3043,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-04
   type: update
   value:
     policy-name: import-vrf--vpc-04
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-04
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-04
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 87
+  weight: 89
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1005]
   summary: Create DHCP relay Vlan1005
   type: update
@@ -3084,7 +3084,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1005
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1006]
   summary: Create DHCP relay Vlan1006
   type: update
@@ -3099,7 +3099,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1006
-  weight: 88
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1008]
   summary: Create DHCP relay Vlan1008
   type: update
@@ -3114,7 +3114,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1008
-  weight: 88
+  weight: 90
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace

--- a/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.actions.expected.yaml
@@ -639,7 +639,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -648,7 +648,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -657,7 +657,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -666,7 +666,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -675,7 +675,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -684,7 +684,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -693,7 +693,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -702,7 +702,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -711,7 +711,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -720,7 +720,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -729,7 +729,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -738,7 +738,7 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -747,59 +747,59 @@
     - config:
         index: 0
       index: 0
-  weight: 41
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
   summary: Create Subinterface 0 IPv6 Enable
   type: update
-  weight: 45
+  weight: 47
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.0
   type: update
@@ -810,7 +810,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.2
   type: update
@@ -821,7 +821,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.2
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.20
   type: update
@@ -832,7 +832,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.20
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.4
   type: update
@@ -843,7 +843,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.4
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.6
   type: update
@@ -854,7 +854,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.6
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.8
   type: update
@@ -865,7 +865,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.8
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.10
   type: update
@@ -876,7 +876,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.10
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.12
   type: update
@@ -887,7 +887,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.12
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.14
   type: update
@@ -898,7 +898,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.14
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.16
   type: update
@@ -909,7 +909,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.16
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.18
   type: update
@@ -920,7 +920,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.18
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.0
   type: update
@@ -931,7 +931,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.0
-  weight: 47
+  weight: 49
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.7
   type: update
@@ -942,7 +942,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.7
-  weight: 47
+  weight: 49
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -950,7 +950,7 @@
     config:
       source-interface:
       - Management0
-  weight: 51
+  weight: 53
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -960,18 +960,18 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 52
+  weight: 54
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -983,7 +983,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -999,7 +999,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -1011,7 +1011,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -1031,7 +1031,7 @@
           as: 65100
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -1045,7 +1045,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -1059,7 +1059,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -1068,7 +1068,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet0]/link-flap
   summary: Create ErrDisable Interface Ethernet0
   type: update
@@ -1079,7 +1079,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet1]/link-flap
   summary: Create ErrDisable Interface Ethernet1
   type: update
@@ -1090,7 +1090,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet10]/link-flap
   summary: Create ErrDisable Interface Ethernet10
   type: update
@@ -1101,7 +1101,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet2]/link-flap
   summary: Create ErrDisable Interface Ethernet2
   type: update
@@ -1112,7 +1112,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -1123,7 +1123,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -1134,7 +1134,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -1145,7 +1145,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -1156,7 +1156,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -1167,7 +1167,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet8]/link-flap
   summary: Create ErrDisable Interface Ethernet8
   type: update
@@ -1178,7 +1178,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet9]/link-flap
   summary: Create ErrDisable Interface Ethernet9
   type: update
@@ -1189,7 +1189,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
   summary: Create VRF BGP neighbor 172.30.128.1
   type: update
@@ -1218,7 +1218,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.11]
   summary: Create VRF BGP neighbor 172.30.128.11
   type: update
@@ -1247,7 +1247,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.11
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.13]
   summary: Create VRF BGP neighbor 172.30.128.13
   type: update
@@ -1276,7 +1276,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.13
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.15]
   summary: Create VRF BGP neighbor 172.30.128.15
   type: update
@@ -1305,7 +1305,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.15
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.17]
   summary: Create VRF BGP neighbor 172.30.128.17
   type: update
@@ -1334,7 +1334,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.17
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.19]
   summary: Create VRF BGP neighbor 172.30.128.19
   type: update
@@ -1363,7 +1363,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.19
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.21]
   summary: Create VRF BGP neighbor 172.30.128.21
   type: update
@@ -1392,7 +1392,7 @@
         neighbor-address: 172.30.128.21
         peer-as: 65534
       neighbor-address: 172.30.128.21
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -1421,7 +1421,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -1450,7 +1450,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -1479,7 +1479,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -1508,7 +1508,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -1545,7 +1545,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.3]
   summary: Create VRF BGP neighbor 172.30.8.3
   type: update
@@ -1582,7 +1582,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.4]
   summary: Create VRF BGP neighbor 172.30.8.4
   type: update
@@ -1619,7 +1619,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.5]
   summary: Create VRF BGP neighbor 172.30.8.5
   type: update
@@ -1656,7 +1656,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.6]
   summary: Create VRF BGP neighbor 172.30.8.6
   type: update
@@ -1693,7 +1693,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 83
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -1702,7 +1702,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -1715,7 +1715,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -1728,7 +1728,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 85
+  weight: 87
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace


### PR DESCRIPTION
Toggling hostBGP on a VLAN subnet left the switch agent stuck in an ApplyPending retry loop, in both directions:

- removing hostBGP (true->false): the parent-port switched access/trunk VLAN update was scheduled before the subinterface delete, so SONiC rejected the update while the subinterface still owned the VLAN (`Cannot configure vlan id as subinterface ... has same vlan`).
- adding hostBGP (false->true): the subinterface create was scheduled before the parent-port switched VLAN delete, so SONiC rejected the subinterface while the parent still owned the VLAN (`Same vlan id is configured on parent interface`, the original #1486 report).

Orders the ethernet switched VLAN delete and update weights between `InterfaceSubinterfaceDelete` and `InterfaceSubinterfaceUpdate`, so a VLAN is never on a port's switched-vlan and on a subinterface of that port at once.

Verified on env-5 (DS5000, SONiC 4.5.0): both transitions converge instead of looping.

Fixes #1486
