### PR TITLE
feat: config drop neighbor time on leaves

### DIFF
--- a/pkg/agent/dozer/bcm/enforcer.go
+++ b/pkg/agent/dozer/bcm/enforcer.go
@@ -170,6 +170,7 @@ const (
 	ActionWeightBFDProfileUpdate
 	ActionWeightErrDisableGlobalUpdate
 	ActionWeightErrDisablePortUpdate
+	ActionWeightNeighborGlobalUpdate
 	ActionWeightVRFBGPNeighborUpdate
 	ActionWeightVRFBGPNetworkUpdate
 	ActionWrightVRFTableConnectionUpdate
@@ -194,6 +195,7 @@ const (
 	ActionWrightVRFTableConnectionDelete
 	ActionWeightVRFBGPNetworkDelete
 	ActionWeightBFDProfileDelete
+	ActionWeightNeighborGlobalDelete
 	ActionWeightErrDisablePortDelete
 	ActionWeightErrDisableGlobalDelete
 	ActionWeightVRFSAGDelete

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -203,6 +203,11 @@ func (p *BroadcomProcessor) PlanDesiredState(_ context.Context, agent *agentapi.
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to plan VXLAN")
 		}
+
+		err = planNeighborGlobal(agent, spec)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to plan neighbor global")
+		}
 	}
 
 	if agent.Spec.Switch.Redundancy.Type == meta.RedundancyTypeMCLAG {
@@ -394,6 +399,14 @@ func planBFDProfiles(agent *agentapi.Agent, spec *dozer.Spec) error { //nolint:u
 		RequiredMinimumReceive:   pointer.To(uint32(300)),
 		DesiredMinimumTxInterval: pointer.To(uint32(300)),
 		DetectionMultiplier:      pointer.To(uint8(3)),
+	}
+
+	return nil
+}
+
+func planNeighborGlobal(_ *agentapi.Agent, spec *dozer.Spec) error { //nolint:unparam
+	spec.NeighborGlobal = &dozer.SpecNeighborGlobal{
+		IPv4DropNeighborAgingTime: pointer.To(uint16(60)), // 60s is the lowest value allowed
 	}
 
 	return nil

--- a/pkg/agent/dozer/bcm/spec.go
+++ b/pkg/agent/dozer/bcm/spec.go
@@ -164,6 +164,10 @@ var specEnforcer = &DefaultValueEnforcer[string, *dozer.Spec]{
 			return errors.Wrap(err, "failed to handle errdisable interfaces")
 		}
 
+		if err := specNeighborGlobalEnforcer.Handle(basePath, "", actual.NeighborGlobal, desired.NeighborGlobal, actions); err != nil {
+			return errors.Wrap(err, "failed to handle neighbor global")
+		}
+
 		return nil
 	},
 }
@@ -282,6 +286,12 @@ func loadActualSpec(ctx context.Context, agent *agentapi.Agent, client GNMICClie
 
 	if err := loadActualErrDisableInterfaces(ctx, client, spec); err != nil {
 		return errors.Wrapf(err, "failed to load errdisable interfaces")
+	}
+
+	if agent.Spec.Role.IsLeaf() {
+		if err := loadActualNeighborGlobal(ctx, client, spec); err != nil {
+			return errors.Wrapf(err, "failed to load neighbor global")
+		}
 	}
 
 	return nil

--- a/pkg/agent/dozer/bcm/spec_neighbor.go
+++ b/pkg/agent/dozer/bcm/spec_neighbor.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package bcm
+
+import (
+	"context"
+
+	"github.com/openconfig/ygot/ygot"
+	"github.com/pkg/errors"
+	"go.githedgehog.com/fabric-bcm-ygot/pkg/oc"
+	"go.githedgehog.com/fabric/pkg/agent/dozer"
+	"go.githedgehog.com/fabric/pkg/util/pointer"
+)
+
+// neighborGlobalName is the fixed key of the single NEIGH_GLOBAL_LIST entry as
+// observed via sonic-cli ("Values").
+const neighborGlobalName = "Values"
+
+var specNeighborGlobalEnforcer = &DefaultValueEnforcer[string, *dozer.SpecNeighborGlobal]{
+	Summary:      "Neighbor Global",
+	CreatePath:   "/openconfig-neighbor:neighbor-globals/neighbor-global",
+	Path:         "/openconfig-neighbor:neighbor-globals/neighbor-global[name=" + neighborGlobalName + "]",
+	UpdateWeight: ActionWeightNeighborGlobalUpdate,
+	DeleteWeight: ActionWeightNeighborGlobalDelete,
+	Marshal: func(_ string, value *dozer.SpecNeighborGlobal) (ygot.ValidatedGoStruct, error) {
+		return &oc.OpenconfigNeighbor_NeighborGlobals{
+			NeighborGlobal: map[string]*oc.OpenconfigNeighbor_NeighborGlobals_NeighborGlobal{
+				neighborGlobalName: {
+					Name: pointer.To(neighborGlobalName),
+					Config: &oc.OpenconfigNeighbor_NeighborGlobals_NeighborGlobal_Config{
+						Name:                      pointer.To(neighborGlobalName),
+						Ipv4DropNeighborAgingTime: value.IPv4DropNeighborAgingTime,
+					},
+				},
+			},
+		}, nil
+	},
+}
+
+func loadActualNeighborGlobal(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
+	ocNeigh := &oc.OpenconfigNeighbor_NeighborGlobals{}
+	err := client.Get(ctx, "/openconfig-neighbor:neighbor-globals/neighbor-global", ocNeigh)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get neighbor global config")
+	}
+
+	spec.NeighborGlobal = unmarshalActualNeighborGlobal(ocNeigh)
+
+	return nil
+}
+
+func unmarshalActualNeighborGlobal(ocVal *oc.OpenconfigNeighbor_NeighborGlobals) *dozer.SpecNeighborGlobal {
+	if ocVal == nil {
+		return nil
+	}
+
+	ng, ok := ocVal.NeighborGlobal[neighborGlobalName]
+	if !ok || ng.Config == nil || ng.Config.Ipv4DropNeighborAgingTime == nil {
+		return nil
+	}
+
+	return &dozer.SpecNeighborGlobal{
+		IPv4DropNeighborAgingTime: ng.Config.Ipv4DropNeighborAgingTime,
+	}
+}

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
@@ -3722,6 +3722,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1001]
   summary: Create VRF BGP neighbor Ethernet2.1001
   type: update
@@ -3748,7 +3758,7 @@
         neighbor-address: Ethernet2.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1001
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3.1001]
   summary: Create VRF BGP neighbor Ethernet3.1001
   type: update
@@ -3775,7 +3785,7 @@
         neighbor-address: Ethernet3.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet3.1001
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1002]
   summary: Create VRF BGP neighbor Ethernet2.1002
   type: update
@@ -3802,7 +3812,7 @@
         neighbor-address: Ethernet2.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1002
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3.1002]
   summary: Create VRF BGP neighbor Ethernet3.1002
   type: update
@@ -3829,7 +3839,7 @@
         neighbor-address: Ethernet3.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet3.1002
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.0]
   summary: Create VRF BGP neighbor 172.30.128.0
   type: update
@@ -3858,7 +3868,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.10]
   summary: Create VRF BGP neighbor 172.30.128.10
   type: update
@@ -3887,7 +3897,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.10
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -3916,7 +3926,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -3945,7 +3955,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3982,7 +3992,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -4019,7 +4029,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -4028,7 +4038,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4041,7 +4051,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4054,7 +4064,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4067,7 +4077,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4082,7 +4092,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4097,7 +4107,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4110,7 +4120,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4125,7 +4135,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4140,7 +4150,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4153,7 +4163,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4168,7 +4178,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4183,7 +4193,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4196,7 +4206,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4209,65 +4219,65 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-snp-02
   type: update
   value:
     policy-name: ext-import--ext-snp-02
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-sp-01
   type: update
   value:
     policy-name: ext-import--ext-sp-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEext-snp-02
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfEext-snp-02
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -4282,7 +4292,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -4291,4 +4301,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
@@ -581,6 +581,12 @@ loadshare:
     config:
       hash: hash
       qpn: false
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
@@ -317,6 +317,8 @@ lldp:
   helloTimer: 5
   systemDescription: Hedgehog Fabric
   systemName: leaf-01
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
@@ -2882,6 +2882,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet1.1001]
   summary: Create VRF BGP neighbor Ethernet1.1001
   type: update
@@ -2908,7 +2918,7 @@
         neighbor-address: Ethernet1.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet1.1001
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1001]
   summary: Create VRF BGP neighbor Ethernet2.1001
   type: update
@@ -2935,7 +2945,7 @@
         neighbor-address: Ethernet2.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1001
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet1.1002]
   summary: Create VRF BGP neighbor Ethernet1.1002
   type: update
@@ -2962,7 +2972,7 @@
         neighbor-address: Ethernet1.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet1.1002
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1002]
   summary: Create VRF BGP neighbor Ethernet2.1002
   type: update
@@ -2989,7 +2999,7 @@
         neighbor-address: Ethernet2.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1002
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -3018,7 +3028,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.16]
   summary: Create VRF BGP neighbor 172.30.128.16
   type: update
@@ -3047,7 +3057,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.16
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.4]
   summary: Create VRF BGP neighbor 172.30.128.4
   type: update
@@ -3076,7 +3086,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.4
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.6]
   summary: Create VRF BGP neighbor 172.30.128.6
   type: update
@@ -3105,7 +3115,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.6
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3142,7 +3152,7 @@
       transport:
         config:
           local-address: 172.30.8.3
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -3179,7 +3189,7 @@
       transport:
         config:
           local-address: 172.30.8.3
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.3/32]
   summary: Create VRF BGP network 172.30.8.3/32
   type: update
@@ -3188,7 +3198,7 @@
     - config:
         prefix: 172.30.8.3/32
       prefix: 172.30.8.3/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3201,7 +3211,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3216,7 +3226,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3231,7 +3241,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3244,7 +3254,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3259,7 +3269,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3274,7 +3284,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3287,7 +3297,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3302,7 +3312,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3317,7 +3327,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3330,7 +3340,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3343,39 +3353,39 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -3390,7 +3400,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -3399,4 +3409,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.gnmi.expected.yaml
@@ -330,6 +330,12 @@ loadshare:
     config:
       hash: hash
       qpn: false
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.spec.expected.yaml
@@ -227,6 +227,8 @@ lldp:
   helloTimer: 5
   systemDescription: Hedgehog Fabric
   systemName: leaf-02
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.actions.expected.yaml
@@ -893,7 +893,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -922,7 +922,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -951,7 +951,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -980,7 +980,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -1013,7 +1013,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -1050,7 +1050,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.3]
   summary: Create VRF BGP neighbor 172.30.8.3
   type: update
@@ -1087,7 +1087,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -1096,7 +1096,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -1109,7 +1109,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -1122,7 +1122,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -1131,4 +1131,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.actions.expected.yaml
@@ -2580,6 +2580,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
   summary: Create VRF BGP neighbor 172.30.128.1
   type: update
@@ -2612,7 +2622,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -2641,7 +2651,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -2670,7 +2680,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -2699,7 +2709,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -2728,7 +2738,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2765,7 +2775,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -2802,7 +2812,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -2811,7 +2821,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2824,7 +2834,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2839,7 +2849,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2854,7 +2864,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2867,7 +2877,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2882,7 +2892,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2897,7 +2907,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2910,7 +2920,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2923,33 +2933,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -2964,7 +2974,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -2979,7 +2989,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -2988,4 +2998,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.gnmi.expected.yaml
@@ -416,6 +416,12 @@ lst:
         name: spinelink
         timeout: 60
       name: spinelink
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.spec.expected.yaml
@@ -265,6 +265,8 @@ lstInterfaces:
   Ethernet6:
     groups:
     - spinelink
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.actions.expected.yaml
@@ -2646,6 +2646,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.11]
   summary: Create VRF BGP neighbor 172.30.128.11
   type: update
@@ -2678,7 +2688,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.11
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.13]
   summary: Create VRF BGP neighbor 172.30.128.13
   type: update
@@ -2707,7 +2717,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.13
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.15]
   summary: Create VRF BGP neighbor 172.30.128.15
   type: update
@@ -2736,7 +2746,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.15
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -2765,7 +2775,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.4]
   summary: Create VRF BGP neighbor 172.30.128.4
   type: update
@@ -2794,7 +2804,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.4
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2831,7 +2841,7 @@
       transport:
         config:
           local-address: 172.30.8.1
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -2868,7 +2878,7 @@
       transport:
         config:
           local-address: 172.30.8.1
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.1/32]
   summary: Create VRF BGP network 172.30.8.1/32
   type: update
@@ -2877,7 +2887,7 @@
     - config:
         prefix: 172.30.8.1/32
       prefix: 172.30.8.1/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2890,7 +2900,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2905,7 +2915,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2920,7 +2930,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2933,7 +2943,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2948,7 +2958,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2963,7 +2973,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2976,7 +2986,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2989,33 +2999,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -3030,7 +3040,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -3045,7 +3055,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -3054,4 +3064,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.gnmi.expected.yaml
@@ -444,6 +444,12 @@ lst:
         name: spinelink
         timeout: 60
       name: spinelink
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.spec.expected.yaml
@@ -280,6 +280,8 @@ lstInterfaces:
   Ethernet7:
     groups:
     - spinelink
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
@@ -2486,6 +2486,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=100.1.10.6]
   summary: Create VRF BGP neighbor 100.1.10.6
   type: update
@@ -2512,7 +2522,7 @@
         neighbor-address: 100.1.10.6
         peer-as: 64102
       neighbor-address: 100.1.10.6
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -2541,7 +2551,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -2570,7 +2580,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.6]
   summary: Create VRF BGP neighbor 172.30.128.6
   type: update
@@ -2599,7 +2609,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.6
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.8]
   summary: Create VRF BGP neighbor 172.30.128.8
   type: update
@@ -2628,7 +2638,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.8
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2665,7 +2675,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2702,7 +2712,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -2711,7 +2721,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2724,7 +2734,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2739,7 +2749,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2754,7 +2764,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2767,7 +2777,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2780,33 +2790,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-bgp-01
   type: update
   value:
     policy-name: ext-import--ext-bgp-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEext-bgp-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfEext-bgp-01
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -2821,7 +2831,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -2830,4 +2840,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
@@ -485,6 +485,12 @@ loadshare:
     config:
       hash: hash
       qpn: false
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
@@ -276,6 +276,8 @@ lldp:
   helloTimer: 5
   systemDescription: Hedgehog Fabric
   systemName: leaf-03
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.actions.expected.yaml
@@ -2910,6 +2910,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.0]
   summary: Create VRF BGP neighbor 172.30.128.0
   type: update
@@ -2938,7 +2948,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -2967,7 +2977,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.22]
   summary: Create VRF BGP neighbor 172.30.128.22
   type: update
@@ -2996,7 +3006,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.22
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.24]
   summary: Create VRF BGP neighbor 172.30.128.24
   type: update
@@ -3025,7 +3035,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.24
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3062,7 +3072,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -3099,7 +3109,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.95.1]
   summary: Create VRF BGP neighbor 172.30.95.1
   type: update
@@ -3120,7 +3130,7 @@
         neighbor-address: 172.30.95.1
         peer-type: INTERNAL
       neighbor-address: 172.30.95.1
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -3129,7 +3139,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3142,7 +3152,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3157,7 +3167,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3172,7 +3182,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3185,7 +3195,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3200,7 +3210,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3215,7 +3225,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3228,7 +3238,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3241,33 +3251,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -3282,7 +3292,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -3297,7 +3307,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -3312,7 +3322,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1004]
   summary: Create DHCP relay Vlan1004
   type: update
@@ -3327,7 +3337,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1004
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -3336,4 +3346,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.gnmi.expected.yaml
@@ -516,6 +516,12 @@ mclag:
         peer-link: PortChannel250
         source-address: 172.30.95.0
       domain-id: 100
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-1.out.spec.expected.yaml
@@ -327,6 +327,8 @@ mclags:
     peerIP: 172.30.95.1
     peerLink: PortChannel250
     sourceIP: 172.30.95.0
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
@@ -3867,6 +3867,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=100.1.10.6]
   summary: Create VRF BGP neighbor 100.1.10.6
   type: update
@@ -3893,7 +3903,7 @@
         neighbor-address: 100.1.10.6
         peer-as: 64102
       neighbor-address: 100.1.10.6
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.10]
   summary: Create VRF BGP neighbor 172.30.128.10
   type: update
@@ -3922,7 +3932,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.10
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.30]
   summary: Create VRF BGP neighbor 172.30.128.30
   type: update
@@ -3951,7 +3961,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.30
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.32]
   summary: Create VRF BGP neighbor 172.30.128.32
   type: update
@@ -3980,7 +3990,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.32
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.8]
   summary: Create VRF BGP neighbor 172.30.128.8
   type: update
@@ -4009,7 +4019,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.8
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -4046,7 +4056,7 @@
       transport:
         config:
           local-address: 172.30.8.4
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -4083,7 +4093,7 @@
       transport:
         config:
           local-address: 172.30.8.4
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.4/32]
   summary: Create VRF BGP network 172.30.8.4/32
   type: update
@@ -4092,7 +4102,7 @@
     - config:
         prefix: 172.30.8.4/32
       prefix: 172.30.8.4/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4105,7 +4115,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4120,7 +4130,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4135,7 +4145,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4148,7 +4158,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4163,7 +4173,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4178,7 +4188,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4191,7 +4201,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4206,7 +4216,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4221,7 +4231,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4234,7 +4244,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4247,31 +4257,31 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEexternal-01
   type: update
   value:
     policy-name: ext-import--external-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-04
   type: update
   value:
     policy-name: import-vrf--vpc-04
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEexternal-01
   type: update
@@ -4279,14 +4289,14 @@
     name:
     - VrfVvpc-01
     - VrfVvpc-03
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfEexternal-01
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
@@ -4294,14 +4304,14 @@
     name:
     - VrfEexternal-01
     - VrfVvpc-04
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-04
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1005]
   summary: Create DHCP relay Vlan1005
   type: update
@@ -4316,7 +4326,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1005
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1006]
   summary: Create DHCP relay Vlan1006
   type: update
@@ -4331,7 +4341,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1006
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1007]
   summary: Create DHCP relay Vlan1007
   type: update
@@ -4346,7 +4356,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1007
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -4355,4 +4365,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
@@ -587,6 +587,12 @@ lst:
         name: spinelink
         timeout: 60
       name: spinelink
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
@@ -338,6 +338,8 @@ lstInterfaces:
   Ethernet7:
     groups:
     - spinelink
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
@@ -2733,6 +2733,16 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 85
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -2761,7 +2771,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -2790,7 +2800,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.34]
   summary: Create VRF BGP neighbor 172.30.128.34
   type: update
@@ -2819,7 +2829,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.34
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.36]
   summary: Create VRF BGP neighbor 172.30.128.36
   type: update
@@ -2848,7 +2858,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.36
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2885,7 +2895,7 @@
       transport:
         config:
           local-address: 172.30.8.5
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2922,7 +2932,7 @@
       transport:
         config:
           local-address: 172.30.8.5
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.5/32]
   summary: Create VRF BGP network 172.30.8.5/32
   type: update
@@ -2931,7 +2941,7 @@
     - config:
         prefix: 172.30.8.5/32
       prefix: 172.30.8.5/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2944,7 +2954,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2959,7 +2969,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2974,7 +2984,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2987,7 +2997,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3002,7 +3012,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3017,7 +3027,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3030,7 +3040,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3043,33 +3053,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-04
   type: update
   value:
     policy-name: import-vrf--vpc-04
-  weight: 88
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-04
-  weight: 89
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-04
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 90
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1005]
   summary: Create DHCP relay Vlan1005
   type: update
@@ -3084,7 +3094,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1005
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1006]
   summary: Create DHCP relay Vlan1006
   type: update
@@ -3099,7 +3109,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1006
-  weight: 90
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1008]
   summary: Create DHCP relay Vlan1008
   type: update
@@ -3114,7 +3124,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1008
-  weight: 90
+  weight: 91
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -3123,4 +3133,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.gnmi.expected.yaml
@@ -427,6 +427,12 @@ lst:
         name: spinelink
         timeout: 60
       name: spinelink
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
 network-instances:
   network-instance:
   - config:

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.spec.expected.yaml
@@ -279,6 +279,8 @@ lstInterfaces:
   Ethernet7:
     groups:
     - spinelink
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
 ntp:
   sourceInterface:
   - Management0

--- a/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.actions.expected.yaml
@@ -1218,7 +1218,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.11]
   summary: Create VRF BGP neighbor 172.30.128.11
   type: update
@@ -1247,7 +1247,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.11
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.13]
   summary: Create VRF BGP neighbor 172.30.128.13
   type: update
@@ -1276,7 +1276,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.13
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.15]
   summary: Create VRF BGP neighbor 172.30.128.15
   type: update
@@ -1305,7 +1305,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.15
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.17]
   summary: Create VRF BGP neighbor 172.30.128.17
   type: update
@@ -1334,7 +1334,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.17
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.19]
   summary: Create VRF BGP neighbor 172.30.128.19
   type: update
@@ -1363,7 +1363,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.19
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.21]
   summary: Create VRF BGP neighbor 172.30.128.21
   type: update
@@ -1392,7 +1392,7 @@
         neighbor-address: 172.30.128.21
         peer-as: 65534
       neighbor-address: 172.30.128.21
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -1421,7 +1421,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -1450,7 +1450,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -1479,7 +1479,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -1508,7 +1508,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -1545,7 +1545,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.3]
   summary: Create VRF BGP neighbor 172.30.8.3
   type: update
@@ -1582,7 +1582,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.4]
   summary: Create VRF BGP neighbor 172.30.8.4
   type: update
@@ -1619,7 +1619,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.5]
   summary: Create VRF BGP neighbor 172.30.8.5
   type: update
@@ -1656,7 +1656,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.6]
   summary: Create VRF BGP neighbor 172.30.8.6
   type: update
@@ -1693,7 +1693,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -1702,7 +1702,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 86
+  weight: 87
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -1715,7 +1715,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -1728,7 +1728,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 88
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -1737,4 +1737,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/dozer.go
+++ b/pkg/agent/dozer/dozer.go
@@ -79,6 +79,7 @@ type Spec struct {
 	BFDProfiles          map[string]*SpecBFDProfile        `json:"bfdProfiles,omitempty"`
 	ErrDisableGlobal     *SpecErrDisableGlobal             `json:"errDisableGlobal,omitempty"`
 	ErrDisableInterfaces map[string]*SpecErrDisable        `json:"errDisableInterfaces,omitempty"`
+	NeighborGlobal       *SpecNeighborGlobal               `json:"neighborGlobal,omitempty"`
 }
 
 type SpecLLDP struct {
@@ -346,6 +347,10 @@ type SpecErrDisable struct {
 	RecoveryInterval *uint32 `json:"recoveryInterval,omitempty"`
 }
 
+type SpecNeighborGlobal struct {
+	IPv4DropNeighborAgingTime *uint16 `json:"ipv4DropNeighborAgingTime,omitempty"`
+}
+
 type SpecDHCPRelay struct {
 	SourceInterface *string  `json:"sourceInterface,omitempty"`
 	RelayAddress    []string `json:"relayAddress,omitempty"`
@@ -590,6 +595,7 @@ var (
 	_ SpecPart = (*SpecBFDProfile)(nil)
 	_ SpecPart = (*SpecErrDisableGlobal)(nil)
 	_ SpecPart = (*SpecErrDisable)(nil)
+	_ SpecPart = (*SpecNeighborGlobal)(nil)
 )
 
 func (s *Spec) IsNil() bool {
@@ -773,6 +779,10 @@ func (s *SpecErrDisableGlobal) IsNil() bool {
 }
 
 func (s *SpecErrDisable) IsNil() bool {
+	return s == nil
+}
+
+func (s *SpecNeighborGlobal) IsNil() bool {
 	return s == nil
 }
 


### PR DESCRIPTION
defensive fix to minimize the effects of an issue in BCM SONiC where a host changing IP within an L3VNI subnet will be blackholed until the old neighbor entry ages out. This makes the worst case be a 60s blackhole, down from the default 5 minutes.

Related to https://github.com/githedgehog/internal/issues/399