### PR TITLE
fix(gw-ctrl): all gateways should be reconciled on any gw change

### DIFF
--- a/pkg/ctrl/gateway_ctrl.go
+++ b/pkg/ctrl/gateway_ctrl.go
@@ -88,6 +88,7 @@ func SetupGatewayReconcilerWith(mgr kctrl.Manager, cfg *meta.FabricConfig) error
 	if err := kctrl.NewControllerManagedBy(mgr).
 		Named("Gateway").
 		For(&gwapi.Gateway{}).
+		Watches(&gwapi.Gateway{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllGateways)).
 		Watches(&gwapi.GatewayPeering{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllGateways)).
 		Watches(&gwapi.VPCInfo{}, handler.EnqueueRequestsFromMapFunc(r.enqueueAllGateways)).
 		Complete(r); err != nil {


### PR DESCRIPTION
One of the reasons is that we need to react to changes in gateway priorities within gateway groups.

Fix #1537