### PR TITLE
User ACLs: Make scope mandatory in rule definition

### DIFF
--- a/api/gateway/v1alpha1/gatewaypeering_types.go
+++ b/api/gateway/v1alpha1/gatewaypeering_types.go
@@ -75,7 +75,7 @@ type ACLDefaultAction string
 // +kubebuilder:validation:Enum=deny;allow
 type ACLAction string
 
-// +kubebuilder:validation:Enum=flow;packet;""
+// +kubebuilder:validation:Enum=flow;packet
 type ACLScope string
 
 const (
@@ -140,8 +140,8 @@ type PeeringACLRule struct {
 	Action ACLAction `json:"action"`
 	// What the rule should match against, omit to match everything in the rule's direction
 	Match PeeringACLMatch `json:"match,omitempty"`
-	// Scope of the rule, can be either "flow" (default if empty) or "packet"
-	Scope ACLScope `json:"scope,omitempty"`
+	// Scope of the rule, can be either "flow" or "packet"
+	Scope ACLScope `json:"scope"`
 	Log   bool     `json:"log,omitempty"`
 }
 
@@ -276,11 +276,6 @@ func (p *GatewayPeering) Default() {
 	if acl := p.Spec.ACL; acl != nil {
 		if acl.Default == "" {
 			acl.Default = ACLDefaultDenyUnlessExposed
-		}
-		for i := range acl.Rules {
-			if acl.Rules[i].Scope == "" {
-				acl.Rules[i].Scope = ACLScopeFlow
-			}
 		}
 	}
 }

--- a/api/gateway/v1alpha1/gatewaypeering_types.go
+++ b/api/gateway/v1alpha1/gatewaypeering_types.go
@@ -435,6 +435,9 @@ func (p *GatewayPeering) Validate(ctx context.Context, kube kclient.Reader, fabr
 			if !slices.Contains(ACLActions, rule.Action) {
 				return fmt.Errorf("invalid action %q in ACL rule %d%s", rule.Action, i, ruleBlob) //nolint:err113
 			}
+			if !slices.Contains(ACLScopes, rule.Scope) {
+				return fmt.Errorf("invalid scope %q in ACL rule %d%s", rule.Scope, i, ruleBlob) //nolint:err113
+			}
 			if rule.From == "" && rule.To == "" {
 				return fmt.Errorf("at least one of from and to must be specified in ACL rule %d%s", i, ruleBlob) //nolint:err113
 			}

--- a/api/gateway/v1alpha1/gatewaypeering_types_test.go
+++ b/api/gateway/v1alpha1/gatewaypeering_types_test.go
@@ -1073,6 +1073,15 @@ func TestValidateACLNoKube(t *testing.T) {
 			err: true,
 		},
 		{
+			name: "invalid scope",
+			acl: &PeeringACL{
+				Rules: []PeeringACLRule{
+					{From: "vpc-1", Action: ACLActionDeny, Scope: "bogus"},
+				},
+			},
+			err: true,
+		},
+		{
 			name: "neither from nor to set",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{

--- a/api/gateway/v1alpha1/gatewaypeering_types_test.go
+++ b/api/gateway/v1alpha1/gatewaypeering_types_test.go
@@ -1051,7 +1051,7 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "valid rule with from only",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{From: "vpc-1", Action: ACLActionAllow},
+					{From: "vpc-1", Action: ACLActionAllow, Scope: ACLScopeFlow},
 				},
 			},
 		},
@@ -1059,7 +1059,7 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "valid rule with to only",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{To: "vpc-2", Action: ACLActionDeny},
+					{To: "vpc-2", Action: ACLActionDeny, Scope: ACLScopeFlow},
 				},
 			},
 		},
@@ -1067,7 +1067,16 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "invalid action",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{From: "vpc-1", Action: "bogus"},
+					{From: "vpc-1", Action: "bogus", Scope: ACLScopeFlow},
+				},
+			},
+			err: true,
+		},
+		{
+			name: "missing scope",
+			acl: &PeeringACL{
+				Rules: []PeeringACLRule{
+					{From: "vpc-1", Action: ACLActionDeny},
 				},
 			},
 			err: true,
@@ -1085,7 +1094,7 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "neither from nor to set",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{Action: ACLActionAllow},
+					{Action: ACLActionAllow, Scope: ACLScopeFlow},
 				},
 			},
 			err: true,
@@ -1094,7 +1103,7 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "from does not match either VPC",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{From: "vpc-3", Action: ACLActionAllow},
+					{From: "vpc-3", Action: ACLActionAllow, Scope: ACLScopeFlow},
 				},
 			},
 			err: true,
@@ -1103,7 +1112,7 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "to does not match either VPC",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{To: "vpc-3", Action: ACLActionAllow},
+					{To: "vpc-3", Action: ACLActionAllow, Scope: ACLScopeFlow},
 				},
 			},
 			err: true,
@@ -1112,7 +1121,12 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "valid rule name",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{Name: "web-traffic", From: "vpc-1", Action: ACLActionAllow},
+					{
+						Name:   "web-traffic",
+						From:   "vpc-1",
+						Action: ACLActionAllow,
+						Scope:  ACLScopeFlow,
+					},
 				},
 			},
 		},
@@ -1120,7 +1134,12 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "invalid rule name characters",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{Name: "Web_Traffic!", From: "vpc-1", Action: ACLActionAllow},
+					{
+						Name:   "Web_Traffic!",
+						From:   "vpc-1",
+						Action: ACLActionAllow,
+						Scope:  ACLScopeFlow,
+					},
 				},
 			},
 			err: true,
@@ -1129,7 +1148,12 @@ func TestValidateACLNoKube(t *testing.T) {
 			name: "rule name too long",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{
-					{Name: strings.Repeat("a", 65), From: "vpc-1", Action: ACLActionAllow},
+					{
+						Name:   strings.Repeat("a", 65),
+						From:   "vpc-1",
+						Action: ACLActionAllow,
+						Scope:  ACLScopeFlow,
+					},
 				},
 			},
 			err: true,
@@ -1146,6 +1170,7 @@ func TestValidateACLNoKube(t *testing.T) {
 								{CIDR: "10.0.1.0/24", VPCSubnet: "sub1"},
 							},
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1163,6 +1188,7 @@ func TestValidateACLNoKube(t *testing.T) {
 								{CIDR: "10.0.2.0/24", VPCSubnet: "sub1"},
 							},
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1180,6 +1206,7 @@ func TestValidateACLNoKube(t *testing.T) {
 								{CIDR: "not-a-cidr"},
 							},
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1197,6 +1224,7 @@ func TestValidateACLNoKube(t *testing.T) {
 								{CIDR: "not-a-cidr"},
 							},
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1214,6 +1242,7 @@ func TestValidateACLNoKube(t *testing.T) {
 							Source:      []PeeringACLMatchEndpoint{{CIDR: "10.0.1.0/24", Ports: []string{"80", "443"}}},
 							Destination: []PeeringACLMatchEndpoint{{CIDR: "10.0.2.0/24", Ports: []string{"8080-8090"}}},
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1228,6 +1257,7 @@ func TestValidateACLNoKube(t *testing.T) {
 						Match: PeeringACLMatch{
 							Source: []PeeringACLMatchEndpoint{{CIDR: "10.0.1.0/24", Ports: []string{"not-a-port"}}},
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1243,6 +1273,7 @@ func TestValidateACLNoKube(t *testing.T) {
 						Match: PeeringACLMatch{
 							Destination: []PeeringACLMatchEndpoint{{CIDR: "10.0.2.0/24", Ports: []string{"not-a-port"}}},
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1259,6 +1290,7 @@ func TestValidateACLNoKube(t *testing.T) {
 							Source:   []PeeringACLMatchEndpoint{{CIDR: "10.0.1.0/24"}},
 							Protocol: ACLMatchProtocolTCP,
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1274,6 +1306,7 @@ func TestValidateACLNoKube(t *testing.T) {
 							Source:   []PeeringACLMatchEndpoint{{CIDR: "10.0.1.0/24"}},
 							Protocol: "42",
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1289,6 +1322,7 @@ func TestValidateACLNoKube(t *testing.T) {
 							Source:   []PeeringACLMatchEndpoint{{CIDR: "10.0.1.0/24"}},
 							Protocol: "not-a-protocol",
 						},
+						Scope: ACLScopeFlow,
 					},
 				},
 			},
@@ -1347,6 +1381,7 @@ func TestValidateACLVPCSubnet(t *testing.T) {
 							Match: PeeringACLMatch{
 								Source: []PeeringACLMatchEndpoint{{VPCSubnet: "sub1"}},
 							},
+							Scope: ACLScopeFlow,
 						},
 					},
 				}
@@ -1364,6 +1399,7 @@ func TestValidateACLVPCSubnet(t *testing.T) {
 							Match: PeeringACLMatch{
 								Destination: []PeeringACLMatchEndpoint{{VPCSubnet: "sub1"}},
 							},
+							Scope: ACLScopeFlow,
 						},
 					},
 				}
@@ -1382,6 +1418,7 @@ func TestValidateACLVPCSubnet(t *testing.T) {
 							Match: PeeringACLMatch{
 								Source: []PeeringACLMatchEndpoint{{VPCSubnet: "nonexistent"}},
 							},
+							Scope: ACLScopeFlow,
 						},
 					},
 				}
@@ -1401,6 +1438,7 @@ func TestValidateACLVPCSubnet(t *testing.T) {
 							Match: PeeringACLMatch{
 								Destination: []PeeringACLMatchEndpoint{{VPCSubnet: "nonexistent"}},
 							},
+							Scope: ACLScopeFlow,
 						},
 					},
 				}
@@ -1420,6 +1458,7 @@ func TestValidateACLVPCSubnet(t *testing.T) {
 							Match: PeeringACLMatch{
 								Source: []PeeringACLMatchEndpoint{{VPCSubnet: "sub1"}},
 							},
+							Scope: ACLScopeFlow,
 						},
 					},
 				}

--- a/config/crd/bases/gateway.githedgehog.com_gatewaypeerings.yaml
+++ b/config/crd/bases/gateway.githedgehog.com_gatewaypeerings.yaml
@@ -134,12 +134,11 @@ spec:
                           description: Optional name for logs and diagnostics
                           type: string
                         scope:
-                          description: Scope of the rule, can be either "flow" (default
-                            if empty) or "packet"
+                          description: Scope of the rule, can be either "flow" or
+                            "packet"
                           enum:
                           - flow
                           - packet
-                          - ""
                           type: string
                         to:
                           description: To has to match one of the peering's two VPCs
@@ -147,6 +146,7 @@ spec:
                           type: string
                       required:
                       - action
+                      - scope
                       type: object
                     type: array
                 required:

--- a/config/crd/bases/gwint.githedgehog.com_gatewayagents.yaml
+++ b/config/crd/bases/gwint.githedgehog.com_gatewayagents.yaml
@@ -317,11 +317,10 @@ spec:
                                 type: string
                               scope:
                                 description: Scope of the rule, can be either "flow"
-                                  (default if empty) or "packet"
+                                  or "packet"
                                 enum:
                                 - flow
                                 - packet
-                                - ""
                                 type: string
                               to:
                                 description: To has to match one of the peering's
@@ -330,6 +329,7 @@ spec:
                                 type: string
                             required:
                             - action
+                            - scope
                             type: object
                           type: array
                       required:

--- a/docs/api.md
+++ b/docs/api.md
@@ -913,7 +913,7 @@ _Underlying type:_ _string_
 
 
 _Validation:_
-- Enum: [flow packet ]
+- Enum: [flow packet]
 
 _Appears in:_
 - [PeeringACLRule](#peeringaclrule)
@@ -1244,7 +1244,7 @@ _Appears in:_
 | `to` _string_ | To has to match one of the peering's two VPCs if present, implicit from the "from" field otherwise |  |  |
 | `action` _[ACLAction](#aclaction)_ | Action to execute if the rule matches, can be either "deny" or "allow" |  | Enum: [deny allow] <br /> |
 | `match` _[PeeringACLMatch](#peeringaclmatch)_ | What the rule should match against, omit to match everything in the rule's direction |  |  |
-| `scope` _[ACLScope](#aclscope)_ | Scope of the rule, can be either "flow" (default if empty) or "packet" |  | Enum: [flow packet ] <br /> |
+| `scope` _[ACLScope](#aclscope)_ | Scope of the rule, can be either "flow" or "packet" |  | Enum: [flow packet] <br /> |
 | `log` _boolean_ |  |  |  |
 
 


### PR DESCRIPTION
So far, the scope ("packet" or "flow") for an ACL rule was optional, and would default to "flow" if not specified. This is the desired behaviour: by default, we want the reverse traffic to be allowed for a given ACL rule.

However, at the moment we don't support the "flow" scope for peerings with connections that use static NAT or no NAT (we only support it when all connections go through masquerade or port-forwarding, because this is currently necessary for creating stateful flow table entries in the dataplane). This means that by default, we use a scope value that will be rejected with several configurations, which is not ideal.

One workaround would be to make the "packet" scope the default value, instead; but we don't want that, and it would be hard to change in the future. Instead, make the scope required (no default value) at the moment, and we can revert to "flow" as the default once we've extended support in dataplane without risking to break user configurations.

Also add some validation for the scope enum variants.
