### PR TITLE
feat(dhcpd): add liveness/readiness probe

### DIFF
--- a/cmd/fabric-dhcpd/main.go
+++ b/cmd/fabric-dhcpd/main.go
@@ -111,6 +111,14 @@ func main() {
 		Destination: &anyDeviceOnMgmt,
 	}
 
+	var healthListenAddr string
+	healthListenAddrFlag := &cli.StringFlag{
+		Name:        "health-listen",
+		Usage:       "address for the liveness/readiness HTTP server (empty to disable)",
+		Value:       ":8080",
+		Destination: &healthListenAddr,
+	}
+
 	cli.VersionFlag.(*cli.BoolFlag).Aliases = []string{"V"}
 	app := &cli.App{
 		Name:                   "hhdhcpd",
@@ -127,14 +135,16 @@ func main() {
 					verboseFlag,
 					listenInterfaceFlag,
 					anyDeviceOnMgmtFlag,
+					healthListenAddrFlag,
 				},
 				Before: func(_ *cli.Context) error {
 					return setupLogger(verbose, true)
 				},
 				Action: func(_ *cli.Context) error {
 					return errors.Wrapf((&dhcp.Server{
-						ListenInterface: listenInterface,
-						AnyDeviceOnMgmt: anyDeviceOnMgmt,
+						ListenInterface:  listenInterface,
+						AnyDeviceOnMgmt:  anyDeviceOnMgmt,
+						HealthListenAddr: healthListenAddr,
 					}).Run(ctx), "failed to run dhcp server")
 				},
 			},

--- a/config/helm/fabric-dhcpd/templates/deployment.yaml
+++ b/config/helm/fabric-dhcpd/templates/deployment.yaml
@@ -52,7 +52,27 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["--listen={{ .Values.listenInterface }}", "--any-device-on-mgmt={{ .Values.anyDeviceOnMgmt }}"]
+          args: ["--listen={{ .Values.listenInterface }}", "--any-device-on-mgmt={{ .Values.anyDeviceOnMgmt }}", "--health-listen=:{{ .Values.healthPort }}"]
+          ports:
+            - name: healthz
+              containerPort: {{ .Values.healthPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/config/helm/fabric-dhcpd/values.yaml
+++ b/config/helm/fabric-dhcpd/values.yaml
@@ -30,6 +30,11 @@ fullnameOverride: ""
 listenInterface: "eth0"
 anyDeviceOnMgmt: false
 
+# Port for the liveness/readiness HTTP server (/healthz, /readyz). Bound on the
+# node since the pod uses hostNetwork, so it must not collide with other host
+# services.
+healthPort: 8080
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/pkg/dhcp/health.go
+++ b/pkg/dhcp/health.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package dhcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+)
+
+var errServeStopped = errors.New("dhcp serve loop has stopped")
+
+// listenInterfaceName strips an optional ":port" (or "[host]:port") suffix from
+// a --listen value, returning the bare interface name or IP. coredhcp accepts
+// values like "eth0:67"; the ifindex lookup needs just the interface name.
+func listenInterfaceName(listen string) string {
+	if host, _, err := net.SplitHostPort(listen); err == nil {
+		return host
+	}
+
+	return listen
+}
+
+// checkHealth reports whether the DHCP server is still able to serve requests.
+//
+// It is intentionally conservative about false positives (an idle server is
+// healthy) and targets the failure mode seen in the field: the coredhcp
+// listener binds its UDP socket to the --listen interface via SO_BINDTODEVICE,
+// resolved once at startup. If that interface is torn down and recreated (e.g.
+// CNI/multus churn), the socket is left bound to a now-stale interface, ReadFrom
+// blocks forever with no error, and the process keeps running while serving
+// nothing. We detect that by comparing the listen interface's current ifindex
+// against the one captured when coredhcp started; any change (or the interface
+// disappearing / going down) means the socket can no longer receive and the
+// container must be restarted to re-bind.
+func (s *Server) checkHealth() error {
+	if s.serveStopped.Load() {
+		return errServeStopped
+	}
+
+	// boundIfIndex is 0 when listening on an IP rather than a named interface;
+	// there is no SO_BINDTODEVICE binding to go stale in that case.
+	if s.boundIfIndex != 0 {
+		listenHost := listenInterfaceName(s.ListenInterface)
+		iface, err := net.InterfaceByName(listenHost)
+		if err != nil {
+			return fmt.Errorf("listen interface %s not found: %w", listenHost, err)
+		}
+		if iface.Index != s.boundIfIndex {
+			return fmt.Errorf("listen interface %s ifindex changed (%d -> %d): socket is bound to a stale interface and can no longer receive, restart required", //nolint:err113
+				listenHost, s.boundIfIndex, iface.Index)
+		}
+		if iface.Flags&net.FlagUp == 0 {
+			return fmt.Errorf("listen interface %s is down", listenHost) //nolint:err113
+		}
+	}
+
+	return nil
+}
+
+// healthzHandler responds 200 when checkHealth passes and 503 otherwise. It
+// backs both /healthz and /readyz, so a wedged instance is restarted by the
+// kubelet.
+func (s *Server) healthzHandler(w http.ResponseWriter, _ *http.Request) {
+	if err := s.checkHealth(); err != nil {
+		slog.Warn("Health check failed", "err", err)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprintf(w, "unhealthy: %v\n", err)
+
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintln(w, "ok")
+}
+
+// startHealthz serves /healthz and /readyz for Kubernetes liveness/readiness
+// probes.
+func (s *Server) startHealthz(ctx context.Context, addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.healthzHandler)
+	mux.HandleFunc("/readyz", s.healthzHandler)
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		<-ctx.Done()
+		// ctx is already done here; use a fresh context to bound the shutdown.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx) //nolint:contextcheck
+	}()
+
+	slog.Info("Starting healthz server", "addr", addr)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("healthz server on %s: %w", addr, err)
+	}
+
+	return nil
+}

--- a/pkg/dhcp/health_test.go
+++ b/pkg/dhcp/health_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package dhcp
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListenInterfaceName(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		listen string
+		want   string
+	}{
+		{"bare interface", "eth0", "eth0"},
+		{"interface with port", "eth0:67", "eth0"},
+		{"bare ipv4", "127.0.0.1", "127.0.0.1"},
+		{"ipv4 with port", "127.0.0.1:67", "127.0.0.1"},
+		{"bare ipv6", "::1", "::1"},
+		{"ipv6 with port", "[::1]:67", "::1"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, listenInterfaceName(tt.listen))
+		})
+	}
+}
+
+func TestCheckHealth(t *testing.T) {
+	lo, err := net.InterfaceByName("lo")
+	if err != nil {
+		t.Skip("no loopback interface available")
+	}
+	loUp := lo.Flags&net.FlagUp != 0
+
+	serveStopped := &Server{ListenInterface: "lo", boundIfIndex: lo.Index}
+	serveStopped.serveStopped.Store(true)
+
+	for _, tt := range []struct {
+		name     string
+		server   *Server
+		needLoUp bool
+		wantErr  bool
+	}{
+		{
+			name:    "serve loop stopped is unhealthy",
+			server:  serveStopped,
+			wantErr: true,
+		},
+		{
+			name:    "listening on an IP skips the ifindex check",
+			server:  &Server{ListenInterface: "127.0.0.1"}, // boundIfIndex 0
+			wantErr: false,
+		},
+		{
+			name:     "matching ifindex is healthy",
+			server:   &Server{ListenInterface: "lo", boundIfIndex: lo.Index},
+			needLoUp: true,
+			wantErr:  false,
+		},
+		{
+			name:     "port suffix is normalized away",
+			server:   &Server{ListenInterface: "lo:67", boundIfIndex: lo.Index},
+			needLoUp: true,
+			wantErr:  false,
+		},
+		{
+			name:    "stale ifindex is unhealthy",
+			server:  &Server{ListenInterface: "lo", boundIfIndex: lo.Index + 1000},
+			wantErr: true,
+		},
+		{
+			name:    "missing interface is unhealthy",
+			server:  &Server{ListenInterface: "hh-nonexistent0", boundIfIndex: 1},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.needLoUp && !loUp {
+				t.Skip("loopback interface is down")
+			}
+			got := tt.server.checkHealth()
+			if tt.wantErr {
+				assert.Error(t, got)
+			} else {
+				assert.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestHealthzHandler(t *testing.T) {
+	t.Run("healthy returns 200", func(t *testing.T) {
+		s := &Server{ListenInterface: "127.0.0.1"} // boundIfIndex 0 => no ifindex check
+		rec := httptest.NewRecorder()
+		s.healthzHandler(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), "ok")
+	})
+
+	t.Run("wedged returns 503", func(t *testing.T) {
+		s := &Server{}
+		s.serveStopped.Store(true)
+		rec := httptest.NewRecorder()
+		s.healthzHandler(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		assert.Contains(t, rec.Body.String(), "unhealthy")
+	})
+}

--- a/pkg/dhcp/server.go
+++ b/pkg/dhcp/server.go
@@ -5,10 +5,13 @@ package dhcp
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -17,14 +20,18 @@ import (
 )
 
 type Server struct {
-	ListenInterface string
-	AnyDeviceOnMgmt bool
+	ListenInterface  string
+	AnyDeviceOnMgmt  bool
+	HealthListenAddr string // address for the liveness/readiness HTTP server; empty disables it
 
 	kube           kclient.WithWatch
 	subnets        map[string]*dhcpapi.DHCPSubnet
 	switchToIP     map[string]string   // switch name → relay IP (for cleanup)
 	relayAllowlist map[string]struct{} // known leaf relay IPs
 	m              sync.RWMutex
+
+	boundIfIndex int         // ifindex of ListenInterface at startup (0 when listening on an IP)
+	serveStopped atomic.Bool // set when the coredhcp serve loop exits
 }
 
 func (s *Server) Run(ctx context.Context) error {
@@ -45,6 +52,19 @@ func (s *Server) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Capture the ifindex of the listen interface so the health check can detect
+	// the socket being left bound to a stale interface after a teardown/recreate.
+	// When listening on an IP rather than a named interface there is no
+	// SO_BINDTODEVICE binding to go stale, so the check is skipped (boundIfIndex 0).
+	listenHost := listenInterfaceName(s.ListenInterface)
+	if net.ParseIP(listenHost) == nil {
+		iface, err := net.InterfaceByName(listenHost)
+		if err != nil {
+			return fmt.Errorf("resolving listen interface %s: %w", listenHost, err)
+		}
+		s.boundIfIndex = iface.Index
+	}
+
 	wg := sync.WaitGroup{}
 
 	wg.Go(func() { s.watchWithRetry(ctx, "DHCPSubnet", s.watchDHCPSubnets) })
@@ -52,10 +72,20 @@ func (s *Server) Run(ctx context.Context) error {
 
 	wg.Go(func() {
 		if err := s.startCoreDHCP(ctx); err != nil {
+			s.serveStopped.Store(true)
 			slog.Error("Start CoreDHCP failed", "err", err)
 			os.Exit(2) // TODO graceful handling
 		}
 	})
+
+	if s.HealthListenAddr != "" {
+		wg.Go(func() {
+			if err := s.startHealthz(ctx, s.HealthListenAddr); err != nil {
+				slog.Error("Healthz server failed", "err", err)
+				os.Exit(4) // TODO graceful handling
+			}
+		})
+	}
 
 	wg.Go(func() {
 		if err := s.startPeriodicCleanup(ctx); err != nil {


### PR DESCRIPTION
fabric-dhcpd's coredhcp listener binds its UDP socket to the --listen interface via SO_BINDTODEVICE, resolved once at startup. If that interface is torn down and recreated (e.g. CNI/multus churn), the socket is left bound to a stale ifindex, ReadFrom blocks forever with no error, and the process keeps running while serving nothing — a silent, unrecoverable wedge with no probe for the kubelet to act on.

Add a /healthz + /readyz HTTP server whose check reflects actual serving health: it reports unhealthy when the serve loop has stopped, or when the listen interface's current ifindex differs from the one bound at startup (or it is gone/down). The check is conservative — an idle server stays healthy — and the health socket binds INADDR_ANY so it survives the interface recreate and can still report the stale DHCP socket.

Wire it through a new --health-listen flag (default :8080) and add liveness/readiness probes to the Helm deployment so a wedged instance is restarted in seconds instead of running dark for days.

Related to #1494 