### PR TITLE
chore(gwconfig): Make rate limiter config for logging optional

### DIFF
--- a/api/gateway/v1alpha1/gateway_types.go
+++ b/api/gateway/v1alpha1/gateway_types.go
@@ -82,14 +82,13 @@ type GatewayLogs struct {
 	RateLimit *GatewayLogRateLimit       `json:"rateLimit,omitempty"`
 }
 
-// GatewayLogRateLimit configures the token-bucket rate limiter applied to log
-// output. Both fields must be greater than zero when the limiter is set.
+// GatewayLogRateLimit configures the token-bucket rate limiter applied to logs
 type GatewayLogRateLimit struct {
-	// token bucket capacity
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
+	// token bucket capacity (default 50)
 	Burst uint32 `json:"burst,omitempty"`
-	// ReplenishPerSecond is the number of tokens (messages) replenished per second
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
+	// ReplenishPerSecond is the number of tokens (messages) replenished per second (default 5)
 	ReplenishPerSecond uint32 `json:"replenishPerSecond,omitempty"`
 }
 
@@ -178,10 +177,12 @@ func (gw *Gateway) Default() {
 			"all": GatewayLogLevelInfo,
 		}
 	}
-	if gw.Spec.Logs.RateLimit == nil {
-		gw.Spec.Logs.RateLimit = &GatewayLogRateLimit{
-			Burst:              DefaultGatewayLogRateLimitBurst,
-			ReplenishPerSecond: DefaultGatewayLogRateLimitReplenishPerSecond,
+	if rl := gw.Spec.Logs.RateLimit; rl != nil {
+		if rl.Burst == 0 {
+			rl.Burst = DefaultGatewayLogRateLimitBurst
+		}
+		if rl.ReplenishPerSecond == 0 {
+			rl.ReplenishPerSecond = DefaultGatewayLogRateLimitReplenishPerSecond
 		}
 	}
 	if gw.Spec.Workers == 0 {

--- a/api/gateway/v1alpha1/gateway_types_test.go
+++ b/api/gateway/v1alpha1/gateway_types_test.go
@@ -278,27 +278,23 @@ func TestGatewayValidate(t *testing.T) {
 			err:  v1alpha1.ErrInvalidGW,
 		},
 		{
-			name: "test-log-rate-limit-valid",
+			name: "test-log-rate-limit-explicit",
 			gw: *gwa("gw-1", func(gw *v1alpha1.Gateway) {
-				gw.Spec.Logs.RateLimit = &v1alpha1.GatewayLogRateLimit{Burst: 50, ReplenishPerSecond: 5}
+				gw.Spec.Logs.RateLimit = &v1alpha1.GatewayLogRateLimit{Burst: 100, ReplenishPerSecond: 10}
 			}),
 			objs: base,
 		},
 		{
-			name: "test-log-rate-limit-zero-burst",
+			name: "test-log-rate-limit-empty-defaults",
 			gw: *gwa("gw-1", func(gw *v1alpha1.Gateway) {
-				gw.Spec.Logs.RateLimit = &v1alpha1.GatewayLogRateLimit{Burst: 0, ReplenishPerSecond: 5}
+				gw.Spec.Logs.RateLimit = &v1alpha1.GatewayLogRateLimit{}
 			}),
 			objs: base,
-			err:  v1alpha1.ErrInvalidGW,
 		},
 		{
-			name: "test-log-rate-limit-zero-replenish",
-			gw: *gwa("gw-1", func(gw *v1alpha1.Gateway) {
-				gw.Spec.Logs.RateLimit = &v1alpha1.GatewayLogRateLimit{Burst: 50, ReplenishPerSecond: 0}
-			}),
+			name: "test-log-rate-limit-absent-disabled",
+			gw:   *gwa("gw-1"),
 			objs: base,
-			err:  v1alpha1.ErrInvalidGW,
 		},
 	}
 
@@ -327,4 +323,32 @@ func TestGatewayValidate(t *testing.T) {
 			assert.ErrorIs(t, actual, tt.err, "validate should return expected error")
 		})
 	}
+}
+
+func TestGatewayLogRateLimitDefaulting(t *testing.T) {
+	t.Run("absent stays disabled", func(t *testing.T) {
+		gw := gwa("gw-1")
+		gw.Default()
+		assert.Nil(t, gw.Spec.Logs.RateLimit, "absent rateLimit must remain nil (disabled)")
+	})
+
+	t.Run("empty defaults to 50:5", func(t *testing.T) {
+		gw := gwa("gw-1", func(gw *v1alpha1.Gateway) {
+			gw.Spec.Logs.RateLimit = &v1alpha1.GatewayLogRateLimit{}
+		})
+		gw.Default()
+		require.NotNil(t, gw.Spec.Logs.RateLimit)
+		assert.Equal(t, v1alpha1.DefaultGatewayLogRateLimitBurst, gw.Spec.Logs.RateLimit.Burst)
+		assert.Equal(t, v1alpha1.DefaultGatewayLogRateLimitReplenishPerSecond, gw.Spec.Logs.RateLimit.ReplenishPerSecond)
+	})
+
+	t.Run("explicit values are kept", func(t *testing.T) {
+		gw := gwa("gw-1", func(gw *v1alpha1.Gateway) {
+			gw.Spec.Logs.RateLimit = &v1alpha1.GatewayLogRateLimit{Burst: 100, ReplenishPerSecond: 10}
+		})
+		gw.Default()
+		require.NotNil(t, gw.Spec.Logs.RateLimit)
+		assert.Equal(t, uint32(100), gw.Spec.Logs.RateLimit.Burst)
+		assert.Equal(t, uint32(10), gw.Spec.Logs.RateLimit.ReplenishPerSecond)
+	})
 }

--- a/config/crd/bases/gateway.githedgehog.com_gateways.yaml
+++ b/config/crd/bases/gateway.githedgehog.com_gateways.yaml
@@ -114,20 +114,19 @@ spec:
                   default:
                     type: string
                   rateLimit:
-                    description: |-
-                      GatewayLogRateLimit configures the token-bucket rate limiter applied to log
-                      output. Both fields must be greater than zero when the limiter is set.
+                    description: GatewayLogRateLimit configures the token-bucket rate
+                      limiter applied to logs
                     properties:
                       burst:
-                        description: token bucket capacity
+                        description: token bucket capacity (default 50)
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                       replenishPerSecond:
                         description: ReplenishPerSecond is the number of tokens (messages)
-                          replenished per second
+                          replenished per second (default 5)
                         format: int32
-                        minimum: 1
+                        minimum: 0
                         type: integer
                     type: object
                   tags:

--- a/config/crd/bases/gwint.githedgehog.com_gatewayagents.yaml
+++ b/config/crd/bases/gwint.githedgehog.com_gatewayagents.yaml
@@ -142,20 +142,19 @@ spec:
                       default:
                         type: string
                       rateLimit:
-                        description: |-
-                          GatewayLogRateLimit configures the token-bucket rate limiter applied to log
-                          output. Both fields must be greater than zero when the limiter is set.
+                        description: GatewayLogRateLimit configures the token-bucket
+                          rate limiter applied to logs
                         properties:
                           burst:
-                            description: token bucket capacity
+                            description: token bucket capacity (default 50)
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                           replenishPerSecond:
                             description: ReplenishPerSecond is the number of tokens
-                              (messages) replenished per second
+                              (messages) replenished per second (default 5)
                             format: int32
-                            minimum: 1
+                            minimum: 0
                             type: integer
                         type: object
                       tags:

--- a/docs/api.md
+++ b/docs/api.md
@@ -995,8 +995,7 @@ _Appears in:_
 
 
 
-GatewayLogRateLimit configures the token-bucket rate limiter applied to log
-output. Both fields must be greater than zero when the limiter is set.
+GatewayLogRateLimit configures the token-bucket rate limiter applied to logs
 
 
 
@@ -1005,8 +1004,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `burst` _integer_ | token bucket capacity |  | Minimum: 1 <br /> |
-| `replenishPerSecond` _integer_ | ReplenishPerSecond is the number of tokens (messages) replenished per second |  | Minimum: 1 <br /> |
+| `burst` _integer_ | token bucket capacity (default 50) |  | Minimum: 0 <br /> |
+| `replenishPerSecond` _integer_ | ReplenishPerSecond is the number of tokens (messages) replenished per second (default 5) |  | Minimum: 0 <br /> |
 
 
 #### GatewayLogs


### PR DESCRIPTION
If no config specified GW will not enable tracing throtteling. If It's specified, unset fields will be defined as defaults