### PR TITLE
fix(agent): handle saved config breakouts

### DIFF
--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -308,7 +308,8 @@ func planNTP(agent *agentapi.Agent, spec *dozer.Spec) error {
 
 func planBreakouts(agent *agentapi.Agent, spec *dozer.Spec) error { //nolint:unparam
 	// it depends on the actual switch status, not on the intended state
-	if agent.Status.State.RoCE {
+	spec.RoCE = agent.Status.State.RoCE
+	if spec.RoCE {
 		return nil // no breakouts config when RoCE is enabled
 	}
 

--- a/pkg/agent/dozer/bcm/processor.go
+++ b/pkg/agent/dozer/bcm/processor.go
@@ -177,7 +177,7 @@ func (p *BroadcomProcessor) LoadActualState(ctx context.Context, agent *agentapi
 		return nil, errors.New("gnmi client is not set")
 	}
 
-	spec := &dozer.Spec{}
+	spec := &dozer.Spec{RoCE: agent.Status.State.RoCE}
 
 	if err := loadActualSpec(ctx, agent, p.client, spec); err != nil {
 		return nil, errors.Wrapf(err, "failed to load actual state")

--- a/pkg/agent/dozer/bcm/spec_system.go
+++ b/pkg/agent/dozer/bcm/spec_system.go
@@ -261,11 +261,19 @@ func unmarshalOCPortBreakouts(ocVal *oc.SonicPortBreakout_SonicPortBreakout) (ma
 	}
 
 	for _, breakoutCfg := range ocVal.BREAKOUT_CFG.BREAKOUT_CFG_LIST {
-		if breakoutCfg.Port == nil || breakoutCfg.BrkoutMode == nil || breakoutCfg.Status == nil {
+		if breakoutCfg.Port == nil || breakoutCfg.BrkoutMode == nil {
 			continue
 		}
 
-		if *breakoutCfg.Status != "Completed" || breakoutCfg.BreakoutOwner != oc.SonicPortBreakout_SonicPortBreakout_BREAKOUT_CFG_BREAKOUT_CFG_LIST_BreakoutOwner_MANUAL {
+		if breakoutCfg.BreakoutOwner != oc.SonicPortBreakout_SonicPortBreakout_BREAKOUT_CFG_BREAKOUT_CFG_LIST_BreakoutOwner_MANUAL {
+			continue
+		}
+
+		// `status` is an operational field written by the dynamic-breakout operation.
+		// It (and lanes/*_lanes) is absent when the breakout is rehydrated from saved
+		// config after a reboot, since no operation runs — treat "absent" as applied.
+		// Only skip while an operation is actively in progress.
+		if breakoutCfg.Status != nil && *breakoutCfg.Status != "Completed" {
 			continue
 		}
 

--- a/pkg/agent/dozer/bcm/spec_system.go
+++ b/pkg/agent/dozer/bcm/spec_system.go
@@ -240,6 +240,11 @@ var specPortBreakoutEnforcer = &DefaultValueEnforcer[string, *dozer.SpecPortBrea
 }
 
 func loadActualPortBreakouts(ctx context.Context, client GNMICClient, spec *dozer.Spec) error {
+	if spec.RoCE {
+		spec.PortBreakouts = map[string]*dozer.SpecPortBreakout{}
+
+		return nil
+	}
 	ocVal := &oc.SonicPortBreakout_SonicPortBreakout{}
 	err := client.Get(ctx, "/sonic-port-breakout/BREAKOUT_CFG", ocVal)
 	if err != nil {

--- a/pkg/agent/dozer/dozer.go
+++ b/pkg/agent/dozer/dozer.go
@@ -78,6 +78,7 @@ type Spec struct {
 	ErrDisableGlobal     *SpecErrDisableGlobal             `json:"errDisableGlobal,omitempty"`
 	ErrDisableInterfaces map[string]*SpecErrDisable        `json:"errDisableInterfaces,omitempty"`
 	NeighborGlobal       *SpecNeighborGlobal               `json:"neighborGlobal,omitempty"`
+	RoCE                 bool                              `json:"-"`
 }
 
 type SpecLLDP struct {


### PR DESCRIPTION
without this change we get a permanent (fake) drift in config as the agent believes the breakout was not applied even though it was, just because the state field is not populated when the breakout comes from saved config

Part of https://github.com/githedgehog/internal/issues/417