### PR TITLE
Add as4630 54 pe

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -19,6 +19,7 @@ features and port naming scheme.
 | [Edgecore DCS204 (AS7726-32X)](#edgecore-dcs204) | **spine**, **leaf** | Broadcom TD3-X7 3.2T | 32xQSFP28-100G, 2xSFP28-10G |
 | [Edgecore DCS240 (AS9726)](#edgecore-dcs240) | **spine**, **leaf** | Broadcom TD4 | 32xQSFP56DD-400G, 2xSFP28-10G |
 | [Edgecore DCS501 (AS7712-32X)](#edgecore-dcs501) | **spine** | Broadcom TH | 32xQSFP28-100G |
+| [Edgecore EPS202 (AS4630-54PE)](#edgecore-eps202) | **spine**, **leaf (limited)** | Broadcom TD3-X3 | 48xRJ45-1G, 4xSFP28-25G, 2xQSFP28-100G |
 | [Edgecore EPS203 (AS4630-54NPE)](#edgecore-eps203) | **leaf (limited)** | Broadcom TD3-X3 | 36xRJ45-2.5G, 12xRJ45-10G, 4xSFP28-25G, 2xQSFP28-100G |
 | [Supermicro SSE-C4632SB](#supermicro-sse-c4632sb) | **spine**, **leaf** | Broadcom TD3-X7 3.2T | 32xQSFP28-100G, 1xSFP28-10G |
 
@@ -45,6 +46,7 @@ The following table shows which features are supported by each switch profile:
 | [Edgecore DCS204 (AS7726-32X)](#edgecore-dcs204) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-close: |
 | [Edgecore DCS240 (AS9726)](#edgecore-dcs240) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-close: | :material-check: | :material-close: |
 | [Edgecore DCS501 (AS7712-32X)](#edgecore-dcs501) | :material-close: | :material-check: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: | :material-close: |
+| [Edgecore EPS202 (AS4630-54PE)](#edgecore-eps202) | :material-close: | :material-check: | :material-check: | :material-check: | :material-close: | :material-close: | :material-check: | :material-close: |
 | [Edgecore EPS203 (AS4630-54NPE)](#edgecore-eps203) | :material-close: | :material-check: | :material-check: | :material-check: | :material-close: | :material-check: | :material-check: | :material-close: |
 | [Supermicro SSE-C4632SB](#supermicro-sse-c4632sb) | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-close: |
 | [Virtual Switch](#virtual-switch) | :material-check: | :material-close: | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: | :material-close: |
@@ -1044,6 +1046,94 @@ Label column is a port label on a physical switch.
 | E1/30 | 30 | Breakout |  | 1x100G | 1x100G, 1x40G, 4x10G, 4x25G |
 | E1/31 | 31 | Breakout |  | 1x100G | 1x100G, 1x40G, 4x10G, 4x25G |
 | E1/32 | 32 | Breakout |  | 1x100G | 1x100G, 1x40G, 4x10G, 4x25G |
+
+
+## Edgecore EPS202
+
+Profile Name (to use in switch object `.spec.profile`): **edgecore-eps202**
+
+Other names: Edgecore AS4630-54PE
+
+**Supported roles**: **spine**, **leaf (limited)**
+
+Switch Silicon: **Broadcom TD3-X3**
+
+Ports Summary: **48xRJ45-1G, 4xSFP28-25G, 2xQSFP28-100G**
+
+Notes: Doesn't support StaticExternals and ExternalAttachments with VLANs due to the lack of subinterfaces support.
+
+**Supported features:**
+
+- Subinterfaces: false
+- ACLs: true
+- L2VNI: true
+- L3VNI: true
+- RoCE: false
+- MCLAG: false
+- ESLAG: true
+- ECMP RoCE QPN hashing: false
+
+**Available Ports:**
+
+Label column is a port label on a physical switch.
+
+| Port | Label | Type | Group | Default | Supported |
+|------|-------|------|-------|---------|-----------|
+| M1 |  | Management |  |  |  |
+| E1/1 | 1 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/2 | 2 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/3 | 3 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/4 | 4 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/5 | 5 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/6 | 6 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/7 | 7 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/8 | 8 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/9 | 9 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/10 | 10 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/11 | 11 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/12 | 12 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/13 | 13 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/14 | 14 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/15 | 15 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/16 | 16 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/17 | 17 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/18 | 18 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/19 | 19 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/20 | 20 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/21 | 21 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/22 | 22 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/23 | 23 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/24 | 24 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/25 | 25 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/26 | 26 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/27 | 27 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/28 | 28 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/29 | 29 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/30 | 30 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/31 | 31 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/32 | 32 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/33 | 33 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/34 | 34 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/35 | 35 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/36 | 36 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/37 | 37 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/38 | 38 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/39 | 39 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/40 | 40 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/41 | 41 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/42 | 42 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/43 | 43 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/44 | 44 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/45 | 45 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/46 | 46 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/47 | 47 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/48 | 48 | Direct |  | 1G | 1G, AutoNeg supported (default: true) |
+| E1/49 | 49 | Direct |  | 25G | 1G, 10G, 25G |
+| E1/50 | 50 | Direct |  | 25G | 1G, 10G, 25G |
+| E1/51 | 51 | Direct |  | 25G | 1G, 10G, 25G |
+| E1/52 | 52 | Direct |  | 25G | 1G, 10G, 25G |
+| E1/53 | 53 | Breakout |  | 1x100G | 1x100G, 1x40G, 4x10G, 4x25G |
+| E1/54 | 54 | Breakout |  | 1x100G | 1x100G, 1x40G, 4x10G, 4x25G |
 
 
 ## Edgecore EPS203

--- a/docs/supported-devices.md
+++ b/docs/supported-devices.md
@@ -13,6 +13,7 @@
 | Edgecore DCS204 (AS7726-32X) | **spine**, **leaf** | Broadcom TD3-X7 3.2T | 32xQSFP28-100G, 2xSFP28-10G |
 | Edgecore DCS240 (AS9726) | **spine**, **leaf** | Broadcom TD4 | 32xQSFP56DD-400G, 2xSFP28-10G |
 | Edgecore DCS501 (AS7712-32X) | **spine** | Broadcom TH | 32xQSFP28-100G |
+| Edgecore EPS202 (AS4630-54PE) | **spine**, **leaf (limited)** | Broadcom TD3-X3 | 48xRJ45-1G, 4xSFP28-25G, 2xQSFP28-100G |
 | Edgecore EPS203 (AS4630-54NPE) | **leaf (limited)** | Broadcom TD3-X3 | 36xRJ45-2.5G, 12xRJ45-10G, 4xSFP28-25G, 2xQSFP28-100G |
 | Supermicro SSE-C4632SB | **spine**, **leaf** | Broadcom TD3-X7 3.2T | 32xQSFP28-100G, 1xSFP28-10G |
 

--- a/pkg/agent/dozer/bcm/control_link.go
+++ b/pkg/agent/dozer/bcm/control_link.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"strings"
 
 	"github.com/vishvananda/netlink"
 	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
@@ -51,14 +52,39 @@ func (p *BroadcomProcessor) EnsureControlLink(_ context.Context, agent *agentapi
 		return fmt.Errorf("control VIP %s is not in switch IP subnet %s", controlVIP, switchIP) //nolint:goerr113
 	}
 
+	mgmtIP, err := netlink.ParseAddr(agent.Spec.Switch.IP)
+	if err != nil {
+		return fmt.Errorf("parsing switch IP %s: %w", agent.Spec.Switch.IP, err)
+	}
+
+	linkList, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("getting list of links: %w", err)
+	}
+
+	for _, link := range linkList {
+		if link.Attrs().Name == mgmtPort {
+			continue
+		} else if strings.HasPrefix(link.Attrs().Name, "eth") {
+			intfAddrs, err := netlink.AddrList(link, 0)
+			if err != nil {
+				return fmt.Errorf("getting address for link %s: %w", link.Attrs().Name, err)
+			}
+			for _, val := range intfAddrs {
+				if mgmtIP.Equal(val) {
+					if err = netlink.AddrDel(link, mgmtIP); err != nil {
+						return fmt.Errorf("deleting duplicate management IP: %w", err)
+					}
+				}
+			}
+		}
+
+		continue
+	}
+
 	link, err := netlink.LinkByName(mgmtPort)
 	if err != nil {
 		return fmt.Errorf("getting link %s: %w", mgmtPort, err)
-	}
-
-	addr, err := netlink.ParseAddr(agent.Spec.Switch.IP)
-	if err != nil {
-		return fmt.Errorf("parsing switch IP %s: %w", agent.Spec.Switch.IP, err)
 	}
 
 	addrs, err := netlink.AddrList(link, 0)
@@ -68,7 +94,7 @@ func (p *BroadcomProcessor) EnsureControlLink(_ context.Context, agent *agentapi
 
 	exists := false
 	for _, a := range addrs {
-		if a.Equal(*addr) {
+		if a.Equal(*mgmtIP) {
 			exists = true
 
 			break
@@ -76,7 +102,7 @@ func (p *BroadcomProcessor) EnsureControlLink(_ context.Context, agent *agentapi
 	}
 
 	if !exists {
-		if err := netlink.AddrAdd(link, addr); err != nil {
+		if err := netlink.AddrAdd(link, mgmtIP); err != nil {
 			return fmt.Errorf("adding address %s to link %s: %w", switchIP, mgmtPort, err)
 		}
 	}

--- a/pkg/ctrl/switchprofile/catalog.go
+++ b/pkg/ctrl/switchprofile/catalog.go
@@ -42,6 +42,7 @@ var defaultSwitchProfiles = []wiringapi.SwitchProfile{
 	EdgecoreDCS204,
 	EdgecoreDCS240,
 	EdgecoreDCS501,
+	EdgecoreEPS202,
 	EdgecoreEPS203,
 	SupermicroSSEC4632SB,
 	VS,

--- a/pkg/ctrl/switchprofile/p_bcm_edgecore_eps202.go
+++ b/pkg/ctrl/switchprofile/p_bcm_edgecore_eps202.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package switchprofile
+
+import (
+	"go.githedgehog.com/fabric/api/meta"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var EdgecoreEPS202 = wiringapi.SwitchProfile{
+	ObjectMeta: kmetav1.ObjectMeta{
+		Name: "edgecore-eps202",
+	},
+	Spec: wiringapi.SwitchProfileSpec{
+		DisplayName:   "Edgecore EPS202",
+		OtherNames:    []string{"Edgecore AS4630-54PE"},
+		SwitchSilicon: SiliconBroadcomTD3_X3,
+		Features: wiringapi.SwitchProfileFeatures{
+			Subinterfaces: false,
+			ACLs:          true,
+			L2VNI:         true,
+			L3VNI:         true,
+			RoCE:          false,
+			MCLAG:         false,
+			ESLAG:         true,
+			ECMPRoCEQPN:   false,
+		},
+		Notes:    "Doesn't support StaticExternals and ExternalAttachments with VLANs due to the lack of subinterfaces support.",
+		NOSType:  meta.NOSTypeSONiCBCMCampus,
+		Platform: "x86_64-accton_as4630_54pe-r0",
+		Config: wiringapi.SwitchProfileConfig{
+			MaxPathsEBGP: 16,
+		},
+		Ports: map[string]wiringapi.SwitchProfilePort{
+			"M1":    {NOSName: "Management0", Management: true, OniePortName: "eth2"},
+			"E1/1":  {NOSName: "Ethernet0", Label: "1", Profile: "RJ45-1G"},
+			"E1/2":  {NOSName: "Ethernet1", Label: "2", Profile: "RJ45-1G"},
+			"E1/3":  {NOSName: "Ethernet2", Label: "3", Profile: "RJ45-1G"},
+			"E1/4":  {NOSName: "Ethernet3", Label: "4", Profile: "RJ45-1G"},
+			"E1/5":  {NOSName: "Ethernet4", Label: "5", Profile: "RJ45-1G"},
+			"E1/6":  {NOSName: "Ethernet5", Label: "6", Profile: "RJ45-1G"},
+			"E1/7":  {NOSName: "Ethernet6", Label: "7", Profile: "RJ45-1G"},
+			"E1/8":  {NOSName: "Ethernet7", Label: "8", Profile: "RJ45-1G"},
+			"E1/9":  {NOSName: "Ethernet8", Label: "9", Profile: "RJ45-1G"},
+			"E1/10": {NOSName: "Ethernet9", Label: "10", Profile: "RJ45-1G"},
+			"E1/11": {NOSName: "Ethernet10", Label: "11", Profile: "RJ45-1G"},
+			"E1/12": {NOSName: "Ethernet11", Label: "12", Profile: "RJ45-1G"},
+			"E1/13": {NOSName: "Ethernet12", Label: "13", Profile: "RJ45-1G"},
+			"E1/14": {NOSName: "Ethernet13", Label: "14", Profile: "RJ45-1G"},
+			"E1/15": {NOSName: "Ethernet14", Label: "15", Profile: "RJ45-1G"},
+			"E1/16": {NOSName: "Ethernet15", Label: "16", Profile: "RJ45-1G"},
+			"E1/17": {NOSName: "Ethernet16", Label: "17", Profile: "RJ45-1G"},
+			"E1/18": {NOSName: "Ethernet17", Label: "18", Profile: "RJ45-1G"},
+			"E1/19": {NOSName: "Ethernet18", Label: "19", Profile: "RJ45-1G"},
+			"E1/20": {NOSName: "Ethernet19", Label: "20", Profile: "RJ45-1G"},
+			"E1/21": {NOSName: "Ethernet20", Label: "21", Profile: "RJ45-1G"},
+			"E1/22": {NOSName: "Ethernet21", Label: "22", Profile: "RJ45-1G"},
+			"E1/23": {NOSName: "Ethernet22", Label: "23", Profile: "RJ45-1G"},
+			"E1/24": {NOSName: "Ethernet23", Label: "24", Profile: "RJ45-1G"},
+			"E1/25": {NOSName: "Ethernet24", Label: "25", Profile: "RJ45-1G"},
+			"E1/26": {NOSName: "Ethernet25", Label: "26", Profile: "RJ45-1G"},
+			"E1/27": {NOSName: "Ethernet26", Label: "27", Profile: "RJ45-1G"},
+			"E1/28": {NOSName: "Ethernet27", Label: "28", Profile: "RJ45-1G"},
+			"E1/29": {NOSName: "Ethernet28", Label: "29", Profile: "RJ45-1G"},
+			"E1/30": {NOSName: "Ethernet29", Label: "30", Profile: "RJ45-1G"},
+			"E1/31": {NOSName: "Ethernet30", Label: "31", Profile: "RJ45-1G"},
+			"E1/32": {NOSName: "Ethernet31", Label: "32", Profile: "RJ45-1G"},
+			"E1/33": {NOSName: "Ethernet32", Label: "33", Profile: "RJ45-1G"},
+			"E1/34": {NOSName: "Ethernet33", Label: "34", Profile: "RJ45-1G"},
+			"E1/35": {NOSName: "Ethernet34", Label: "35", Profile: "RJ45-1G"},
+			"E1/36": {NOSName: "Ethernet35", Label: "36", Profile: "RJ45-1G"},
+			"E1/37": {NOSName: "Ethernet36", Label: "37", Profile: "RJ45-1G"},
+			"E1/38": {NOSName: "Ethernet37", Label: "38", Profile: "RJ45-1G"},
+			"E1/39": {NOSName: "Ethernet38", Label: "39", Profile: "RJ45-1G"},
+			"E1/40": {NOSName: "Ethernet39", Label: "40", Profile: "RJ45-1G"},
+			"E1/41": {NOSName: "Ethernet40", Label: "41", Profile: "RJ45-1G"},
+			"E1/42": {NOSName: "Ethernet41", Label: "42", Profile: "RJ45-1G"},
+			"E1/43": {NOSName: "Ethernet42", Label: "43", Profile: "RJ45-1G"},
+			"E1/44": {NOSName: "Ethernet43", Label: "44", Profile: "RJ45-1G"},
+			"E1/45": {NOSName: "Ethernet44", Label: "45", Profile: "RJ45-1G"},
+			"E1/46": {NOSName: "Ethernet45", Label: "46", Profile: "RJ45-1G"},
+			"E1/47": {NOSName: "Ethernet46", Label: "47", Profile: "RJ45-1G"},
+			"E1/48": {NOSName: "Ethernet47", Label: "48", Profile: "RJ45-1G"}, // 48x RJ45 1G
+			"E1/49": {NOSName: "Ethernet48", Label: "49", Profile: "SFP28-25G"},
+			"E1/50": {NOSName: "Ethernet49", Label: "50", Profile: "SFP28-25G"},
+			"E1/51": {NOSName: "Ethernet50", Label: "51", Profile: "SFP28-25G"},
+			"E1/52": {NOSName: "Ethernet51", Label: "52", Profile: "SFP28-25G"}, // 4x SFP28 25G
+			"E1/53": {NOSName: "1/53", BaseNOSName: "Ethernet52", Label: "53", Profile: "QSFP28-100G"},
+			"E1/54": {NOSName: "1/54", BaseNOSName: "Ethernet56", Label: "54", Profile: "QSFP28-100G"}, // 2x QSFP28 100G
+		},
+		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
+			"RJ45-1G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "1G",
+					Supported: []string{"1G"},
+				},
+				AutoNegAllowed: true,
+				AutoNegDefault: true,
+			},
+			"SFP28-25G": {
+				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
+					Default:   "25G",
+					Supported: []string{"1G", "10G", "25G"},
+				},
+			},
+			"QSFP28-100G": {
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
closes #1445 
This switch had a problem where the management IP address would be set on an interface, then the interface would be renamed, eth0 -> eth3, and the new eth0 would also have the management IP address set. 2 interfaces with the same IP, since eth3 was assigned first, it was the route out for traffic, even though it is `linkdown`.