### PR TITLE
fix: breakouts on 100G ports

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1220,8 +1220,8 @@ Label column is a port label on a physical switch.
 | E1/50 | 50 | Direct |  | 25G | 1G, 10G, 25G |
 | E1/51 | 51 | Direct |  | 25G | 1G, 10G, 25G |
 | E1/52 | 52 | Direct |  | 25G | 1G, 10G, 25G |
-| E1/53 | 53 | Direct |  | 100G | 40G, 100G |
-| E1/54 | 54 | Direct |  | 100G | 40G, 100G |
+| E1/53 | 53 | Breakout |  | 1x100G | 1x100G, 1x40G, 4x10G, 4x25G |
+| E1/54 | 54 | Breakout |  | 1x100G | 1x100G, 1x40G, 4x10G, 4x25G |
 
 
 ## Supermicro SSE-C4632SB

--- a/pkg/ctrl/switchprofile/p_bcm_edgecore_eps203.go
+++ b/pkg/ctrl/switchprofile/p_bcm_edgecore_eps203.go
@@ -87,8 +87,8 @@ var EdgecoreEPS203 = wiringapi.SwitchProfile{
 			"E1/50": {NOSName: "Ethernet49", Label: "50", Profile: "SFP28-25G"},
 			"E1/51": {NOSName: "Ethernet50", Label: "51", Profile: "SFP28-25G"},
 			"E1/52": {NOSName: "Ethernet51", Label: "52", Profile: "SFP28-25G"}, // 4x SFP28 25G
-			"E1/53": {NOSName: "Ethernet52", Label: "53", Profile: "QSFP28-100G"},
-			"E1/54": {NOSName: "Ethernet56", Label: "54", Profile: "QSFP28-100G"}, // No breakouts but name is still adjusted by 4. 2x QSFP28 100G
+			"E1/53": {NOSName: "1/53", BaseNOSName: "Ethernet52", Label: "53", Profile: "QSFP28-100G"},
+			"E1/54": {NOSName: "1/54", BaseNOSName: "Ethernet56", Label: "54", Profile: "QSFP28-100G"}, // 2x QSFP28 100G
 		},
 		PortProfiles: map[string]wiringapi.SwitchProfilePortProfile{
 			"RJ45-2.5G": {
@@ -114,9 +114,14 @@ var EdgecoreEPS203 = wiringapi.SwitchProfile{
 				},
 			},
 			"QSFP28-100G": {
-				Speed: &wiringapi.SwitchProfilePortProfileSpeed{
-					Default:   "100G",
-					Supported: []string{"40G", "100G"},
+				Breakout: &wiringapi.SwitchProfilePortProfileBreakout{
+					Default: "1x100G",
+					Supported: map[string]wiringapi.SwitchProfilePortProfileBreakoutMode{
+						"1x40G":  {Offsets: []string{"0"}},
+						"1x100G": {Offsets: []string{"0"}},
+						"4x10G":  {Offsets: []string{"0", "1", "2", "3"}},
+						"4x25G":  {Offsets: []string{"0", "1", "2", "3"}},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Tested:
```
Ethernet52          -                             down        admin-down       off       10000          9100           Eth1/53/1           
Ethernet53          -                             down        admin-down       off       10000          9100           Eth1/53/2           
Ethernet54          -                             down        admin-down       off       10000          9100           Eth1/53/3           
Ethernet55          -                             down        admin-down       off       10000          9100           Eth1/53/4           
Ethernet56          -                             down        admin-down       off       25000          9100           Eth1/54/1           
Ethernet57          -                             down        admin-down       off       25000          9100           Eth1/54/2           
Ethernet58          -                             down        admin-down       off       25000          9100           Eth1/54/3           
Ethernet59          -                             down        admin-down       off       25000          9100           Eth1/54/4           
as4630-54npe-01# 
```