### PR TITLE
feat(acls): Add validation for user ACLs' scope

### DIFF
--- a/api/gateway/v1alpha1/gatewaypeering_types.go
+++ b/api/gateway/v1alpha1/gatewaypeering_types.go
@@ -435,6 +435,9 @@ func (p *GatewayPeering) Validate(ctx context.Context, kube kclient.Reader, fabr
 			if !slices.Contains(ACLActions, rule.Action) {
 				return fmt.Errorf("invalid action %q in ACL rule %d%s", rule.Action, i, ruleBlob) //nolint:err113
 			}
+			if !slices.Contains(ACLScopes, rule.Scope) {
+				return fmt.Errorf("invalid scope %q in ACL rule %d%s", rule.Scope, i, ruleBlob) //nolint:err113
+			}
 			if rule.From == "" && rule.To == "" {
 				return fmt.Errorf("at least one of from and to must be specified in ACL rule %d%s", i, ruleBlob) //nolint:err113
 			}

--- a/api/gateway/v1alpha1/gatewaypeering_types_test.go
+++ b/api/gateway/v1alpha1/gatewaypeering_types_test.go
@@ -1073,6 +1073,15 @@ func TestValidateACLNoKube(t *testing.T) {
 			err: true,
 		},
 		{
+			name: "invalid scope",
+			acl: &PeeringACL{
+				Rules: []PeeringACLRule{
+					{From: "vpc-1", Action: ACLActionDeny, Scope: "bogus"},
+				},
+			},
+			err: true,
+		},
+		{
 			name: "neither from nor to set",
 			acl: &PeeringACL{
 				Rules: []PeeringACLRule{


### PR DESCRIPTION
Add validation for the options for the scope for user ACL rules, which can be either "packet" or "flow", but nothing else.
