### PR TITLE
save config / factory reset 

### DIFF
--- a/api/agent/v1beta1/agent_types.go
+++ b/api/agent/v1beta1/agent_types.go
@@ -55,9 +55,10 @@ type AgentSpec struct {
 	ExternalPeerings     map[string]vpcapi.ExternalPeeringSpec    `json:"externalPeerings,omitempty"`
 	ConfiguredVPCSubnets map[string]bool                          `json:"configuredVPCSubnets,omitempty"`
 	AttachedVPCs         map[string]bool                          `json:"attachedVPCs,omitempty"`
-	Reinstall            string                                   `json:"reinstall,omitempty"`  // set to InstallID to reinstall NOS
-	Reboot               string                                   `json:"reboot,omitempty"`     // set to RunID to reboot
-	PowerReset           string                                   `json:"powerReset,omitempty"` // set to RunID to power reset
+	Reinstall            string                                   `json:"reinstall,omitempty"`    // set to InstallID to reinstall NOS
+	Reboot               string                                   `json:"reboot,omitempty"`       // set to BootID to reboot
+	PowerReset           string                                   `json:"powerReset,omitempty"`   // set to BootID to power reset
+	FactoryReset         string                                   `json:"factoryReset,omitempty"` // set to BootID to erase the startup config and reboot
 	Catalog              CatalogSpec                              `json:"catalog,omitempty"`
 
 	// TODO impl

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -426,6 +426,39 @@ func main() {
 					}), "failed to install systemd unit")
 				},
 			},
+			{
+				Name:  "factory-reset",
+				Usage: "erase the startup config and reboot, the agent re-applies the fabric config from scratch on boot",
+				Description: `Erases the startup config of the switch and reboots it. On the next boot the agent reconfigures
+the control link and re-applies the whole fabric config from scratch.
+
+Prefer "kubectl fabric switch factory-reset" from the control node, this is the escape hatch for
+when the switch can't be reached from there.`,
+				Flags: []cli.Flag{
+					verboseFlag,
+					basedirFlag,
+					&cli.BoolFlag{
+						Name:    "yes",
+						Aliases: []string{"y"},
+						Usage:   "confirm erasing the config and rebooting",
+					},
+				},
+				Before: func(_ *cli.Context) error {
+					var err error
+					logFile, err = setupLogger(verbose, true, false)
+
+					return err
+				},
+				Action: func(cCtx *cli.Context) error {
+					if !cCtx.Bool("yes") {
+						return cli.Exit("Config will be erased and the switch will reboot. Please confirm with --yes if you're sure.", 1)
+					}
+
+					return errors.Wrapf((&agent.Service{
+						Basedir: basedir,
+					}).FactoryReset(ctx), "failed to factory reset")
+				},
+			},
 		},
 	}
 

--- a/cmd/hhfctl/main.go
+++ b/cmd/hhfctl/main.go
@@ -862,6 +862,32 @@ func main() {
 						},
 					},
 					{
+						Name:    "factory-reset",
+						Aliases: []string{"reset"},
+						Usage:   "Erase the switch startup config and reboot, the agent re-applies the fabric config from scratch on boot (only works if switch is healthy and sends heartbeats)",
+						Description: `Erases the startup config of the switch and reboots it. This is a recovery action to get rid of
+the config drift accumulated on the switch: on the next boot the agent reconfigures the control
+link and re-applies the whole fabric config from scratch.
+
+It does not decommission the switch: the config comes back on the next boot. Use reinstall to
+reboot into ONIE instead.`,
+						Flags: []cli.Flag{
+							verboseFlag,
+							nameFlag,
+							yesFlag,
+						},
+						Before: func(_ *cli.Context) error {
+							return setupLogger(verbose)
+						},
+						Action: func(cCtx *cli.Context) error {
+							if err := yesCheck(cCtx); err != nil {
+								return wrapErrWithPressToContinue(err)
+							}
+
+							return wrapErrWithPressToContinue(errors.Wrapf(hhfctl.SwitchFactoryReset(ctx, name), "failed to factory reset switch"))
+						},
+					},
+					{
 						Name:  "roce",
 						Usage: "Set RoCE mode on the switch (automatically reboots switch)",
 						Flags: []cli.Flag{

--- a/config/crd/bases/agent.githedgehog.com_agents.yaml
+++ b/config/crd/bases/agent.githedgehog.com_agents.yaml
@@ -1167,6 +1167,8 @@ spec:
                       type: object
                   type: object
                 type: object
+              factoryReset:
+                type: string
               ipv4Namespaces:
                 additionalProperties:
                   description: IPv4NamespaceSpec defines the desired state of IPv4Namespace

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -91,6 +91,44 @@ type Service struct {
 	lastStatus    *agentapi.AgentStatus
 }
 
+func selectProcessor(agent *agentapi.Agent) (dozer.Processor, error) {
+	nosType := agent.Spec.SwitchProfile.NOSType
+
+	switch {
+	case slices.Contains(fmeta.NOSTypesSONiCBCM, nosType):
+		return bcm.Processor(), nil
+	case slices.Contains(fmeta.NOSTypesSONiCCLSPlus, nosType):
+		return clsp.Processor(), nil
+	case slices.Contains(fmeta.NOSTypesCumulus, nosType):
+		return cmls.Processor(), nil
+	default:
+		return nil, fmt.Errorf("unsupported nos type: %s", nosType) //nolint:err113
+	}
+}
+
+// FactoryReset erases the switch startup config and reboots without going through the Agent
+// object, for when the switch can't be reached from the control node. The agent re-applies the
+// config from the local file on the next boot.
+func (svc *Service) FactoryReset(ctx context.Context) error {
+	if svc.Basedir == "" {
+		return errors.New("basedir is required")
+	}
+
+	agent, err := svc.loadConfigFromFile()
+	if err != nil {
+		return errors.Wrap(err, "failed to load config")
+	}
+
+	processor, err := selectProcessor(agent)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("Factory resetting switch, config will be erased and switch will reboot", "name", agent.Name)
+
+	return errors.Wrap(processor.FactoryReset(ctx), "failed to factory reset")
+}
+
 func (svc *Service) Run(ctx context.Context, getClient func() (*gnmi.Client, error)) error {
 	svc.reg = switchstate.NewRegistry()
 	svc.reg.AgentMetrics.Version.WithLabelValues(version.Version).Set(1)
@@ -130,18 +168,13 @@ func (svc *Service) Run(ctx context.Context, getClient func() (*gnmi.Client, err
 	isClsP := slices.Contains(fmeta.NOSTypesSONiCCLSPlus, agent.Spec.SwitchProfile.NOSType)
 	isCumulus := slices.Contains(fmeta.NOSTypesCumulus, agent.Spec.SwitchProfile.NOSType)
 
-	switch {
-	case isBCM:
-		bcmProcessor := bcm.Processor()
-		svc.processor = bcmProcessor
-	case isClsP:
-		svc.processor = clsp.Processor()
-	case isCumulus:
+	svc.processor, err = selectProcessor(agent)
+	if err != nil {
+		return err
+	}
+
+	if isCumulus {
 		svc.SkipControlLink = true
-		cmlsProcessor := cmls.Processor()
-		svc.processor = cmlsProcessor
-	default:
-		return fmt.Errorf("unsupported nos type: %s", agent.Spec.SwitchProfile.NOSType) //nolint:err113
 	}
 
 	if !svc.DryRun {
@@ -781,7 +814,8 @@ func (svc *Service) processActions(ctx context.Context, agent *agentapi.Agent) e
 	}
 
 	reboot := false
-	if agent.Spec.Reinstall != "" && agent.Spec.Reinstall == svc.installID {
+	reinstall := agent.Spec.Reinstall != "" && agent.Spec.Reinstall == svc.installID
+	if reinstall {
 		slog.Info("Reinstall requested", "installID", agent.Spec.Reinstall)
 		if !svc.SkipActions {
 			slog.Info("Making ONIE next boot entry")
@@ -797,6 +831,23 @@ func (svc *Service) processActions(ctx context.Context, agent *agentapi.Agent) e
 			}
 
 			reboot = true
+		}
+	}
+
+	if agent.Spec.FactoryReset != "" && agent.Spec.FactoryReset == svc.bootID {
+		if reinstall {
+			// a reinstall wipes the whole NOS, so erasing the config first would be pointless
+			slog.Info("Factory reset requested, but skipping it as a reinstall is already pending")
+		} else {
+			slog.Info("Factory reset requested, erasing config and rebooting", "bootID", agent.Spec.FactoryReset)
+			if !svc.SkipActions {
+				// FactoryReset reboots on success, so we only ever return from it on failure. Failing
+				// the whole apply here would leave the request armed (the bootID doesn't change
+				// without a reboot) and re-fire it on every generation change, so only warn.
+				if err := svc.processor.FactoryReset(ctx); err != nil {
+					slog.Warn("Failed to factory reset switch, continuing", "error", err)
+				}
+			}
 		}
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -539,6 +539,10 @@ func enforceBroadcomState(ctx context.Context, processor dozer.Processor, agent 
 		slog.Warn("Action warning: " + warning)
 	}
 
+	if err := processor.SaveConfig(ctx); err != nil {
+		slog.Warn("Failed to save config to switch after enforcing", "error", err)
+	}
+
 	return nil
 }
 

--- a/pkg/agent/clsp/processor.go
+++ b/pkg/agent/clsp/processor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 
 	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
@@ -33,9 +34,16 @@ func (c *CelesticaPlusProcessor) Reinstall(ctx context.Context) error {
 	return bcm.Processor().Reinstall(ctx) //nolint:wrapcheck
 }
 
-// TODO
 func (c *CelesticaPlusProcessor) FactoryReset(ctx context.Context) error {
-	return fmt.Errorf("not implemented") //nolint:err113
+	cmd := exec.CommandContext(ctx, "sonic-cli", "-c", "\"write erase\"")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to reset config: %w", err)
+	}
+
+	return c.Reboot(ctx, true)
 }
 
 // TODO
@@ -108,4 +116,16 @@ func (c *CelesticaPlusProcessor) ApplyActions(ctx context.Context, actions []doz
 
 func (c *CelesticaPlusProcessor) CalculateActions(ctx context.Context, actual *dozer.Spec, desired *dozer.Spec) ([]dozer.Action, error) {
 	return nil, fmt.Errorf("unsupported operation") //nolint:err113
+}
+
+func (c *CelesticaPlusProcessor) SaveConfig(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "sonic-cli", "-c", "\"copy running-config startup-config\"")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/agent/clsp/processor.go
+++ b/pkg/agent/clsp/processor.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 
 	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
@@ -35,11 +34,7 @@ func (c *CelesticaPlusProcessor) Reinstall(ctx context.Context) error {
 }
 
 func (c *CelesticaPlusProcessor) FactoryReset(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "sonic-cli", "-c", "\"write erase\"")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
+	if err := bcm.SonicCLIConfirm(ctx, "write erase", "y\n"); err != nil {
 		return fmt.Errorf("failed to reset config: %w", err)
 	}
 
@@ -119,11 +114,7 @@ func (c *CelesticaPlusProcessor) CalculateActions(ctx context.Context, actual *d
 }
 
 func (c *CelesticaPlusProcessor) SaveConfig(ctx context.Context) error {
-	cmd := exec.CommandContext(ctx, "sonic-cli", "-c", "\"copy running-config startup-config\"")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
+	if err := bcm.SonicCLI(ctx, "copy running-config startup-config"); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
 

--- a/pkg/agent/cmls/processor.go
+++ b/pkg/agent/cmls/processor.go
@@ -72,3 +72,8 @@ func (c *CumulusProcessor) ApplyActions(ctx context.Context, actions []dozer.Act
 func (c *CumulusProcessor) CalculateActions(ctx context.Context, actual *dozer.Spec, desired *dozer.Spec) ([]dozer.Action, error) {
 	return nil, fmt.Errorf("unsupported operation") //nolint:err113
 }
+
+// TODO
+func (c *CumulusProcessor) SaveConfig(ctx context.Context) error {
+	return fmt.Errorf("unsupported operation") //nolint:err113
+}

--- a/pkg/agent/dozer/bcm/processor.go
+++ b/pkg/agent/dozer/bcm/processor.go
@@ -155,17 +155,8 @@ func (p *BroadcomProcessor) Reinstall(ctx context.Context) error {
 }
 
 func (p *BroadcomProcessor) FactoryReset(ctx context.Context) error {
-	// "write erase boot" prompts for confirmation ("...continue? [y/N]:") and
-	// reads the answer from the controlling TTY, not stdin, so a plain stdin
-	// pipe is ignored and the command defaults to N. Wrap it in `script`, which
-	// allocates a pty; `script` forwards its own stdin into the pty, so feeding
-	// "y\n" here reaches the prompt.
-	cmd := exec.CommandContext(ctx, "script", "-qec", `sonic-cli -c "write erase boot"`, "/dev/null")
-	cmd.Stdin = strings.NewReader("y\n")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
+	// "write erase boot" prompts for confirmation ("...continue? [y/N]:")
+	if err := SonicCLIConfirm(ctx, "write erase boot", "y\n"); err != nil {
 		return fmt.Errorf("failed to reset config: %w", err)
 	}
 
@@ -416,9 +407,6 @@ func (p *BroadcomProcessor) SetRoCE(ctx context.Context, val bool) error {
 
 func (p *BroadcomProcessor) SaveConfig(ctx context.Context) error {
 	slog.Info("Saving config...")
-	cmd := exec.CommandContext(ctx, "sonic-cli", "-c", "\"write memory\"")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
 
-	return errors.Wrap(cmd.Run(), "failed to save config")
+	return errors.Wrap(SonicCLI(ctx, "write memory"), "failed to save config")
 }

--- a/pkg/agent/dozer/bcm/processor.go
+++ b/pkg/agent/dozer/bcm/processor.go
@@ -154,22 +154,22 @@ func (p *BroadcomProcessor) Reinstall(ctx context.Context) error {
 	return p.Reboot(ctx, true)
 }
 
-func (p *BroadcomProcessor) FactoryReset(_ context.Context) error {
-	// TODO use sonic-cli for it and then switch to GNOI
-	// write erase boot
+func (p *BroadcomProcessor) FactoryReset(ctx context.Context) error {
+	// "write erase boot" prompts for confirmation ("...continue? [y/N]:") and
+	// reads the answer from the controlling TTY, not stdin, so a plain stdin
+	// pipe is ignored and the command defaults to N. Wrap it in `script`, which
+	// allocates a pty; `script` forwards its own stdin into the pty, so feeding
+	// "y\n" here reaches the prompt.
+	cmd := exec.CommandContext(ctx, "script", "-qec", `sonic-cli -c "write erase boot"`, "/dev/null")
+	cmd.Stdin = strings.NewReader("y\n")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-	// stdin, err := cmd.StdinPipe()
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to reset config: %w", err)
+	}
 
-	// go func() {
-	// 	defer stdin.Close()
-	// 	// todo test it
-	// 	io.WriteString(stdin, "y\n")
-	// }()
-
-	return fmt.Errorf("not supported") //nolint:err113
+	return p.Reboot(ctx, true)
 }
 
 func (p *BroadcomProcessor) LoadActualState(ctx context.Context, agent *agentapi.Agent) (*dozer.Spec, error) {
@@ -412,4 +412,13 @@ func (p *BroadcomProcessor) SetRoCE(ctx context.Context, val bool) error {
 	}
 
 	return nil
+}
+
+func (p *BroadcomProcessor) SaveConfig(ctx context.Context) error {
+	slog.Info("Saving config...")
+	cmd := exec.CommandContext(ctx, "sonic-cli", "-c", "\"write memory\"")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return errors.Wrap(cmd.Run(), "failed to save config")
 }

--- a/pkg/agent/dozer/bcm/sonic_cli.go
+++ b/pkg/agent/dozer/bcm/sonic_cli.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package bcm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	// sonic-cli refuses to run as root ("FATAL: root cannot launch CLI") and the agent runs as root,
+	// so every invocation has to drop to a regular user.
+	SonicCLIUser = "admin"
+
+	sonicCLITimeout = 2 * time.Minute
+)
+
+// SonicCLI runs a sonic-cli command.
+func SonicCLI(ctx context.Context, command string) error {
+	ctx, cancel := context.WithTimeout(ctx, sonicCLITimeout)
+	defer cancel()
+
+	return runSonicCLI(ctx, command, exec.CommandContext(ctx,
+		"sudo", "-u", SonicCLIUser, "sonic-cli", "-c", command))
+}
+
+// SonicCLIConfirm runs a sonic-cli command that prompts for confirmation, answering it with answer
+// (such as "y\n"). The prompt is read from the controlling TTY, not stdin, so a plain stdin pipe is
+// ignored and the command defaults to N. `script` allocates a pty and forwards its own stdin into
+// it, so the answer written here reaches the prompt.
+//
+// Under a pty sonic-cli also paginates, so a command with long output stops at "--more--" instead of
+// completing: append "| no-more" to the command to disable paging.
+func SonicCLIConfirm(ctx context.Context, command, answer string) error {
+	ctx, cancel := context.WithTimeout(ctx, sonicCLITimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "script", "-qec", //nolint:gosec
+		fmt.Sprintf("sudo -u %s sonic-cli -c %q", SonicCLIUser, command), "/dev/null")
+	cmd.Stdin = strings.NewReader(answer)
+
+	return runSonicCLI(ctx, command, cmd)
+}
+
+// runSonicCLI returns the command output together with the error, so that a failure is diagnosable
+// from the single log line the caller reports.
+func runSonicCLI(ctx context.Context, command string, cmd *exec.Cmd) error {
+	out := &bytes.Buffer{}
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	err := cmd.Run()
+	output := strings.TrimSpace(out.String())
+
+	if err == nil {
+		if output != "" {
+			slog.Debug("sonic-cli", "command", command, "output", output)
+		}
+
+		return nil
+	}
+
+	// on the deadline the process is killed, which on its own only surfaces as "signal: killed"
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		err = fmt.Errorf("%w (timed out after %s)", err, sonicCLITimeout)
+	}
+
+	if output == "" {
+		return fmt.Errorf("running sonic-cli %q: %w", command, err)
+	}
+
+	return fmt.Errorf("running sonic-cli %q: %w: %s", command, err, output)
+}

--- a/pkg/agent/dozer/dozer.go
+++ b/pkg/agent/dozer/dozer.go
@@ -40,6 +40,7 @@ type Processor interface {
 	FactoryReset(ctx context.Context) error
 	GetRoCE(ctx context.Context) (bool, error)
 	SetRoCE(ctx context.Context, enable bool) error
+	SaveConfig(ctx context.Context) error
 }
 
 type Action interface {

--- a/pkg/hhfctl/switch.go
+++ b/pkg/hhfctl/switch.go
@@ -128,6 +128,30 @@ func SwitchReinstall(ctx context.Context, name string) error {
 	return nil
 }
 
+func SwitchFactoryReset(ctx context.Context, name string) error {
+	kube, err := kubeutil.NewClient(ctx, "", agentapi.AddToScheme)
+	if err != nil {
+		return fmt.Errorf("creating kube client: %w", err)
+	}
+
+	agent, err := getAgent(ctx, kube, name)
+	if err != nil {
+		return err
+	}
+
+	if agent.Status.BootID == "" {
+		return fmt.Errorf("agent is not running (missing .status.bootID)") //nolint:goerr113
+	}
+
+	agent.Spec.FactoryReset = agent.Status.BootID
+	err = kube.Update(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("updating agent object: %w", err)
+	}
+
+	return nil
+}
+
 func SwitchIP(ctx context.Context, name string) error {
 	kube, err := kubeutil.NewClient(ctx, "", wiringapi.AddToScheme)
 	if err != nil {


### PR DESCRIPTION
not yet implemented for Cumulus

config is saved after every config enforcement, currently only for Broadcom agents.
factory-reset can be invoked from hhfctl (`kubectl fabric switch factory-reset`) or via the agent binary itself

Fix https://github.com/githedgehog/internal/issues/417