### PR TITLE
support for BGP unnumbered over fabric/mesh links

### DIFF
--- a/api/wiring/v1beta1/connection_types.go
+++ b/api/wiring/v1beta1/connection_types.go
@@ -992,7 +992,11 @@ func (conn *Connection) Validate(ctx context.Context, kube kclient.Reader, fabri
 		if conn.Spec.Fabric != nil { //nolint:gocritic
 			cf := conn.Spec.Fabric
 			for idx, link := range cf.Links {
-				if link.Spine.IP == "" || link.Leaf.IP == "" {
+				// no IPs on either side means BGP unnumbered, but a link with just one IP is broken
+				if (link.Spine.IP == "") != (link.Leaf.IP == "") {
+					return nil, errors.Errorf("fabric connection %s link %d has an IP on only one side, it must be set on both for a numbered link or on neither for an unnumbered one", conn.Name, idx) //nolint:goerr113
+				}
+				if link.Spine.IP == "" {
 					continue
 				}
 
@@ -1037,7 +1041,11 @@ func (conn *Connection) Validate(ctx context.Context, kube kclient.Reader, fabri
 		} else if conn.Spec.Mesh != nil {
 			cm := conn.Spec.Mesh
 			for idx, link := range cm.Links {
-				if link.Leaf1.IP == "" || link.Leaf2.IP == "" {
+				// no IPs on either side means BGP unnumbered, but a link with just one IP is broken
+				if (link.Leaf1.IP == "") != (link.Leaf2.IP == "") {
+					return nil, errors.Errorf("mesh connection %s link %d has an IP on only one side, it must be set on both for a numbered link or on neither for an unnumbered one", conn.Name, idx) //nolint:goerr113
+				}
+				if link.Leaf1.IP == "" {
 					continue
 				}
 
@@ -1082,8 +1090,9 @@ func (conn *Connection) Validate(ctx context.Context, kube kclient.Reader, fabri
 		} else if conn.Spec.Gateway != nil {
 			cg := conn.Spec.Gateway
 			for idx, link := range cg.Links {
+				// unlike fabric and mesh links, gateway links can't be unnumbered yet, so both IPs are required
 				if link.Switch.IP == "" || link.Gateway.IP == "" {
-					continue
+					return nil, errors.Errorf("gateway connection %s link %d is missing an IP, it must be set on both sides as unnumbered gateway links are not supported yet", conn.Name, idx) //nolint:goerr113
 				}
 
 				switchPrefix, err := netip.ParsePrefix(link.Switch.IP)

--- a/api/wiring/v1beta1/connection_types_test.go
+++ b/api/wiring/v1beta1/connection_types_test.go
@@ -492,6 +492,63 @@ func TestConnectionValidation(t *testing.T) {
 			})),
 		},
 		{
+			// no IPs at all means BGP unnumbered
+			name: "unnumbered-fabric",
+			conn: fabricConnGen("fabric-1", func(conn *wiringapi.Connection) {
+				conn.Spec.Fabric.Links[0].Spine.IP = ""
+				conn.Spec.Fabric.Links[0].Leaf.IP = ""
+			}),
+			withClient: true,
+			objects:    base,
+		},
+		{
+			name: "unnumbered-mesh",
+			conn: meshConnGen("mesh-1", func(conn *wiringapi.Connection) {
+				conn.Spec.Mesh.Links[0].Leaf1.IP = ""
+				conn.Spec.Mesh.Links[0].Leaf2.IP = ""
+			}),
+			withClient: true,
+			objects:    base,
+		},
+		{
+			name: "half-numbered-fabric",
+			conn: fabricConnGen("fabric-1", func(conn *wiringapi.Connection) {
+				conn.Spec.Fabric.Links[0].Leaf.IP = ""
+			}),
+			withClient: true,
+			objects:    base,
+			err:        true,
+		},
+		{
+			// the gateway can't do unnumbered yet, so both sides are required
+			name: "unnumbered-gateway-rejected",
+			conn: gwConnGen("gw-1", func(conn *wiringapi.Connection) {
+				conn.Spec.Gateway.Links[0].Switch.IP = ""
+				conn.Spec.Gateway.Links[0].Gateway.IP = ""
+			}),
+			withClient: true,
+			objects:    base,
+			err:        true,
+		},
+		{
+			name: "half-numbered-gateway",
+			conn: gwConnGen("gw-1", func(conn *wiringapi.Connection) {
+				conn.Spec.Gateway.Links[0].Gateway.IP = ""
+			}),
+			withClient: true,
+			objects:    base,
+			err:        true,
+		},
+		{
+			name: "half-numbered-mesh",
+			conn: meshConnGen("mesh-1", func(conn *wiringapi.Connection) {
+				conn.Spec.Mesh.Links[0].Leaf1.IP = ""
+			}),
+			withClient: true,
+			objects:    base,
+			err:        true,
+		},
+		{
 			name:       "collision-gateway-with-fabric-IP",
 			conn:       gwConnGen("gw-1"),
 			withClient: true,

--- a/pkg/agent/cmls/cumulus.go
+++ b/pkg/agent/cmls/cumulus.go
@@ -160,6 +160,9 @@ func buildConfigFor(tmpl string, agent *agentapi.Agent) (*bytes.Buffer, error) {
 				}
 
 				leafName = link.Leaf.DeviceName()
+				if link.Leaf.IP == "" || link.Spine.IP == "" {
+					return nil, fmt.Errorf("conn %s: unnumbered fabric links are not supported on Cumulus yet", connName) //nolint:goerr113
+				}
 				leafIP, err := netip.ParsePrefix(link.Leaf.IP)
 				if err != nil {
 					return nil, fmt.Errorf("parsing conn %s leaf IP %s: %w", connName, link.Leaf.IP, err)
@@ -193,6 +196,9 @@ func buildConfigFor(tmpl string, agent *agentapi.Agent) (*bytes.Buffer, error) {
 				}
 
 				spineName = link.Spine.DeviceName()
+				if link.Spine.IP == "" || link.Leaf.IP == "" {
+					return nil, fmt.Errorf("conn %s: unnumbered fabric links are not supported on Cumulus yet", connName) //nolint:goerr113
+				}
 				spineIP, err := netip.ParsePrefix(link.Spine.IP)
 				if err != nil {
 					return nil, fmt.Errorf("parsing conn %s spine IP %s: %w", connName, link.Spine.IP, err)

--- a/pkg/agent/dozer/bcm/README.plan.md
+++ b/pkg/agent/dozer/bcm/README.plan.md
@@ -324,6 +324,41 @@ neighbor 172.30.8.3
 !
 ```
 
+#### Unnumbered links
+
+A fabric link whose `Connection` has no IP on either side runs BGP unnumbered instead. This
+is decided per link, so a fabric can mix numbered and unnumbered links; a link with an IP on
+only one side is rejected by the webhook. The interface gets `ipv6 enable` and no address:
+```
+interface Ethernet3
+ description "Fabric spine-01/E1/1 spine-01--fabric--leaf-01"
+ [...]
+ ipv6 enable
+!
+```
+and the session is keyed by the interface rather than by the peer IP:
+```
+neighbor interface Ethernet3
+ description "Fabric spine-01/E1/1 spine-01--fabric--leaf-01"
+ remote-as 65100
+ bfd
+ bfd profile fabric
+ capability extended-nexthop
+ !
+ address-family ipv4 unicast
+  activate
+  route-map protocol-loopback-only out
+ !
+ address-family l2vpn evpn
+!
+```
+A deliberate differences from the [host-BGP](#host-bgp-subnets) sessions, which are also
+unnumbered: `remote-as` stays explicit rather than `remote-as external`. The peer ASN is
+what keeps a miscabled link from establishing and forming a topology we never intended.
+
+The per-node session over the protocol loopbacks is unaffected — it is IPv4-addressed and
+multihop either way.
+
 ### Mesh Connections (i.e. leaf-leaf)
 
 Mesh connections are very much similar to fabric ones, with the main difference being
@@ -359,6 +394,8 @@ loopback, e.g.:
      address-family l2vpn evpn
     !
     ```
+
+Mesh links support [unnumbered](#unnumbered-links) exactly as fabric links do.
 
 Additionally, once per neighboring node (no matter the number of mesh links to it)
 we create a BGP session with its protocol IP, for which we have learned a route over
@@ -405,7 +442,21 @@ to 3999) and configure it as an access VLAN on the interface of the connection:
      ip address 172.30.128.2/31
     ```
 
-The BGP configuration is unchanged.
+For a numbered link the BGP configuration is unchanged. For an
+[unnumbered](#unnumbered-links) one the VLAN interface gets `ipv6 enable` instead of an
+address, and the session is keyed by that interface rather than by the port:
+```
+interface Vlan3901
+ description "TH5 Workaround Mesh Port leaf-02/E1/5"
+ ipv6 enable
+!
+neighbor interface Vlan3901
+ [...]
+```
+The workaround is still needed, because the limitation is about the ingress interface being
+an SVI rather than a port-based routing interface, which has nothing to do with addressing.
+Each link gets its own dedicated VLAN, so the SVI has exactly one member port and the
+unnumbered peering over it stays one-to-one with the physical link.
 
 ### Gateway Connections
 
@@ -444,6 +495,8 @@ that the correct gateway route will be picked based on priorities/communities.
       allowas-in
       route-map l2vpn-neighbors in
     ```
+
+Gateway links are always numbered; the gateway does not support unnumbered yet.
 
 #### Workaround for TH5-based platforms
 

--- a/pkg/agent/dozer/bcm/enforcer.go
+++ b/pkg/agent/dozer/bcm/enforcer.go
@@ -103,6 +103,7 @@ const (
 	ActionWeightInterfaceSubinterfaceStaticARPDelete
 	ActionWeightVRFAttachedHostDelete
 	ActionWeightInterfaceSubinterfaceIPv6Delete
+	ActionWeightInterfaceVLANIPv6Delete
 	ActionWeightVRFInterfaceDelete
 	ActionWeightACLInterfaceDelete
 	ActionWeightVRFBGPNeighborDelete
@@ -121,6 +122,7 @@ const (
 	ActionWeightInterfaceSubinterfaceStaticARPUpdate
 	ActionWeightVRFInterfaceUpdate
 	ActionWeightInterfaceSubinterfaceIPv6Update
+	ActionWeightInterfaceVLANIPv6Update
 	ActionWeightVRFAttachedHostUpdate
 	ActionWeightInterfaceSubinterfaceIPsUpdate
 

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -549,39 +549,50 @@ func planFabricConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 			}
 			peers[peer] = true
 
-			if ipStr == "" {
-				return errors.Errorf("no IP found for fabric conn %s", connName)
+			// no IPs on either side means BGP unnumbered; a single missing IP is a broken link
+			if (ipStr == "") != (peerIP == "") {
+				return errors.Errorf("fabric conn %s has an IP on only one side of the %s link", connName, port)
 			}
+			unnumbered := ipStr == ""
 
-			ip, ipNet, err := net.ParseCIDR(ipStr)
-			if err != nil {
-				return errors.Wrapf(err, "failed to parse fabric conn ip %s", ipStr)
-			}
-			ipPrefixLen, _ := ipNet.Mask.Size()
-
-			spec.Interfaces[port] = &dozer.SpecInterface{
+			iface := &dozer.SpecInterface{
 				Enabled:     pointer.To(true),
 				Description: pointer.To(fmt.Sprintf("Fabric %s %s", remote, connName)),
 				Speed:       getPortSpeed(agent, port),
 				Subinterfaces: map[uint32]*dozer.SpecSubinterface{
-					0: {
-						IPs: map[string]*dozer.SpecInterfaceIP{
-							ip.String(): {
-								PrefixLen: pointer.To(uint8(ipPrefixLen)), //nolint:gosec
-							},
-						},
-					},
+					0: {},
 				},
 			}
+
+			// for unnumbered the neighbor is keyed by the interface instead of the peer IP
+			neighborKey := port
+			if unnumbered {
+				iface.Subinterfaces[0].IPv6 = &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}
+			} else {
+				ip, ipNet, err := net.ParseCIDR(ipStr)
+				if err != nil {
+					return errors.Wrapf(err, "failed to parse fabric conn ip %s", ipStr)
+				}
+				ipPrefixLen, _ := ipNet.Mask.Size()
+
+				iface.Subinterfaces[0].IPs = map[string]*dozer.SpecInterfaceIP{
+					ip.String(): {
+						PrefixLen: pointer.To(uint8(ipPrefixLen)), //nolint:gosec
+					},
+				}
+
+				peerAddr, _, err := net.ParseCIDR(peerIP)
+				if err != nil {
+					return errors.Wrapf(err, "failed to parse fabric conn peer ip %s", peerIP)
+				}
+				neighborKey = peerAddr.String()
+			}
+
+			spec.Interfaces[port] = iface
 
 			peerSw, ok := agent.Spec.Switches[peer]
 			if !ok {
 				return errors.Errorf("no switch found for peer %s (fabric conn %s)", peer, connName)
-			}
-
-			ip, _, err = net.ParseCIDR(peerIP)
-			if err != nil {
-				return errors.Wrapf(err, "failed to parse fabric conn peer ip %s", peerIP)
 			}
 
 			var bfdProfile *string
@@ -589,13 +600,21 @@ func planFabricConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 				bfdProfile = pointer.To(FabricBFDProfile)
 			}
 
-			spec.VRFs[VRFDefault].BGP.Neighbors[ip.String()] = &dozer.SpecVRFBGPNeighbor{
+			// leave it unset for numbered links so we don't touch existing neighbors
+			var extendedNexthop *bool
+			if unnumbered {
+				extendedNexthop = pointer.To(true)
+			}
+
+			// RemoteAS is set even for unnumbered so a miscabled link can't bring the session up
+			spec.VRFs[VRFDefault].BGP.Neighbors[neighborKey] = &dozer.SpecVRFBGPNeighbor{
 				Enabled:                   pointer.To(true),
 				Description:               pointer.To(fmt.Sprintf("Fabric %s %s", remote, connName)),
 				RemoteAS:                  pointer.To(peerSw.ASN),
 				IPv4Unicast:               pointer.To(true),
 				IPv4UnicastExportPolicies: []string{RouteMapProtocolLoopbackOnly},
 				BFDProfile:                bfdProfile,
+				ExtendedNexthop:           extendedNexthop,
 			}
 		}
 	}
@@ -665,15 +684,23 @@ func planMeshConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 			}
 			peers[peer] = true
 
-			if ipStr == "" {
-				return errors.Errorf("no IP found for mesh conn %s", connName)
+			// no IPs on either side means BGP unnumbered; a single missing IP is a broken link
+			if (ipStr == "") != (peerIP == "") {
+				return errors.Errorf("mesh conn %s has an IP on only one side of the %s link", connName, port)
 			}
+			unnumbered := ipStr == ""
 
-			ip, ipNet, err := net.ParseCIDR(ipStr)
-			if err != nil {
-				return errors.Wrapf(err, "failed to parse mesh conn ip %s", ipStr)
+			var ip net.IP
+			var ipPrefixLen int
+			if !unnumbered {
+				var ipNet *net.IPNet
+				var err error
+				ip, ipNet, err = net.ParseCIDR(ipStr)
+				if err != nil {
+					return errors.Wrapf(err, "failed to parse mesh conn ip %s", ipStr)
+				}
+				ipPrefixLen, _ = ipNet.Mask.Size()
 			}
-			ipPrefixLen, _ := ipNet.Mask.Size()
 
 			meshBaseIface := &dozer.SpecInterface{
 				Enabled:     pointer.To(true),
@@ -684,25 +711,38 @@ func planMeshConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 				},
 			}
 
+			// for unnumbered the neighbor is keyed by the interface instead of the peer IP; on TH5
+			// that interface is the workaround SVI below rather than the port
+			neighborKey := port
+
 			// For TH5 switches, use the workaround suggested by Broadcom: configure an Access VLAN that we previously
 			// allocated for this link and configure the IP address on the VLAN rather than the switch interface
-			if agent.Spec.SwitchProfile != nil && agent.Spec.SwitchProfile.SwitchSilicon == switchprofile.SiliconBroadcomTH5 {
+			switch {
+			case agent.Spec.SwitchProfile != nil && agent.Spec.SwitchProfile.SwitchSilicon == switchprofile.SiliconBroadcomTH5:
 				workaroundVLAN, ok := agent.Spec.Catalog.TH5WorkaroundVLANs[port]
 				if !ok {
 					return errors.Errorf("no TH5 workaround VLAN found for port %s of mesh connection %s", port, connName)
 				}
 				meshBaseIface.AccessVLAN = pointer.To(workaroundVLAN)
 				vlanIface := vlanName(workaroundVLAN)
-				spec.Interfaces[vlanIface] = &dozer.SpecInterface{
+				workaroundIface := &dozer.SpecInterface{
 					Enabled:     pointer.To(true),
 					Description: pointer.To(fmt.Sprintf("TH5 Workaround Mesh Port %s", port)),
-					VLANIPs: map[string]*dozer.SpecInterfaceIP{
+				}
+				if unnumbered {
+					workaroundIface.VLANIPv6 = &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}
+					neighborKey = vlanIface
+				} else {
+					workaroundIface.VLANIPs = map[string]*dozer.SpecInterfaceIP{
 						ip.String(): {
 							PrefixLen: pointer.To(uint8(ipPrefixLen)), //nolint:gosec
 						},
-					},
+					}
 				}
-			} else {
+				spec.Interfaces[vlanIface] = workaroundIface
+			case unnumbered:
+				meshBaseIface.Subinterfaces[0].IPv6 = &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}
+			default:
 				meshBaseIface.Subinterfaces[0].IPs = map[string]*dozer.SpecInterfaceIP{
 					ip.String(): {
 						PrefixLen: pointer.To(uint8(ipPrefixLen)), //nolint:gosec
@@ -717,9 +757,12 @@ func planMeshConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 				return errors.Errorf("no switch found for peer %s (mesh conn %s)", peer, connName)
 			}
 
-			ip, _, err = net.ParseCIDR(peerIP)
-			if err != nil {
-				return errors.Wrapf(err, "failed to parse mesh conn peer ip %s", peerIP)
+			if !unnumbered {
+				peerAddr, _, err := net.ParseCIDR(peerIP)
+				if err != nil {
+					return errors.Wrapf(err, "failed to parse mesh conn peer ip %s", peerIP)
+				}
+				neighborKey = peerAddr.String()
 			}
 
 			var bfdProfile *string
@@ -727,13 +770,21 @@ func planMeshConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 				bfdProfile = pointer.To(FabricBFDProfile)
 			}
 
-			spec.VRFs[VRFDefault].BGP.Neighbors[ip.String()] = &dozer.SpecVRFBGPNeighbor{
+			// leave it unset for numbered links so we don't touch existing neighbors
+			var extendedNexthop *bool
+			if unnumbered {
+				extendedNexthop = pointer.To(true)
+			}
+
+			// RemoteAS is set even for unnumbered so a miscabled link can't bring the session up
+			spec.VRFs[VRFDefault].BGP.Neighbors[neighborKey] = &dozer.SpecVRFBGPNeighbor{
 				Enabled:                   pointer.To(true),
 				Description:               pointer.To(fmt.Sprintf("Fabric %s %s", remote, connName)),
 				RemoteAS:                  pointer.To(peerSw.ASN),
 				IPv4Unicast:               pointer.To(true),
 				IPv4UnicastExportPolicies: []string{RouteMapProtocolLoopbackOnly},
 				BFDProfile:                bfdProfile,
+				ExtendedNexthop:           extendedNexthop,
 			}
 		}
 	}
@@ -3981,8 +4032,10 @@ func translatePortNames(agent *agentapi.Agent, spec *dozer.Spec) error {
 					if err != nil {
 						return errors.Wrapf(err, "failed to translate port name %s for BGP neighbor in vrf %s", name, vrfName)
 					}
-					if neighbor.Description != nil {
-						neighbor.Description = pointer.To(strings.ReplaceAll(*neighbor.Description, name, newName))
+					// only a trailing port name refers to this neighbor's own interface (hostBGP);
+					// a fabric/mesh description names the *remote* port, which must be left alone
+					if neighbor.Description != nil && strings.HasSuffix(*neighbor.Description, name) {
+						neighbor.Description = pointer.To(strings.TrimSuffix(*neighbor.Description, name) + newName)
 					}
 				}
 

--- a/pkg/agent/dozer/bcm/plan_test.go
+++ b/pkg/agent/dozer/bcm/plan_test.go
@@ -199,6 +199,12 @@ func TestPlan(t *testing.T) {
 		{name: "mesh-leaf-01"}, // eslag, gateway connected to it
 		{name: "mesh-leaf-02"}, // same as above
 		{name: "mesh-leaf-03"}, // standalone, bgp externals connected to it
+		// group: unnum
+		// the reg and mesh groups above with the fabric/mesh link IPs dropped, so those links run
+		// BGP unnumbered. Gateway links keep their IPs, the gateway does not support unnumbered yet
+		{name: "unnum-reg-spine-1"},  // spine side of unnumbered fabric links
+		{name: "unnum-reg-leaf-3"},   // leaf side of unnumbered fabric links
+		{name: "unnum-mesh-leaf-01"}, // unnumbered mesh links next to a numbered gateway link
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			updateGoldens := os.Getenv("UPDATE") == "true"

--- a/pkg/agent/dozer/bcm/plan_unnumbered_test.go
+++ b/pkg/agent/dozer/bcm/plan_unnumbered_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package bcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/agent/dozer"
+	"go.githedgehog.com/fabric/pkg/ctrl/switchprofile"
+)
+
+// A fabric or mesh link with no IPs on either side runs BGP unnumbered: IPv6 is enabled on the link
+// and the neighbor is keyed by the interface instead of the peer IP, but the peer ASN stays explicit
+// so a miscabled link cannot bring the session up. On TH5 the link lives on the workaround SVI
+// (see planMeshConnections), so that is the interface the peering runs over.
+func TestPlanUnnumberedFabricMeshLinks(t *testing.T) {
+	const (
+		self     = "leaf-01"
+		peer     = "leaf-02"
+		spine    = "spine-01"
+		selfPort = "E1/1"
+		peerASN  = uint32(65102)
+		wVLAN    = uint16(3001)
+	)
+
+	newAgent := func(silicon string, conn wiringapi.ConnectionSpec) *agentapi.Agent {
+		ag := &agentapi.Agent{}
+		ag.Name = self
+		ag.Spec.Switch.ProtocolIP = "172.30.11.1/32"
+		ag.Spec.Connections = map[string]wiringapi.ConnectionSpec{"conn-1": conn}
+		ag.Spec.Switches = map[string]wiringapi.SwitchSpec{
+			peer:  {ASN: peerASN, ProtocolIP: "172.30.11.2/32"},
+			spine: {ASN: peerASN, ProtocolIP: "172.30.11.3/32"},
+		}
+		ag.Spec.SwitchProfile = &wiringapi.SwitchProfileSpec{SwitchSilicon: silicon}
+		ag.Spec.Catalog.TH5WorkaroundVLANs = map[string]uint16{selfPort: wVLAN}
+
+		return ag
+	}
+
+	newSpec := func() *dozer.Spec {
+		return &dozer.Spec{
+			Interfaces:     map[string]*dozer.SpecInterface{},
+			RouteMaps:      map[string]*dozer.SpecRouteMap{},
+			PrefixLists:    map[string]*dozer.SpecPrefixList{},
+			CommunityLists: map[string]*dozer.SpecCommunityList{},
+			VRFs: map[string]*dozer.SpecVRF{
+				VRFDefault: {BGP: &dozer.SpecVRFBGP{Neighbors: map[string]*dozer.SpecVRFBGPNeighbor{}}},
+			},
+		}
+	}
+
+	meshConn := func(ip1, ip2 string) wiringapi.ConnectionSpec {
+		return wiringapi.ConnectionSpec{
+			Mesh: &wiringapi.ConnMesh{
+				Links: []wiringapi.MeshLink{{
+					Leaf1: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.BasePortName{Port: self + "/" + selfPort}, IP: ip1},
+					Leaf2: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.BasePortName{Port: peer + "/E1/2"}, IP: ip2},
+				}},
+			},
+		}
+	}
+
+	// planFabricConnections only runs in spine-leaf mode and needs the underlay route-map inputs
+	fabricAgent := func(ip1, ip2 string) *agentapi.Agent {
+		ag := newAgent(switchprofile.SiliconVS, wiringapi.ConnectionSpec{
+			Fabric: &wiringapi.ConnFabric{
+				Links: []wiringapi.FabricLink{{
+					Spine: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.BasePortName{Port: spine + "/E1/2"}, IP: ip2},
+					Leaf:  wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.BasePortName{Port: self + "/" + selfPort}, IP: ip1},
+				}},
+			},
+		})
+		ag.Spec.Switch.Role = wiringapi.SwitchRoleServerLeaf
+		ag.Spec.Config.SpineLeaf = &agentapi.AgentSpecConfigSpineLeaf{}
+		ag.Spec.Config.VTEPSubnet = "172.30.12.0/24"
+		ag.Spec.Config.ProtocolSubnet = "172.30.11.0/24"
+
+		return ag
+	}
+
+	t.Run("mesh unnumbered", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planMeshConnections(newAgent(switchprofile.SiliconVS, meshConn("", "")), spec))
+
+		sub := spec.Interfaces[selfPort].Subinterfaces[0]
+		require.NotNil(t, sub.IPv6)
+		require.True(t, *sub.IPv6.Enabled)
+		require.Empty(t, sub.IPs)
+
+		neigh, ok := spec.VRFs[VRFDefault].BGP.Neighbors[selfPort]
+		require.True(t, ok, "neighbor must be keyed by the port")
+		require.Equal(t, peerASN, *neigh.RemoteAS)
+		require.True(t, *neigh.ExtendedNexthop)
+		require.Equal(t, FabricBFDProfile, *neigh.BFDProfile)
+	})
+
+	t.Run("mesh numbered", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planMeshConnections(newAgent(switchprofile.SiliconVS, meshConn("172.30.128.0/31", "172.30.128.1/31")), spec))
+
+		sub := spec.Interfaces[selfPort].Subinterfaces[0]
+		require.Nil(t, sub.IPv6)
+		require.Contains(t, sub.IPs, "172.30.128.0")
+
+		neigh, ok := spec.VRFs[VRFDefault].BGP.Neighbors["172.30.128.1"]
+		require.True(t, ok, "neighbor must be keyed by the peer IP")
+		require.Nil(t, neigh.ExtendedNexthop)
+	})
+
+	t.Run("mesh unnumbered on TH5", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planMeshConnections(newAgent(switchprofile.SiliconBroadcomTH5, meshConn("", "")), spec))
+
+		require.Equal(t, wVLAN, *spec.Interfaces[selfPort].AccessVLAN)
+		require.Nil(t, spec.Interfaces[selfPort].Subinterfaces[0].IPv6, "the port itself stays L2 on TH5")
+
+		svi := spec.Interfaces[vlanName(wVLAN)]
+		require.NotNil(t, svi.VLANIPv6)
+		require.True(t, *svi.VLANIPv6.Enabled)
+		require.Empty(t, svi.VLANIPs)
+
+		_, ok := spec.VRFs[VRFDefault].BGP.Neighbors[vlanName(wVLAN)]
+		require.True(t, ok, "neighbor must be keyed by the workaround SVI")
+	})
+
+	t.Run("mesh numbered on TH5", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planMeshConnections(newAgent(switchprofile.SiliconBroadcomTH5, meshConn("172.30.128.0/31", "172.30.128.1/31")), spec))
+
+		svi := spec.Interfaces[vlanName(wVLAN)]
+		require.Nil(t, svi.VLANIPv6)
+		require.Contains(t, svi.VLANIPs, "172.30.128.0")
+
+		_, ok := spec.VRFs[VRFDefault].BGP.Neighbors["172.30.128.1"]
+		require.True(t, ok)
+	})
+
+	t.Run("fabric unnumbered", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planFabricConnections(fabricAgent("", ""), spec))
+
+		sub := spec.Interfaces[selfPort].Subinterfaces[0]
+		require.NotNil(t, sub.IPv6)
+		require.Empty(t, sub.IPs)
+
+		neigh, ok := spec.VRFs[VRFDefault].BGP.Neighbors[selfPort]
+		require.True(t, ok, "neighbor must be keyed by the port")
+		require.Equal(t, peerASN, *neigh.RemoteAS)
+		require.True(t, *neigh.ExtendedNexthop)
+	})
+
+	t.Run("half numbered links are rejected", func(t *testing.T) {
+		require.Error(t, planMeshConnections(newAgent(switchprofile.SiliconVS, meshConn("172.30.128.0/31", "")), newSpec()))
+		require.Error(t, planMeshConnections(newAgent(switchprofile.SiliconVS, meshConn("", "172.30.128.1/31")), newSpec()))
+
+		require.Error(t, planFabricConnections(fabricAgent("172.30.128.0/31", ""), newSpec()))
+	})
+}

--- a/pkg/agent/dozer/bcm/spec_interface.go
+++ b/pkg/agent/dozer/bcm/spec_interface.go
@@ -85,6 +85,15 @@ var specInterfaceEnforcer = &DefaultValueEnforcer[string, *dozer.SpecInterface]{
 			return errors.Wrap(err, "failed to handle interface IPs")
 		}
 
+		// same as for subinterfaces, diff just the IPv6 leaf so that dropping it from a VLAN
+		// interface that otherwise stays is a delete rather than an update with an empty config
+		vlanIPv6Path := basePath + "/routed-vlan/ipv6/config/enabled"
+		actualVLANV6, desiredVLANV6 := ValueOrNil(actual, desired,
+			func(value *dozer.SpecInterface) *dozer.SpecInterfaceIPv6 { return value.VLANIPv6 })
+		if err := specInterfaceVLANIPv6Enforcer.Handle(vlanIPv6Path, name, actualVLANV6, desiredVLANV6, actions); err != nil {
+			return errors.Wrap(err, "failed to handle interface VLAN ipv6")
+		}
+
 		actualStaticARPs, desiredStaticARPs := ValueOrNil(actual, desired,
 			func(value *dozer.SpecInterface) map[string]*dozer.SpecStaticARP { return value.StaticARPs })
 		if err := specInterfaceVLANStaticARPsEnforcer.Handle(basePath, actualStaticARPs, desiredStaticARPs, actions); err != nil {
@@ -234,6 +243,21 @@ var specInterfaceVLANIPEnforcer = &DefaultValueEnforcer[string, *dozer.SpecInter
 				},
 			},
 		}, nil
+	},
+}
+
+var specInterfaceVLANIPv6Enforcer = &DefaultValueEnforcer[string, *dozer.SpecInterfaceIPv6]{
+	Summary:      "Interface %s VLAN IPv6 Enable",
+	NoReplace:    true,
+	UpdateWeight: ActionWeightInterfaceVLANIPv6Update,
+	DeleteWeight: ActionWeightInterfaceVLANIPv6Delete,
+	Marshal: func(_ string, value *dozer.SpecInterfaceIPv6) (ygot.ValidatedGoStruct, error) {
+		cfg := &oc.OpenconfigInterfaces_Interfaces_Interface_RoutedVlan_Ipv6_Config{}
+		if value != nil && value.Enabled != nil {
+			cfg.Enabled = value.Enabled
+		}
+
+		return cfg, nil
 	},
 }
 
@@ -901,6 +925,17 @@ func unmarshalOCInterfaces(agent *agentapi.Agent, ocVal *oc.OpenconfigInterfaces
 							IP:  *n.Config.Ip,
 							MAC: *n.Config.LinkLayerAddress,
 						}
+					}
+				}
+			}
+
+			// only set v6 enable if it exists and is true, and check the state flag too, same
+			// config-flag issue as on subinterfaces
+			if ocIface.RoutedVlan.Ipv6 != nil {
+				if (ocIface.RoutedVlan.Ipv6.Config != nil && ocIface.RoutedVlan.Ipv6.Config.Enabled != nil && *ocIface.RoutedVlan.Ipv6.Config.Enabled) ||
+					(ocIface.RoutedVlan.Ipv6.State != nil && ocIface.RoutedVlan.Ipv6.State.Enabled != nil && *ocIface.RoutedVlan.Ipv6.State.Enabled) {
+					iface.VLANIPv6 = &dozer.SpecInterfaceIPv6{
+						Enabled: pointer.To(true),
 					}
 				}
 			}

--- a/pkg/agent/dozer/bcm/spec_interface_ipv6_test.go
+++ b/pkg/agent/dozer/bcm/spec_interface_ipv6_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.githedgehog.com/fabric/pkg/agent/dozer"
+	"go.githedgehog.com/fabric/pkg/agent/dozer/bcm/gnmi"
 	"go.githedgehog.com/fabric/pkg/util/pointer"
 )
 
@@ -179,6 +180,15 @@ func TestSpecInterfaceVLANIPv6Enforcer(t *testing.T) {
 					continue
 				}
 				ipv6Actions = append(ipv6Actions, Action{Weight: act.Weight, Type: act.Type, Path: act.Path})
+
+				// the routed-vlan IPv6 container has no golden coverage (every plan fixture is vs
+				// silicon, so the TH5 branch that sets VLANIPv6 is never planned), so check the
+				// marshalled payload here instead
+				if act.Type == ActionTypeUpdate {
+					val, err := gnmi.Marshal(act.Value)
+					require.NoError(t, err)
+					require.Equal(t, map[string]any{"enabled": true}, val)
+				}
 			}
 
 			require.Len(t, ipv6Actions, len(tt.wantActions))

--- a/pkg/agent/dozer/bcm/spec_interface_ipv6_test.go
+++ b/pkg/agent/dozer/bcm/spec_interface_ipv6_test.go
@@ -103,3 +103,92 @@ func TestSpecInterfaceSubinterfaceIPv6Enforcer(t *testing.T) {
 	// the IPv6 enable must be removed before the port leaves the VRF
 	require.Less(t, ActionWeightInterfaceSubinterfaceIPv6Delete, ActionWeightVRFInterfaceDelete)
 }
+
+// On TH5 the mesh link IP lives on an SVI rather than the port, so an unnumbered mesh link needs
+// IPv6 enabled on that SVI. Same delete-before-VRF-detach constraint as the subinterface case.
+func TestSpecInterfaceVLANIPv6Enforcer(t *testing.T) {
+	const iface = IfacePrefixVLAN + "3000"
+	const path = "/interfaces/interface[name=Vlan3000]/routed-vlan/ipv6/config/enabled"
+
+	for _, tt := range []struct {
+		name        string
+		actual      *dozer.SpecInterface
+		desired     *dozer.SpecInterface
+		wantActions []Action
+	}{
+		{
+			name:    "ipv6 dropped, VLAN interface stays",
+			actual:  &dozer.SpecInterface{VLANIPv6: &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}},
+			desired: &dozer.SpecInterface{},
+			wantActions: []Action{{
+				Weight: ActionWeightInterfaceVLANIPv6Delete,
+				Type:   ActionTypeDelete,
+				Path:   path,
+			}},
+		},
+		{
+			name:    "ipv6 dropped along with the VLAN interface",
+			actual:  &dozer.SpecInterface{VLANIPv6: &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}},
+			desired: nil,
+			wantActions: []Action{{
+				Weight: ActionWeightInterfaceVLANIPv6Delete,
+				Type:   ActionTypeDelete,
+				Path:   path,
+			}},
+		},
+		{
+			name:    "ipv6 enabled",
+			actual:  &dozer.SpecInterface{},
+			desired: &dozer.SpecInterface{VLANIPv6: &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}},
+			wantActions: []Action{{
+				Weight: ActionWeightInterfaceVLANIPv6Update,
+				Type:   ActionTypeUpdate,
+				Path:   path,
+			}},
+		},
+		{
+			name:        "ipv6 unchanged",
+			actual:      &dozer.SpecInterface{VLANIPv6: &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}},
+			desired:     &dozer.SpecInterface{VLANIPv6: &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)}},
+			wantActions: nil,
+		},
+		{
+			// switching a TH5 mesh link from numbered to unnumbered: the IPv4 address goes away
+			// and IPv6 comes up on the same SVI
+			name:   "numbered to unnumbered",
+			actual: &dozer.SpecInterface{VLANIPs: map[string]*dozer.SpecInterfaceIP{"172.30.128.0": {PrefixLen: pointer.To(uint8(31))}}},
+			desired: &dozer.SpecInterface{
+				VLANIPv6: &dozer.SpecInterfaceIPv6{Enabled: pointer.To(true)},
+			},
+			wantActions: []Action{{
+				Weight: ActionWeightInterfaceVLANIPv6Update,
+				Type:   ActionTypeUpdate,
+				Path:   path,
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actions := &ActionQueue{}
+			err := specInterfaceEnforcer.Handle("", iface, tt.actual, tt.desired, actions)
+			require.NoError(t, err)
+
+			ipv6Actions := []Action{}
+			for _, a := range actions.actions {
+				act := a.(*Action)
+				if act.Weight != ActionWeightInterfaceVLANIPv6Delete && act.Weight != ActionWeightInterfaceVLANIPv6Update {
+					continue
+				}
+				ipv6Actions = append(ipv6Actions, Action{Weight: act.Weight, Type: act.Type, Path: act.Path})
+			}
+
+			require.Len(t, ipv6Actions, len(tt.wantActions))
+			for idx, want := range tt.wantActions {
+				require.Equal(t, want, ipv6Actions[idx])
+			}
+		})
+	}
+
+	// the IPv6 enable must be removed before the SVI leaves the VRF, and applied only after it joined
+	require.Less(t, ActionWeightInterfaceVLANIPv6Delete, ActionWeightVRFInterfaceDelete)
+	require.Greater(t, ActionWeightInterfaceVLANIPv6Update, ActionWeightVRFInterfaceUpdate)
+}

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
@@ -2417,7 +2417,7 @@
   value:
     trunk-vlans:
     - 1003
-  weight: 42
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2426,7 +2426,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]
   summary: Create Subinterface Base 10
   type: update
@@ -2438,7 +2438,7 @@
       vlan:
         config:
           vlan-id: 10
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=20]
   summary: Create Subinterface Base 20
   type: update
@@ -2450,7 +2450,7 @@
       vlan:
         config:
           vlan-id: 20
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2459,7 +2459,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2468,7 +2468,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2480,7 +2480,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2492,7 +2492,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2501,7 +2501,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2513,7 +2513,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2525,7 +2525,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2534,7 +2534,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2543,7 +2543,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2552,7 +2552,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2561,7 +2561,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2570,7 +2570,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2579,7 +2579,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2588,7 +2588,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/interfaces/interface[id=Ethernet0.20]
   summary: Create VRF interface Ethernet0.20
   type: update
@@ -2597,7 +2597,7 @@
     - config:
         id: Ethernet0.20
       id: Ethernet0.20
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2606,7 +2606,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/interfaces/interface[id=Ethernet0.10]
   summary: Create VRF interface Ethernet0.10
   type: update
@@ -2615,7 +2615,7 @@
     - config:
         id: Ethernet0.10
       id: Ethernet0.10
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2624,7 +2624,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet2.1001]
   summary: Create VRF interface Ethernet2.1001
   type: update
@@ -2633,7 +2633,7 @@
     - config:
         id: Ethernet2.1001
       id: Ethernet2.1001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet3.1001]
   summary: Create VRF interface Ethernet3.1001
   type: update
@@ -2642,7 +2642,7 @@
     - config:
         id: Ethernet3.1001
       id: Ethernet3.1001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2651,7 +2651,7 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet2.1002]
   summary: Create VRF interface Ethernet2.1002
   type: update
@@ -2660,7 +2660,7 @@
     - config:
         id: Ethernet2.1002
       id: Ethernet2.1002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet3.1002]
   summary: Create VRF interface Ethernet3.1002
   type: update
@@ -2669,7 +2669,7 @@
     - config:
         id: Ethernet3.1002
       id: Ethernet3.1002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3003]
   summary: Create VRF interface Vlan3003
   type: update
@@ -2678,7 +2678,7 @@
     - config:
         id: Vlan3003
       id: Vlan3003
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1003]
   summary: Create VRF interface Vlan1003
   type: update
@@ -2687,7 +2687,7 @@
     - config:
         id: Vlan1003
       id: Vlan1003
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3004]
   summary: Create VRF interface Vlan3004
   type: update
@@ -2696,31 +2696,31 @@
     - config:
         id: Vlan3004
       id: Vlan3004
-  weight: 46
+  weight: 47
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1003]
   summary: Create VRF attached host
   type: update
@@ -2731,7 +2731,7 @@
         address-family: IPV4
         interface-id: Vlan1003
       interface-id: Vlan1003
-  weight: 48
+  weight: 50
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.16.0
   type: update
@@ -2742,7 +2742,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.16.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=20]/ipv4/addresses/address
   summary: Create Subinterface IP 100.1.20.2
   type: update
@@ -2753,7 +2753,7 @@
         prefix-length: 24
         secondary: false
       ip: 100.1.20.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.1
   type: update
@@ -2764,7 +2764,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.1
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.3
   type: update
@@ -2775,7 +2775,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.3
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.11
   type: update
@@ -2786,7 +2786,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.11
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.13
   type: update
@@ -2797,7 +2797,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.13
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.2
   type: update
@@ -2808,7 +2808,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.0
   type: update
@@ -2819,7 +2819,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.9
   type: update
@@ -2830,14 +2830,14 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.9
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/proxy-arp/config
   summary: Create Subinterface 10 Proxy-ARP
   type: update
   value:
     config:
       mode: REMOTE_ONLY
-  weight: 51
+  weight: 53
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2845,7 +2845,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2855,7 +2855,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1003
   type: update
@@ -2863,7 +2863,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -2871,7 +2871,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3003
   type: update
@@ -2879,7 +2879,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3004
   type: update
@@ -2887,7 +2887,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3004
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=0.0.0.0/0]
   summary: Create VRF static route 0.0.0.0/0
   type: update
@@ -2905,7 +2905,7 @@
             config:
               interface: Eth0.20
       prefix: 0.0.0.0/0
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=100.1.20.1/32]
   summary: Create VRF static route 100.1.20.1/32
   type: update
@@ -2922,7 +2922,7 @@
             config:
               interface: Eth0.20
       prefix: 100.1.20.1/32
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=0.0.0.0/0]
   summary: Create VRF static route 0.0.0.0/0
   type: update
@@ -2940,7 +2940,7 @@
             config:
               interface: Eth0.10
       prefix: 0.0.0.0/0
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=STATIC][name=static]/static-routes/static[prefix=100.1.10.1/32]
   summary: Create VRF static route 100.1.10.1/32
   type: update
@@ -2957,73 +2957,73 @@
             config:
               interface: Eth0.10
       prefix: 100.1.10.1/32
-  weight: 61
+  weight: 63
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/global-sag/config
   summary: Create VRF VrfEext-snp-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/global-sag/config
   summary: Create VRF VrfEext-sp-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/evpn/evpn-mh/config
   summary: Create VRF VrfEext-snp-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/evpn/evpn-mh/config
   summary: Create VRF VrfEext-sp-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -3032,7 +3032,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.0
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -3040,7 +3040,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_100_Vlan3000
   type: update
@@ -3050,7 +3050,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 100
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3001
   type: update
@@ -3060,7 +3060,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3002
   type: update
@@ -3070,7 +3070,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3003
   type: update
@@ -3080,7 +3080,7 @@
       name: vtepfabric
       vlan: Vlan3003
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_500_Vlan3004
   type: update
@@ -3090,7 +3090,7 @@
       name: vtepfabric
       vlan: Vlan3004
       vni: 500
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ext-inbound--leaf-01--ext-snp-02 base
   type: update
@@ -3102,7 +3102,7 @@
         type: ACL_IPV4
       name: ext-inbound--leaf-01--ext-snp-02
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
@@ -3114,7 +3114,7 @@
         type: ACL_IPV4
       name: ipns-egress--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -3126,7 +3126,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3145,7 +3145,7 @@
       transport:
         config:
           destination-port: 443
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 2
   type: update
@@ -3164,7 +3164,7 @@
       transport:
         config:
           destination-port: 8080
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 3
   type: update
@@ -3183,7 +3183,7 @@
       transport:
         config:
           destination-port: 67
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 4
   type: update
@@ -3202,7 +3202,7 @@
       transport:
         config:
           destination-port: 161
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 5
   type: update
@@ -3221,7 +3221,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 6
   type: update
@@ -3240,7 +3240,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 15
   type: update
@@ -3259,7 +3259,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 20
   type: update
@@ -3278,7 +3278,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 25
   type: update
@@ -3294,7 +3294,7 @@
           destination-address: 10.50.10.3/32
           protocol: IP_TCP
       sequence-id: 25
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-01--ext-snp-02][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 30
   type: update
@@ -3310,7 +3310,7 @@
           destination-address: 10.50.10.3/32
           protocol: IP_UDP
       sequence-id: 30
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -3325,7 +3325,7 @@
         config:
           destination-address: 10.0.0.0/16
       sequence-id: 10
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3337,7 +3337,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3353,7 +3353,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3365,7 +3365,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/interfaces/interface[id=Ethernet0.20]
   summary: Create ACL interface Ethernet0.20
   type: update
@@ -3378,7 +3378,7 @@
         config:
           interface: Ethernet0
           subinterface: 20
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Ethernet0.20]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Ethernet0.20 ingress
   type: update
@@ -3389,7 +3389,7 @@
         type: ACL_IPV4
       set-name: ext-inbound--leaf-01--ext-snp-02
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]
   summary: Create ACL interface Vlan3000
   type: update
@@ -3401,7 +3401,7 @@
       interface-ref:
         config:
           interface: Vlan3000
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3000 ingress
   type: update
@@ -3412,7 +3412,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3001]
   summary: Create ACL interface Vlan3001
   type: update
@@ -3424,7 +3424,7 @@
       interface-ref:
         config:
           interface: Vlan3001
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3001]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3001 ingress
   type: update
@@ -3435,7 +3435,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEext-snp-02 BGP base
   type: update
@@ -3455,7 +3455,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEext-sp-01 BGP base
   type: update
@@ -3475,7 +3475,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -3495,7 +3495,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -3515,7 +3515,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -3535,7 +3535,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -3555,7 +3555,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEext-snp-02 BGP L2VPN
   type: update
@@ -3570,7 +3570,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEext-sp-01 BGP L2VPN
   type: update
@@ -3585,7 +3585,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -3600,7 +3600,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -3615,7 +3615,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -3630,7 +3630,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -3644,7 +3644,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -3658,7 +3658,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -3667,7 +3667,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -3678,7 +3678,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -3689,7 +3689,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -3700,7 +3700,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -3711,7 +3711,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -3721,7 +3721,7 @@
         ipv4-drop-neighbor-aging-time: 60
         name: Values
       name: Values
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1001]
   summary: Create VRF BGP neighbor Ethernet2.1001
   type: update
@@ -3748,7 +3748,7 @@
         neighbor-address: Ethernet2.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1001
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3.1001]
   summary: Create VRF BGP neighbor Ethernet3.1001
   type: update
@@ -3775,7 +3775,7 @@
         neighbor-address: Ethernet3.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet3.1001
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1002]
   summary: Create VRF BGP neighbor Ethernet2.1002
   type: update
@@ -3802,7 +3802,7 @@
         neighbor-address: Ethernet2.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1002
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3.1002]
   summary: Create VRF BGP neighbor Ethernet3.1002
   type: update
@@ -3829,7 +3829,7 @@
         neighbor-address: Ethernet3.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet3.1002
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.0]
   summary: Create VRF BGP neighbor 172.30.128.0
   type: update
@@ -3858,7 +3858,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.10]
   summary: Create VRF BGP neighbor 172.30.128.10
   type: update
@@ -3887,7 +3887,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.10
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -3916,7 +3916,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -3945,7 +3945,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3979,7 +3979,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -4013,7 +4013,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -4022,7 +4022,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4035,7 +4035,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4048,7 +4048,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4061,7 +4061,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4076,7 +4076,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4091,7 +4091,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4104,7 +4104,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4119,7 +4119,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4134,7 +4134,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4147,7 +4147,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4162,7 +4162,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4177,7 +4177,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4190,7 +4190,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4203,65 +4203,65 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-snp-02
   type: update
   value:
     policy-name: ext-import--ext-snp-02
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfEext-sp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-sp-01
   type: update
   value:
     policy-name: ext-import--ext-sp-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfEext-snp-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEext-snp-02
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfEext-snp-02
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -4276,7 +4276,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 90
+  weight: 92
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -4285,4 +4285,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
@@ -2174,7 +2174,7 @@
   value:
     trunk-vlans:
     - 1003
-  weight: 42
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2183,7 +2183,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2192,7 +2192,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2204,7 +2204,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2216,7 +2216,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2225,7 +2225,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]
   summary: Create Subinterface Base 1001
   type: update
@@ -2237,7 +2237,7 @@
       vlan:
         config:
           vlan-id: 1001
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]
   summary: Create Subinterface Base 1002
   type: update
@@ -2249,7 +2249,7 @@
       vlan:
         config:
           vlan-id: 1002
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2258,7 +2258,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2267,7 +2267,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2276,7 +2276,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2285,7 +2285,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2294,7 +2294,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2303,7 +2303,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2312,7 +2312,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet1.1001]
   summary: Create VRF interface Ethernet1.1001
   type: update
@@ -2321,7 +2321,7 @@
     - config:
         id: Ethernet1.1001
       id: Ethernet1.1001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Ethernet2.1001]
   summary: Create VRF interface Ethernet2.1001
   type: update
@@ -2330,7 +2330,7 @@
     - config:
         id: Ethernet2.1001
       id: Ethernet2.1001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2339,7 +2339,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet1.1002]
   summary: Create VRF interface Ethernet1.1002
   type: update
@@ -2348,7 +2348,7 @@
     - config:
         id: Ethernet1.1002
       id: Ethernet1.1002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Ethernet2.1002]
   summary: Create VRF interface Ethernet2.1002
   type: update
@@ -2357,7 +2357,7 @@
     - config:
         id: Ethernet2.1002
       id: Ethernet2.1002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2366,7 +2366,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1003]
   summary: Create VRF interface Vlan1003
   type: update
@@ -2375,7 +2375,7 @@
     - config:
         id: Vlan1003
       id: Vlan1003
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2384,31 +2384,31 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 46
+  weight: 47
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1001]/ipv6/config/enabled
   summary: Create Subinterface 1001 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=1002]/ipv6/config/enabled
   summary: Create Subinterface 1002 IPv6 Enable
   type: update
   value:
     enabled: true
-  weight: 47
+  weight: 48
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1003]
   summary: Create VRF attached host
   type: update
@@ -2419,7 +2419,7 @@
         address-family: IPV4
         interface-id: Vlan1003
       interface-id: Vlan1003
-  weight: 48
+  weight: 50
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.5
   type: update
@@ -2430,7 +2430,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.5
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.7
   type: update
@@ -2441,7 +2441,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.7
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.15
   type: update
@@ -2452,7 +2452,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.15
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.17
   type: update
@@ -2463,7 +2463,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.17
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.3
   type: update
@@ -2474,7 +2474,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.3
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.1
   type: update
@@ -2485,7 +2485,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.1
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.10
   type: update
@@ -2496,7 +2496,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.10
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2504,7 +2504,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2514,7 +2514,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1003
   type: update
@@ -2522,7 +2522,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2530,7 +2530,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -2538,7 +2538,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -2546,51 +2546,51 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2599,7 +2599,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.1
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2607,7 +2607,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3000
   type: update
@@ -2617,7 +2617,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3001
   type: update
@@ -2627,7 +2627,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_500_Vlan3002
   type: update
@@ -2637,7 +2637,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 500
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2649,7 +2649,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2665,7 +2665,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2677,7 +2677,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -2697,7 +2697,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -2717,7 +2717,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -2737,7 +2737,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2757,7 +2757,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.3
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -2772,7 +2772,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -2787,7 +2787,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -2802,7 +2802,7 @@
           - advertise-afi-safi: IPV4_UNICAST
             config:
               advertise-afi-safi: IPV4_UNICAST
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2816,7 +2816,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2830,7 +2830,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2839,7 +2839,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -2850,7 +2850,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2861,7 +2861,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2872,7 +2872,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2883,7 +2883,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -2893,7 +2893,7 @@
         ipv4-drop-neighbor-aging-time: 60
         name: Values
       name: Values
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet1.1001]
   summary: Create VRF BGP neighbor Ethernet1.1001
   type: update
@@ -2920,7 +2920,7 @@
         neighbor-address: Ethernet1.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet1.1001
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1001]
   summary: Create VRF BGP neighbor Ethernet2.1001
   type: update
@@ -2947,7 +2947,7 @@
         neighbor-address: Ethernet2.1001
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1001
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet1.1002]
   summary: Create VRF BGP neighbor Ethernet1.1002
   type: update
@@ -2974,7 +2974,7 @@
         neighbor-address: Ethernet1.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet1.1002
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2.1002]
   summary: Create VRF BGP neighbor Ethernet2.1002
   type: update
@@ -3001,7 +3001,7 @@
         neighbor-address: Ethernet2.1002
         peer-type: EXTERNAL
       neighbor-address: Ethernet2.1002
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -3030,7 +3030,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.16]
   summary: Create VRF BGP neighbor 172.30.128.16
   type: update
@@ -3059,7 +3059,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.16
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.4]
   summary: Create VRF BGP neighbor 172.30.128.4
   type: update
@@ -3088,7 +3088,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.4
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.6]
   summary: Create VRF BGP neighbor 172.30.128.6
   type: update
@@ -3117,7 +3117,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.6
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3151,7 +3151,7 @@
       transport:
         config:
           local-address: 172.30.8.3
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -3185,7 +3185,7 @@
       transport:
         config:
           local-address: 172.30.8.3
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.3/32]
   summary: Create VRF BGP network 172.30.8.3/32
   type: update
@@ -3194,7 +3194,7 @@
     - config:
         prefix: 172.30.8.3/32
       prefix: 172.30.8.3/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3207,7 +3207,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3222,7 +3222,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3237,7 +3237,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3250,7 +3250,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3265,7 +3265,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3280,7 +3280,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -3293,7 +3293,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3308,7 +3308,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3323,7 +3323,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -3336,7 +3336,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -3349,39 +3349,39 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -3396,7 +3396,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 90
+  weight: 92
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -3405,4 +3405,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-spine-01.out.actions.expected.yaml
@@ -524,7 +524,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -533,7 +533,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -542,7 +542,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -551,7 +551,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -560,7 +560,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -569,7 +569,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -578,7 +578,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.0
   type: update
@@ -589,7 +589,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.2
   type: update
@@ -600,7 +600,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.4
   type: update
@@ -611,7 +611,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.4
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.6
   type: update
@@ -622,7 +622,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.6
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.8
   type: update
@@ -633,7 +633,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.8
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.0
   type: update
@@ -644,7 +644,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.7
   type: update
@@ -655,7 +655,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.7
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -663,7 +663,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -673,18 +673,18 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -696,7 +696,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -712,7 +712,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -724,7 +724,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -744,7 +744,7 @@
           as: 65100
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -758,7 +758,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -772,7 +772,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -781,7 +781,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet0]/link-flap
   summary: Create ErrDisable Interface Ethernet0
   type: update
@@ -792,7 +792,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet1]/link-flap
   summary: Create ErrDisable Interface Ethernet1
   type: update
@@ -803,7 +803,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet2]/link-flap
   summary: Create ErrDisable Interface Ethernet2
   type: update
@@ -814,7 +814,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -825,7 +825,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -836,7 +836,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
   summary: Create VRF BGP neighbor 172.30.128.1
   type: update
@@ -865,7 +865,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -894,7 +894,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -923,7 +923,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -952,7 +952,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -985,7 +985,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -1019,7 +1019,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.3]
   summary: Create VRF BGP neighbor 172.30.8.3
   type: update
@@ -1053,7 +1053,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -1062,7 +1062,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -1075,7 +1075,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -1088,7 +1088,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -1097,4 +1097,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-01.out.actions.expected.yaml
@@ -1791,7 +1791,7 @@
   value:
     trunk-vlans:
     - 1002
-  weight: 42
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1800,7 +1800,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1809,7 +1809,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1818,7 +1818,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1827,7 +1827,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1836,7 +1836,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1845,7 +1845,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1854,7 +1854,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1863,7 +1863,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1872,7 +1872,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1881,7 +1881,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1890,7 +1890,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1899,7 +1899,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1908,7 +1908,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan1001]
   summary: Create VRF interface Vlan1001
   type: update
@@ -1917,7 +1917,7 @@
     - config:
         id: Vlan1001
       id: Vlan1001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -1926,7 +1926,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan1002]
   summary: Create VRF interface Vlan1002
   type: update
@@ -1935,7 +1935,7 @@
     - config:
         id: Vlan1002
       id: Vlan1002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -1944,7 +1944,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1001]
   summary: Create VRF attached host
   type: update
@@ -1955,7 +1955,7 @@
         address-family: IPV4
         interface-id: Vlan1001
       interface-id: Vlan1001
-  weight: 48
+  weight: 50
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1002]
   summary: Create VRF attached host
   type: update
@@ -1966,7 +1966,7 @@
         address-family: IPV4
         interface-id: Vlan1002
       interface-id: Vlan1002
-  weight: 48
+  weight: 50
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.2
   type: update
@@ -1977,7 +1977,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.4
   type: update
@@ -1988,7 +1988,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.4
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.6
   type: update
@@ -1999,7 +1999,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.6
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.8
   type: update
@@ -2010,7 +2010,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.8
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.0
   type: update
@@ -2021,7 +2021,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.0
   type: update
@@ -2032,7 +2032,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.0
   type: update
@@ -2043,7 +2043,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.7
   type: update
@@ -2054,7 +2054,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.7
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2062,7 +2062,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2072,7 +2072,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1001
   type: update
@@ -2080,7 +2080,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1002
   type: update
@@ -2088,7 +2088,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2096,7 +2096,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -2104,36 +2104,36 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -2141,7 +2141,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -2153,7 +2153,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -2165,7 +2165,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -2176,7 +2176,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet3]
   summary: Create LST Interface Ethernet3
   type: update
@@ -2193,7 +2193,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -2210,7 +2210,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -2227,7 +2227,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -2244,7 +2244,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2253,7 +2253,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.0
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2261,7 +2261,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3000
   type: update
@@ -2271,7 +2271,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_201_Vlan1001
   type: update
@@ -2281,7 +2281,7 @@
       name: vtepfabric
       vlan: Vlan1001
       vni: 201
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3001
   type: update
@@ -2291,7 +2291,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1002
   type: update
@@ -2301,7 +2301,7 @@
       name: vtepfabric
       vlan: Vlan1002
       vni: 301
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2313,7 +2313,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2329,7 +2329,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2341,7 +2341,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -2361,7 +2361,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -2381,7 +2381,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2401,7 +2401,7 @@
           as: 65101
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -2418,7 +2418,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -2435,7 +2435,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2449,7 +2449,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2463,7 +2463,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2472,7 +2472,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -2483,7 +2483,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2494,7 +2494,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2505,7 +2505,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2516,7 +2516,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2527,7 +2527,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -2537,7 +2537,7 @@
         ipv4-drop-neighbor-aging-time: 60
         name: Values
       name: Values
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
   summary: Create VRF BGP neighbor 172.30.128.1
   type: update
@@ -2570,7 +2570,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -2599,7 +2599,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -2628,7 +2628,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -2657,7 +2657,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -2686,7 +2686,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2720,7 +2720,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -2754,7 +2754,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -2763,7 +2763,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2776,7 +2776,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2791,7 +2791,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2806,7 +2806,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2819,7 +2819,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2834,7 +2834,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2849,7 +2849,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2862,7 +2862,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2875,33 +2875,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -2916,7 +2916,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 90
+  weight: 92
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -2931,7 +2931,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 90
+  weight: 92
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -2940,4 +2940,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-02.out.actions.expected.yaml
@@ -1840,7 +1840,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1849,7 +1849,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1858,7 +1858,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1867,7 +1867,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1876,7 +1876,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1885,7 +1885,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1894,7 +1894,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1903,7 +1903,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1912,7 +1912,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1921,7 +1921,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1930,7 +1930,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1939,7 +1939,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1948,7 +1948,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1957,7 +1957,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1966,7 +1966,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan1001]
   summary: Create VRF interface Vlan1001
   type: update
@@ -1975,7 +1975,7 @@
     - config:
         id: Vlan1001
       id: Vlan1001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -1984,7 +1984,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan1002]
   summary: Create VRF interface Vlan1002
   type: update
@@ -1993,7 +1993,7 @@
     - config:
         id: Vlan1002
       id: Vlan1002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2002,7 +2002,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1001]
   summary: Create VRF attached host
   type: update
@@ -2013,7 +2013,7 @@
         address-family: IPV4
         interface-id: Vlan1001
       interface-id: Vlan1001
-  weight: 48
+  weight: 50
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1002]
   summary: Create VRF attached host
   type: update
@@ -2024,7 +2024,7 @@
         address-family: IPV4
         interface-id: Vlan1002
       interface-id: Vlan1002
-  weight: 48
+  weight: 50
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.3
   type: update
@@ -2035,7 +2035,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.3
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.5
   type: update
@@ -2046,7 +2046,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.5
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.12
   type: update
@@ -2057,7 +2057,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.12
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.14
   type: update
@@ -2068,7 +2068,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.14
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.10
   type: update
@@ -2079,7 +2079,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.10
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.1
   type: update
@@ -2090,7 +2090,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.1
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.1
   type: update
@@ -2101,7 +2101,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.1
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.8
   type: update
@@ -2112,7 +2112,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.8
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2120,7 +2120,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2130,7 +2130,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1001
   type: update
@@ -2138,7 +2138,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1002
   type: update
@@ -2146,7 +2146,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2154,7 +2154,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -2162,36 +2162,36 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
   summary: Create VRF VrfVvpc-02 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-02 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -2199,7 +2199,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -2211,7 +2211,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -2223,7 +2223,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -2234,7 +2234,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -2251,7 +2251,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -2268,7 +2268,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -2285,7 +2285,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet7]
   summary: Create LST Interface Ethernet7
   type: update
@@ -2302,7 +2302,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2311,7 +2311,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.1
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2319,7 +2319,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3000
   type: update
@@ -2329,7 +2329,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_201_Vlan1001
   type: update
@@ -2339,7 +2339,7 @@
       name: vtepfabric
       vlan: Vlan1001
       vni: 201
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3001
   type: update
@@ -2349,7 +2349,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1002
   type: update
@@ -2359,7 +2359,7 @@
       name: vtepfabric
       vlan: Vlan1002
       vni: 301
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2371,7 +2371,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2387,7 +2387,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2399,7 +2399,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -2419,7 +2419,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.1
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-02 BGP base
   type: update
@@ -2439,7 +2439,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.1
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2459,7 +2459,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.1
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -2476,7 +2476,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-02 BGP L2VPN
   type: update
@@ -2493,7 +2493,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2507,7 +2507,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2521,7 +2521,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2530,7 +2530,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2541,7 +2541,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2552,7 +2552,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2563,7 +2563,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2574,7 +2574,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet8]/link-flap
   summary: Create ErrDisable Interface Ethernet8
   type: update
@@ -2585,7 +2585,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -2595,7 +2595,7 @@
         ipv4-drop-neighbor-aging-time: 60
         name: Values
       name: Values
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.11]
   summary: Create VRF BGP neighbor 172.30.128.11
   type: update
@@ -2628,7 +2628,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.11
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.13]
   summary: Create VRF BGP neighbor 172.30.128.13
   type: update
@@ -2657,7 +2657,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.13
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.15]
   summary: Create VRF BGP neighbor 172.30.128.15
   type: update
@@ -2686,7 +2686,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.15
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.2]
   summary: Create VRF BGP neighbor 172.30.128.2
   type: update
@@ -2715,7 +2715,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.2
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.4]
   summary: Create VRF BGP neighbor 172.30.128.4
   type: update
@@ -2744,7 +2744,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.4
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2778,7 +2778,7 @@
       transport:
         config:
           local-address: 172.30.8.1
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -2812,7 +2812,7 @@
       transport:
         config:
           local-address: 172.30.8.1
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.1/32]
   summary: Create VRF BGP network 172.30.8.1/32
   type: update
@@ -2821,7 +2821,7 @@
     - config:
         prefix: 172.30.8.1/32
       prefix: 172.30.8.1/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2834,7 +2834,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2849,7 +2849,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2864,7 +2864,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2877,7 +2877,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2892,7 +2892,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2907,7 +2907,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2920,7 +2920,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2933,33 +2933,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-02
   type: update
   value:
     policy-name: import-vrf--vpc-02
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfVvpc-02
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-02
   type: update
   value:
     name:
     - VrfVvpc-01
-  weight: 89
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
   summary: Create DHCP relay Vlan1001
   type: update
@@ -2974,7 +2974,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1001
-  weight: 90
+  weight: 92
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
   summary: Create DHCP relay Vlan1002
   type: update
@@ -2989,7 +2989,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1002
-  weight: 90
+  weight: 92
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -2998,4 +2998,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
@@ -1618,7 +1618,7 @@
   value:
     trunk-vlans:
     - 1003
-  weight: 42
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1627,7 +1627,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]
   summary: Create Subinterface Base 10
   type: update
@@ -1639,7 +1639,7 @@
       vlan:
         config:
           vlan-id: 10
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1648,7 +1648,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1657,7 +1657,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1666,7 +1666,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1675,7 +1675,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1684,7 +1684,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1693,7 +1693,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1702,7 +1702,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1711,7 +1711,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1720,7 +1720,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1729,7 +1729,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1738,7 +1738,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/interfaces/interface[id=Ethernet0.10]
   summary: Create VRF interface Ethernet0.10
   type: update
@@ -1747,7 +1747,7 @@
     - config:
         id: Ethernet0.10
       id: Ethernet0.10
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -1756,7 +1756,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1003]
   summary: Create VRF interface Vlan1003
   type: update
@@ -1765,7 +1765,7 @@
     - config:
         id: Vlan1003
       id: Vlan1003
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -1774,7 +1774,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1003]
   summary: Create VRF attached host
   type: update
@@ -1785,7 +1785,7 @@
         address-family: IPV4
         interface-id: Vlan1003
       interface-id: Vlan1003
-  weight: 48
+  weight: 50
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/addresses/address
   summary: Create Subinterface IP 100.1.10.1
   type: update
@@ -1796,7 +1796,7 @@
         prefix-length: 24
         secondary: false
       ip: 100.1.10.1
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.7
   type: update
@@ -1807,7 +1807,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.7
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.9
   type: update
@@ -1818,7 +1818,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.9
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.13
   type: update
@@ -1829,7 +1829,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.13
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.15
   type: update
@@ -1840,7 +1840,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.15
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.2
   type: update
@@ -1851,7 +1851,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.2
   type: update
@@ -1862,7 +1862,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.9
   type: update
@@ -1873,7 +1873,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.9
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -1881,7 +1881,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -1891,7 +1891,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1003
   type: update
@@ -1899,7 +1899,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1003
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -1907,40 +1907,40 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/global-sag/config
   summary: Create VRF VrfEext-bgp-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/evpn/evpn-mh/config
   summary: Create VRF VrfEext-bgp-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -1949,7 +1949,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.2
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -1957,7 +1957,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_100_Vlan3000
   type: update
@@ -1967,7 +1967,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 100
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3001
   type: update
@@ -1977,7 +1977,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_401_Vlan1003
   type: update
@@ -1987,7 +1987,7 @@
       name: vtepfabric
       vlan: Vlan1003
       vni: 401
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ext-inbound--leaf-03--ext-bgp-01 base
   type: update
@@ -1999,7 +1999,7 @@
         type: ACL_IPV4
       name: ext-inbound--leaf-03--ext-bgp-01
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
@@ -2011,7 +2011,7 @@
         type: ACL_IPV4
       name: ipns-egress--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2023,7 +2023,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2042,7 +2042,7 @@
       transport:
         config:
           destination-port: 443
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 2
   type: update
@@ -2061,7 +2061,7 @@
       transport:
         config:
           destination-port: 8080
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 3
   type: update
@@ -2080,7 +2080,7 @@
       transport:
         config:
           destination-port: 67
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 4
   type: update
@@ -2099,7 +2099,7 @@
       transport:
         config:
           destination-port: 161
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 5
   type: update
@@ -2118,7 +2118,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 6
   type: update
@@ -2137,7 +2137,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--ext-bgp-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2149,7 +2149,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -2164,7 +2164,7 @@
         config:
           destination-address: 10.0.0.0/16
       sequence-id: 10
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2176,7 +2176,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2192,7 +2192,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2204,7 +2204,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/interfaces/interface[id=Ethernet0.10]
   summary: Create ACL interface Ethernet0.10
   type: update
@@ -2224,7 +2224,7 @@
         config:
           interface: Ethernet0
           subinterface: 10
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Ethernet0.10]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Ethernet0.10 ingress
   type: update
@@ -2235,7 +2235,7 @@
         type: ACL_IPV4
       set-name: ext-inbound--leaf-03--ext-bgp-01
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]
   summary: Create ACL interface Vlan3000
   type: update
@@ -2247,7 +2247,7 @@
       interface-ref:
         config:
           interface: Vlan3000
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3000]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3000 ingress
   type: update
@@ -2258,7 +2258,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEext-bgp-01 BGP base
   type: update
@@ -2278,7 +2278,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -2298,7 +2298,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2318,7 +2318,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.2
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEext-bgp-01 BGP L2VPN
   type: update
@@ -2335,7 +2335,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - ext-inbound--ext-bgp-01
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -2352,7 +2352,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2366,7 +2366,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2380,7 +2380,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2389,7 +2389,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2400,7 +2400,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2411,7 +2411,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2422,7 +2422,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2433,7 +2433,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -2443,7 +2443,7 @@
         ipv4-drop-neighbor-aging-time: 60
         name: Values
       name: Values
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=100.1.10.6]
   summary: Create VRF BGP neighbor 100.1.10.6
   type: update
@@ -2470,7 +2470,7 @@
         neighbor-address: 100.1.10.6
         peer-as: 64102
       neighbor-address: 100.1.10.6
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -2499,7 +2499,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -2528,7 +2528,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.6]
   summary: Create VRF BGP neighbor 172.30.128.6
   type: update
@@ -2557,7 +2557,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.6
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.8]
   summary: Create VRF BGP neighbor 172.30.128.8
   type: update
@@ -2586,7 +2586,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.8
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2620,7 +2620,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2654,7 +2654,7 @@
       transport:
         config:
           local-address: 172.30.8.2
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.2/32]
   summary: Create VRF BGP network 172.30.8.2/32
   type: update
@@ -2663,7 +2663,7 @@
     - config:
         prefix: 172.30.8.2/32
       prefix: 172.30.8.2/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2676,7 +2676,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2691,7 +2691,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2706,7 +2706,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2719,7 +2719,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2732,33 +2732,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEext-bgp-01
   type: update
   value:
     policy-name: ext-import--ext-bgp-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfEext-bgp-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEext-bgp-01
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfEext-bgp-01
-  weight: 89
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1003]
   summary: Create DHCP relay Vlan1003
   type: update
@@ -2773,7 +2773,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1003
-  weight: 90
+  weight: 92
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -2782,4 +2782,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
@@ -2653,7 +2653,7 @@
   value:
     trunk-vlans:
     - 1007
-  weight: 42
+  weight: 43
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2662,7 +2662,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]
   summary: Create Subinterface Base 10
   type: update
@@ -2674,7 +2674,7 @@
       vlan:
         config:
           vlan-id: 10
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2683,7 +2683,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2692,7 +2692,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2701,7 +2701,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2710,7 +2710,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2719,7 +2719,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2728,7 +2728,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2737,7 +2737,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2746,7 +2746,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2755,7 +2755,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2764,7 +2764,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2773,7 +2773,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2782,7 +2782,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /network-instances/network-instance[name=VrfEexternal-01]/interfaces/interface[id=Ethernet0.10]
   summary: Create VRF interface Ethernet0.10
   type: update
@@ -2791,7 +2791,7 @@
     - config:
         id: Ethernet0.10
       id: Ethernet0.10
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfEexternal-01]/interfaces/interface[id=Vlan3003]
   summary: Create VRF interface Vlan3003
   type: update
@@ -2800,7 +2800,7 @@
     - config:
         id: Vlan3003
       id: Vlan3003
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3001]
   summary: Create VRF interface Vlan3001
   type: update
@@ -2809,7 +2809,7 @@
     - config:
         id: Vlan3001
       id: Vlan3001
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1005]
   summary: Create VRF interface Vlan1005
   type: update
@@ -2818,7 +2818,7 @@
     - config:
         id: Vlan1005
       id: Vlan1005
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1006]
   summary: Create VRF interface Vlan1006
   type: update
@@ -2827,7 +2827,7 @@
     - config:
         id: Vlan1006
       id: Vlan1006
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2836,7 +2836,7 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan1007]
   summary: Create VRF interface Vlan1007
   type: update
@@ -2845,7 +2845,7 @@
     - config:
         id: Vlan1007
       id: Vlan1007
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2854,7 +2854,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1005]
   summary: Create VRF attached host
   type: update
@@ -2865,7 +2865,7 @@
         address-family: IPV4
         interface-id: Vlan1005
       interface-id: Vlan1005
-  weight: 48
+  weight: 50
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1006]
   summary: Create VRF attached host
   type: update
@@ -2876,7 +2876,7 @@
         address-family: IPV4
         interface-id: Vlan1006
       interface-id: Vlan1006
-  weight: 48
+  weight: 50
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1007]
   summary: Create VRF attached host
   type: update
@@ -2887,7 +2887,7 @@
         address-family: IPV4
         interface-id: Vlan1007
       interface-id: Vlan1007
-  weight: 48
+  weight: 50
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/addresses/address
   summary: Create Subinterface IP 100.1.10.1
   type: update
@@ -2898,7 +2898,7 @@
         prefix-length: 24
         secondary: false
       ip: 100.1.10.1
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.9
   type: update
@@ -2909,7 +2909,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.9
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.11
   type: update
@@ -2920,7 +2920,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.11
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.31
   type: update
@@ -2931,7 +2931,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.31
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.33
   type: update
@@ -2942,7 +2942,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.33
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.4
   type: update
@@ -2953,7 +2953,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.4
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.1
   type: update
@@ -2964,7 +2964,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.1
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.11
   type: update
@@ -2975,7 +2975,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.11
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2983,7 +2983,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2993,7 +2993,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1005
   type: update
@@ -3001,7 +3001,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1005
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1006
   type: update
@@ -3009,7 +3009,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1006
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1007
   type: update
@@ -3017,7 +3017,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1007
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -3025,7 +3025,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3001
   type: update
@@ -3033,7 +3033,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3001
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -3041,58 +3041,58 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfEexternal-01]/global-sag/config
   summary: Create VRF VrfEexternal-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
   summary: Create VRF VrfVvpc-01 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-04]/global-sag/config
   summary: Create VRF VrfVvpc-04 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfEexternal-01]/evpn/evpn-mh/config
   summary: Create VRF VrfEexternal-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-01 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-04]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-04 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -3100,7 +3100,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -3112,7 +3112,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -3124,7 +3124,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -3135,7 +3135,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -3152,7 +3152,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -3169,7 +3169,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -3186,7 +3186,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet7]
   summary: Create LST Interface Ethernet7
   type: update
@@ -3203,7 +3203,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -3212,7 +3212,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.1
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -3220,7 +3220,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_100_Vlan3003
   type: update
@@ -3230,7 +3230,7 @@
       name: vtepfabric
       vlan: Vlan3003
       vni: 100
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_200_Vlan3001
   type: update
@@ -3240,7 +3240,7 @@
       name: vtepfabric
       vlan: Vlan3001
       vni: 200
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3002
   type: update
@@ -3250,7 +3250,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1006
   type: update
@@ -3260,7 +3260,7 @@
       name: vtepfabric
       vlan: Vlan1006
       vni: 301
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_302_Vlan1005
   type: update
@@ -3270,7 +3270,7 @@
       name: vtepfabric
       vlan: Vlan1005
       vni: 302
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3000
   type: update
@@ -3280,7 +3280,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_401_Vlan1007
   type: update
@@ -3290,7 +3290,7 @@
       name: vtepfabric
       vlan: Vlan1007
       vni: 401
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ext-inbound--leaf-03--external-01 base
   type: update
@@ -3302,7 +3302,7 @@
         type: ACL_IPV4
       name: ext-inbound--leaf-03--external-01
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL ipns-egress--default base
   type: update
@@ -3314,7 +3314,7 @@
         type: ACL_IPV4
       name: ipns-egress--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -3326,7 +3326,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3345,7 +3345,7 @@
       transport:
         config:
           destination-port: 443
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 2
   type: update
@@ -3364,7 +3364,7 @@
       transport:
         config:
           destination-port: 8080
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 3
   type: update
@@ -3383,7 +3383,7 @@
       transport:
         config:
           destination-port: 67
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 4
   type: update
@@ -3402,7 +3402,7 @@
       transport:
         config:
           destination-port: 161
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 5
   type: update
@@ -3421,7 +3421,7 @@
       transport:
         config:
           destination-port: 4789
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 6
   type: update
@@ -3440,7 +3440,7 @@
       transport:
         config:
           destination-port: 22
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3452,7 +3452,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 10
   type: update
@@ -3467,7 +3467,7 @@
         config:
           destination-address: 10.0.0.0/16
       sequence-id: 10
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3479,7 +3479,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -3495,7 +3495,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -3507,7 +3507,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /acl/interfaces/interface[id=Ethernet0.10]
   summary: Create ACL interface Ethernet0.10
   type: update
@@ -3527,7 +3527,7 @@
         config:
           interface: Ethernet0
           subinterface: 10
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Ethernet0.10]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Ethernet0.10 ingress
   type: update
@@ -3538,7 +3538,7 @@
         type: ACL_IPV4
       set-name: ext-inbound--leaf-03--external-01
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3003]
   summary: Create ACL interface Vlan3003
   type: update
@@ -3550,7 +3550,7 @@
       interface-ref:
         config:
           interface: Vlan3003
-  weight: 77
+  weight: 79
 - path: /acl/interfaces/interface[id=Vlan3003]/ingress-acl-sets/ingress-acl-set
   summary: Update ACL interface Vlan3003 ingress
   type: update
@@ -3561,7 +3561,7 @@
         type: ACL_IPV4
       set-name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 77
+  weight: 79
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfEexternal-01 BGP base
   type: update
@@ -3581,7 +3581,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-01 BGP base
   type: update
@@ -3601,7 +3601,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -3621,7 +3621,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-04 BGP base
   type: update
@@ -3641,7 +3641,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -3661,7 +3661,7 @@
           as: 65102
           network-import-check: true
           router-id: 172.30.8.4
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfEexternal-01 BGP L2VPN
   type: update
@@ -3678,7 +3678,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - ext-inbound--external-01
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-01 BGP L2VPN
   type: update
@@ -3695,7 +3695,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -3712,7 +3712,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-04 BGP L2VPN
   type: update
@@ -3729,7 +3729,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -3743,7 +3743,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -3757,7 +3757,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -3766,7 +3766,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -3777,7 +3777,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -3788,7 +3788,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -3799,7 +3799,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -3810,7 +3810,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -3820,7 +3820,7 @@
         ipv4-drop-neighbor-aging-time: 60
         name: Values
       name: Values
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=100.1.10.6]
   summary: Create VRF BGP neighbor 100.1.10.6
   type: update
@@ -3847,7 +3847,7 @@
         neighbor-address: 100.1.10.6
         peer-as: 64102
       neighbor-address: 100.1.10.6
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.10]
   summary: Create VRF BGP neighbor 172.30.128.10
   type: update
@@ -3876,7 +3876,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.10
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.30]
   summary: Create VRF BGP neighbor 172.30.128.30
   type: update
@@ -3905,7 +3905,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.30
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.32]
   summary: Create VRF BGP neighbor 172.30.128.32
   type: update
@@ -3934,7 +3934,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.32
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.8]
   summary: Create VRF BGP neighbor 172.30.128.8
   type: update
@@ -3963,7 +3963,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.8
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -3997,7 +3997,7 @@
       transport:
         config:
           local-address: 172.30.8.4
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -4031,7 +4031,7 @@
       transport:
         config:
           local-address: 172.30.8.4
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.4/32]
   summary: Create VRF BGP network 172.30.8.4/32
   type: update
@@ -4040,7 +4040,7 @@
     - config:
         prefix: 172.30.8.4/32
       prefix: 172.30.8.4/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4053,7 +4053,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4068,7 +4068,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4083,7 +4083,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4096,7 +4096,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4111,7 +4111,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4126,7 +4126,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -4139,7 +4139,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4154,7 +4154,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4169,7 +4169,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -4182,7 +4182,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -4195,31 +4195,31 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfEexternal-01
   type: update
   value:
     policy-name: ext-import--external-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-01
   type: update
   value:
     policy-name: import-vrf--vpc-01
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-04
   type: update
   value:
     policy-name: import-vrf--vpc-04
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfEexternal-01
   type: update
@@ -4227,14 +4227,14 @@
     name:
     - VrfVvpc-01
     - VrfVvpc-03
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-01
   type: update
   value:
     name:
     - VrfEexternal-01
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
@@ -4242,14 +4242,14 @@
     name:
     - VrfEexternal-01
     - VrfVvpc-04
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-04
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1005]
   summary: Create DHCP relay Vlan1005
   type: update
@@ -4264,7 +4264,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1005
-  weight: 90
+  weight: 92
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1006]
   summary: Create DHCP relay Vlan1006
   type: update
@@ -4279,7 +4279,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1006
-  weight: 90
+  weight: 92
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1007]
   summary: Create DHCP relay Vlan1007
   type: update
@@ -4294,7 +4294,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1007
-  weight: 90
+  weight: 92
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -4303,4 +4303,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
@@ -1924,7 +1924,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1933,7 +1933,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1942,7 +1942,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1951,7 +1951,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1960,7 +1960,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1969,7 +1969,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1978,7 +1978,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1987,7 +1987,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -1996,7 +1996,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2005,7 +2005,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2014,7 +2014,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2023,7 +2023,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2032,7 +2032,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=PortChannel3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -2041,7 +2041,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1005]
   summary: Create VRF interface Vlan1005
   type: update
@@ -2050,7 +2050,7 @@
     - config:
         id: Vlan1005
       id: Vlan1005
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1006]
   summary: Create VRF interface Vlan1006
   type: update
@@ -2059,7 +2059,7 @@
     - config:
         id: Vlan1006
       id: Vlan1006
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3002]
   summary: Create VRF interface Vlan3002
   type: update
@@ -2068,7 +2068,7 @@
     - config:
         id: Vlan3002
       id: Vlan3002
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan1008]
   summary: Create VRF interface Vlan1008
   type: update
@@ -2077,7 +2077,7 @@
     - config:
         id: Vlan1008
       id: Vlan1008
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan3000]
   summary: Create VRF interface Vlan3000
   type: update
@@ -2086,7 +2086,7 @@
     - config:
         id: Vlan3000
       id: Vlan3000
-  weight: 46
+  weight: 47
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1005]
   summary: Create VRF attached host
   type: update
@@ -2097,7 +2097,7 @@
         address-family: IPV4
         interface-id: Vlan1005
       interface-id: Vlan1005
-  weight: 48
+  weight: 50
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1006]
   summary: Create VRF attached host
   type: update
@@ -2108,7 +2108,7 @@
         address-family: IPV4
         interface-id: Vlan1006
       interface-id: Vlan1006
-  weight: 48
+  weight: 50
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1008]
   summary: Create VRF attached host
   type: update
@@ -2119,7 +2119,7 @@
         address-family: IPV4
         interface-id: Vlan1008
       interface-id: Vlan1008
-  weight: 48
+  weight: 50
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.13
   type: update
@@ -2130,7 +2130,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.13
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.15
   type: update
@@ -2141,7 +2141,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.15
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.35
   type: update
@@ -2152,7 +2152,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.35
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.37
   type: update
@@ -2163,7 +2163,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.37
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.5
   type: update
@@ -2174,7 +2174,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.5
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.12.2
   type: update
@@ -2185,7 +2185,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.12.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.12
   type: update
@@ -2196,7 +2196,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.12
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -2204,7 +2204,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -2214,7 +2214,7 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1005
   type: update
@@ -2222,7 +2222,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1005
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1006
   type: update
@@ -2230,7 +2230,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1006
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan1008
   type: update
@@ -2238,7 +2238,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan1008
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3000
   type: update
@@ -2246,7 +2246,7 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3000
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
   summary: Create Suppress VLAN neigh Vlan3002
   type: update
@@ -2254,36 +2254,36 @@
     SUPPRESS_VLAN_NEIGH_LIST:
     - name: Vlan3002
       suppress: "on"
-  weight: 59
+  weight: 61
 - path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
   summary: Create VRF VrfVvpc-03 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-04]/global-sag/config
   summary: Create VRF VrfVvpc-04 SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-03 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=VrfVvpc-04]/evpn/evpn-mh/config
   summary: Create VRF VrfVvpc-04 EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
@@ -2291,7 +2291,7 @@
     config:
       mac-holdtime: 60
       startup-delay: 60
-  weight: 63
+  weight: 65
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
   summary: Create VRF PortChannel1 EVPN ethernet segment
   type: update
@@ -2303,7 +2303,7 @@
         interface: PortChannel1
         name: PortChannel1
       name: PortChannel1
-  weight: 64
+  weight: 66
 - path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
   summary: Create VRF PortChannel2 EVPN ethernet segment
   type: update
@@ -2315,7 +2315,7 @@
         interface: PortChannel2
         name: PortChannel2
       name: PortChannel2
-  weight: 64
+  weight: 66
 - path: /lst/lst-groups/lst-group
   summary: Create LST Group spinelink
   type: update
@@ -2326,7 +2326,7 @@
         name: spinelink
         timeout: 60
       name: spinelink
-  weight: 65
+  weight: 67
 - path: /lst/interfaces/interface[id=Ethernet4]
   summary: Create LST Interface Ethernet4
   type: update
@@ -2343,7 +2343,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet5]
   summary: Create LST Interface Ethernet5
   type: update
@@ -2360,7 +2360,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet6]
   summary: Create LST Interface Ethernet6
   type: update
@@ -2377,7 +2377,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /lst/interfaces/interface[id=Ethernet7]
   summary: Create LST Interface Ethernet7
   type: update
@@ -2394,7 +2394,7 @@
         - config:
             group-name: spinelink
           group-name: spinelink
-  weight: 66
+  weight: 68
 - path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
   summary: Create VXLAN tunnel vtepfabric
   type: update
@@ -2403,7 +2403,7 @@
     - name: vtepfabric
       src_intf: Loopback2
       src_ip: 172.30.12.2
-  weight: 69
+  weight: 71
 - path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
   summary: Create VXLAN EVPN NVO nvo1
   type: update
@@ -2411,7 +2411,7 @@
     VXLAN_EVPN_NVO_LIST:
     - name: nvo1
       source_vtep: vtepfabric
-  weight: 71
+  weight: 73
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_300_Vlan3002
   type: update
@@ -2421,7 +2421,7 @@
       name: vtepfabric
       vlan: Vlan3002
       vni: 300
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_301_Vlan1006
   type: update
@@ -2431,7 +2431,7 @@
       name: vtepfabric
       vlan: Vlan1006
       vni: 301
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_302_Vlan1005
   type: update
@@ -2441,7 +2441,7 @@
       name: vtepfabric
       vlan: Vlan1005
       vni: 302
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_400_Vlan3000
   type: update
@@ -2451,7 +2451,7 @@
       name: vtepfabric
       vlan: Vlan3000
       vni: 400
-  weight: 73
+  weight: 75
 - path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
   summary: Create VXLAN tunnel map map_402_Vlan1008
   type: update
@@ -2461,7 +2461,7 @@
       name: vtepfabric
       vlan: Vlan1008
       vni: 402
-  weight: 73
+  weight: 75
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -2473,7 +2473,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -2489,7 +2489,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -2501,7 +2501,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-03 BGP base
   type: update
@@ -2521,7 +2521,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.5
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF VrfVvpc-04 BGP base
   type: update
@@ -2541,7 +2541,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.5
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -2561,7 +2561,7 @@
           as: 65103
           network-import-check: true
           router-id: 172.30.8.5
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-03 BGP L2VPN
   type: update
@@ -2578,7 +2578,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF VrfVvpc-04 BGP L2VPN
   type: update
@@ -2595,7 +2595,7 @@
               advertise-afi-safi: IPV4_UNICAST
               route-map:
               - filter-attached-hosts
-  weight: 79
+  weight: 81
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -2609,7 +2609,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -2623,7 +2623,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -2632,7 +2632,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -2643,7 +2643,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -2654,7 +2654,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -2665,7 +2665,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -2676,7 +2676,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -2686,7 +2686,7 @@
         ipv4-drop-neighbor-aging-time: 60
         name: Values
       name: Values
-  weight: 84
+  weight: 86
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.12]
   summary: Create VRF BGP neighbor 172.30.128.12
   type: update
@@ -2715,7 +2715,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.12
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.14]
   summary: Create VRF BGP neighbor 172.30.128.14
   type: update
@@ -2744,7 +2744,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.34]
   summary: Create VRF BGP neighbor 172.30.128.34
   type: update
@@ -2773,7 +2773,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.34
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.36]
   summary: Create VRF BGP neighbor 172.30.128.36
   type: update
@@ -2802,7 +2802,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.36
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
   summary: Create VRF BGP neighbor 172.30.8.0
   type: update
@@ -2836,7 +2836,7 @@
       transport:
         config:
           local-address: 172.30.8.5
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
   summary: Create VRF BGP neighbor 172.30.8.1
   type: update
@@ -2870,7 +2870,7 @@
       transport:
         config:
           local-address: 172.30.8.5
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.5/32]
   summary: Create VRF BGP network 172.30.8.5/32
   type: update
@@ -2879,7 +2879,7 @@
     - config:
         prefix: 172.30.8.5/32
       prefix: 172.30.8.5/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2892,7 +2892,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2907,7 +2907,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2922,7 +2922,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection attachedhost
   type: update
@@ -2935,7 +2935,7 @@
         src-protocol: ATTACHED_HOST
       dst-protocol: BGP
       src-protocol: ATTACHED_HOST
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2950,7 +2950,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2965,7 +2965,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -2978,7 +2978,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -2991,33 +2991,33 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-03
   type: update
   value:
     policy-name: import-vrf--vpc-03
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
   summary: Create VRF BGP import policy VrfVvpc-04
   type: update
   value:
     policy-name: import-vrf--vpc-04
-  weight: 88
+  weight: 90
 - path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-03
   type: update
   value:
     name:
     - VrfVvpc-04
-  weight: 89
+  weight: 91
 - path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
   summary: Create VRF BGP import VRF VrfVvpc-04
   type: update
   value:
     name:
     - VrfVvpc-03
-  weight: 89
+  weight: 91
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1005]
   summary: Create DHCP relay Vlan1005
   type: update
@@ -3032,7 +3032,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1005
-  weight: 90
+  weight: 92
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1006]
   summary: Create DHCP relay Vlan1006
   type: update
@@ -3047,7 +3047,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1006
-  weight: 90
+  weight: 92
 - path: relay-agent/dhcp/interfaces/interface[id=Vlan1008]
   summary: Create DHCP relay Vlan1008
   type: update
@@ -3062,7 +3062,7 @@
         - 172.30.0.1
         src-intf: Management0
       id: Vlan1008
-  weight: 90
+  weight: 92
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -3071,4 +3071,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-spine-1.out.actions.expected.yaml
@@ -639,7 +639,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -648,7 +648,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -657,7 +657,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -666,7 +666,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -675,7 +675,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -684,7 +684,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -693,7 +693,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -702,7 +702,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -711,7 +711,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -720,7 +720,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -729,7 +729,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -738,7 +738,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
@@ -747,7 +747,7 @@
     - config:
         index: 0
       index: 0
-  weight: 43
+  weight: 44
 - path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.0
   type: update
@@ -758,7 +758,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.2
   type: update
@@ -769,7 +769,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.2
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.20
   type: update
@@ -780,7 +780,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.20
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.4
   type: update
@@ -791,7 +791,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.4
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.6
   type: update
@@ -802,7 +802,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.6
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.8
   type: update
@@ -813,7 +813,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.8
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.10
   type: update
@@ -824,7 +824,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.10
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.12
   type: update
@@ -835,7 +835,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.12
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.14
   type: update
@@ -846,7 +846,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.14
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.16
   type: update
@@ -857,7 +857,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.16
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.128.18
   type: update
@@ -868,7 +868,7 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.18
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.0
   type: update
@@ -879,7 +879,7 @@
         prefix-length: 32
         secondary: false
       ip: 172.30.8.0
-  weight: 49
+  weight: 51
 - path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.0.7
   type: update
@@ -890,7 +890,7 @@
         prefix-length: 21
         secondary: false
       ip: 172.30.0.7
-  weight: 49
+  weight: 51
 - path: /system/ntp/config
   summary: Create NTP
   type: update
@@ -898,7 +898,7 @@
     config:
       source-interface:
       - Management0
-  weight: 53
+  weight: 55
 - path: /system/ntp/servers/server[address=172.30.0.1]
   summary: Create NTP server 172.30.0.1
   type: update
@@ -908,18 +908,18 @@
       config:
         address: 172.30.0.1
         prefer: true
-  weight: 54
+  weight: 56
 - path: /network-instances/network-instance[name=default]/global-sag/config
   summary: Create VRF default SAG
   type: update
   value:
     config:
       anycast-mac: "00:00:00:11:11:11"
-  weight: 62
+  weight: 64
 - path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
   summary: Create VRF default EVPNMH
   type: update
-  weight: 63
+  weight: 65
 - path: /acl/acl-sets/acl-set
   summary: Create ACL no-ipns-peering--default base
   type: update
@@ -931,7 +931,7 @@
         type: ACL_IPV4
       name: no-ipns-peering--default
       type: ACL_IPV4
-  weight: 74
+  weight: 76
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 1
   type: update
@@ -947,7 +947,7 @@
           destination-address: 10.0.0.0/16
           source-address: 10.0.0.0/16
       sequence-id: 1
-  weight: 76
+  weight: 78
 - path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
   summary: Create ACL entry 65535
   type: update
@@ -959,7 +959,7 @@
       config:
         sequence-id: 65535
       sequence-id: 65535
-  weight: 76
+  weight: 78
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
   summary: Create VRF default BGP base
   type: update
@@ -979,7 +979,7 @@
           as: 65100
           network-import-check: true
           router-id: 172.30.8.0
-  weight: 78
+  weight: 80
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
   summary: Create VRF default BGP L2VPN
   type: update
@@ -993,7 +993,7 @@
           advertise-all-vni: true
         route-advertise:
           route-advertise-list: []
-  weight: 79
+  weight: 81
 - path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
   summary: Create BFD Profile fabric
   type: update
@@ -1007,7 +1007,7 @@
         profile-name: fabric
         required-minimum-receive: 300
       profile-name: fabric
-  weight: 80
+  weight: 82
 - path: /openconfig-errdisable-ext:errdisable/config
   summary: Create ErrDisable Global
   type: update
@@ -1016,7 +1016,7 @@
       cause:
       - LINK_FLAP
       interval: 300
-  weight: 81
+  weight: 83
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet0]/link-flap
   summary: Create ErrDisable Interface Ethernet0
   type: update
@@ -1027,7 +1027,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet1]/link-flap
   summary: Create ErrDisable Interface Ethernet1
   type: update
@@ -1038,7 +1038,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet10]/link-flap
   summary: Create ErrDisable Interface Ethernet10
   type: update
@@ -1049,7 +1049,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet2]/link-flap
   summary: Create ErrDisable Interface Ethernet2
   type: update
@@ -1060,7 +1060,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
   summary: Create ErrDisable Interface Ethernet3
   type: update
@@ -1071,7 +1071,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
   summary: Create ErrDisable Interface Ethernet4
   type: update
@@ -1082,7 +1082,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
   summary: Create ErrDisable Interface Ethernet5
   type: update
@@ -1093,7 +1093,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
   summary: Create ErrDisable Interface Ethernet6
   type: update
@@ -1104,7 +1104,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
   summary: Create ErrDisable Interface Ethernet7
   type: update
@@ -1115,7 +1115,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet8]/link-flap
   summary: Create ErrDisable Interface Ethernet8
   type: update
@@ -1126,7 +1126,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet9]/link-flap
   summary: Create ErrDisable Interface Ethernet9
   type: update
@@ -1137,7 +1137,7 @@
         flap-threshold: 3
         recovery-interval: 300
         sampling-interval: 30
-  weight: 82
+  weight: 84
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
   summary: Create VRF BGP neighbor 172.30.128.1
   type: update
@@ -1166,7 +1166,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.1
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.11]
   summary: Create VRF BGP neighbor 172.30.128.11
   type: update
@@ -1195,7 +1195,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.11
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.13]
   summary: Create VRF BGP neighbor 172.30.128.13
   type: update
@@ -1224,7 +1224,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.13
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.15]
   summary: Create VRF BGP neighbor 172.30.128.15
   type: update
@@ -1253,7 +1253,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.15
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.17]
   summary: Create VRF BGP neighbor 172.30.128.17
   type: update
@@ -1282,7 +1282,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.17
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.19]
   summary: Create VRF BGP neighbor 172.30.128.19
   type: update
@@ -1311,7 +1311,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.19
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.21]
   summary: Create VRF BGP neighbor 172.30.128.21
   type: update
@@ -1340,7 +1340,7 @@
         neighbor-address: 172.30.128.21
         peer-as: 65534
       neighbor-address: 172.30.128.21
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.3]
   summary: Create VRF BGP neighbor 172.30.128.3
   type: update
@@ -1369,7 +1369,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.3
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.5]
   summary: Create VRF BGP neighbor 172.30.128.5
   type: update
@@ -1398,7 +1398,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.5
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.7]
   summary: Create VRF BGP neighbor 172.30.128.7
   type: update
@@ -1427,7 +1427,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.7
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.9]
   summary: Create VRF BGP neighbor 172.30.128.9
   type: update
@@ -1456,7 +1456,7 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.9
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
   summary: Create VRF BGP neighbor 172.30.8.2
   type: update
@@ -1490,7 +1490,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.3]
   summary: Create VRF BGP neighbor 172.30.8.3
   type: update
@@ -1524,7 +1524,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.4]
   summary: Create VRF BGP neighbor 172.30.8.4
   type: update
@@ -1558,7 +1558,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.5]
   summary: Create VRF BGP neighbor 172.30.8.5
   type: update
@@ -1592,7 +1592,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.6]
   summary: Create VRF BGP neighbor 172.30.8.6
   type: update
@@ -1626,7 +1626,7 @@
       transport:
         config:
           local-address: 172.30.8.0
-  weight: 85
+  weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
   summary: Create VRF BGP network 172.30.8.0/32
   type: update
@@ -1635,7 +1635,7 @@
     - config:
         prefix: 172.30.8.0/32
       prefix: 172.30.8.0/32
-  weight: 86
+  weight: 88
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection connected
   type: update
@@ -1648,7 +1648,7 @@
         src-protocol: DIRECTLY_CONNECTED
       dst-protocol: BGP
       src-protocol: DIRECTLY_CONNECTED
-  weight: 87
+  weight: 89
 - path: /network-instances/network-instance[name=default]/table-connections/table-connection
   summary: Create VRF table connection static
   type: update
@@ -1661,7 +1661,7 @@
         src-protocol: STATIC
       dst-protocol: BGP
       src-protocol: STATIC
-  weight: 87
+  weight: 89
 - path: /loadshare/roce-attrs
   summary: Update ECMP RoCE
   type: replace
@@ -1670,4 +1670,4 @@
       config:
         hash: hash
         qpn: false
-  weight: 130
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.in.agent.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.in.agent.yaml
@@ -1,0 +1,588 @@
+apiVersion: agent.githedgehog.com/v1beta1
+kind: Agent
+metadata:
+  creationTimestamp: "2026-03-02T16:04:57Z"
+  generation: 3
+  labels:
+    fabric.githedgehog.com/profile: vs
+    switchgroup.fabric.githedgehog.com/eslag-1: "true"
+    vlanns.fabric.githedgehog.com/default: "true"
+  name: leaf-01
+  namespace: default
+  resourceVersion: "8929"
+  uid: 99d56f7f-b07f-4bb2-8488-f51cd502ca9f
+spec:
+  alloy: {}
+  attachedVPCs:
+    vpc-01: true
+    vpc-02: true
+  catalog:
+    connectionIDs:
+      server-01--eslag--leaf-01--leaf-02: 1
+      server-02--eslag--leaf-01--leaf-02: 2
+    irbVLANs:
+      vpc-01: 3000
+      vpc-02: 3001
+    portChannelIDs:
+      server-01--eslag--leaf-01--leaf-02: 2
+      server-02--eslag--leaf-01--leaf-02: 1
+      server-04--bundled--leaf-02: 3
+    subnetIDs:
+      10.0.1.0/24: 100
+      10.0.2.0/24: 101
+    vpcSubnetVNIs:
+      vpc-01:
+        subnet-01: 201
+      vpc-02:
+        subnet-01: 301
+    vpcVNIs:
+      vpc-01: 200
+      vpc-02: 300
+  config:
+    alloy:
+      hostname: leaf-01
+      kube: {}
+      logFiles:
+        agent:
+          pathTargets:
+          - path: /var/log/agent.log
+        syslog:
+          pathTargets:
+          - path: /var/log/syslog
+      proxyURL: http://172.30.0.1:31028
+      pyroscope: {}
+      scrapes:
+        agent:
+          address: 127.0.0.1:7042
+          intervalSeconds: 60
+          self: {}
+          unix: {}
+        node:
+          intervalSeconds: 60
+          self: {}
+          unix:
+            collectors:
+            - cpu
+            - loadavg
+            - meminfo
+            - filesystem
+            enable: true
+      targets: {}
+    baseVPCCommunity: "50000:0"
+    controlVIP: 172.30.0.1/32
+    defaultMaxPathsEBGP: 64
+    eslagESIPrefix: '00:f2:00:00:'
+    eslagMACBase: f2:00:00:00:00:00
+    fabricMTU: 9100
+    fabricSubnet: 172.30.128.0/17
+    gatewayASN: 65534
+    gatewayBFD: true
+    gatewayCommunities:
+      "0": "50001:0"
+      "1": "50001:1"
+      "2": "50001:2"
+      "3": "50001:3"
+      "4": "50001:4"
+      "5": "50001:5"
+      "6": "50001:6"
+      "7": "50001:7"
+      "8": "50001:8"
+      "9": "50001:9"
+    mclagSessionSubnet: 172.30.95.0/31
+    protocolSubnet: 172.30.8.0/22
+    proxyExternalSubnet: 172.30.16.0/22
+    serverFacingMTUOffset: 64
+    spineLeaf: {}
+    vpcLoopbackSubnet: 172.30.96.0/19
+    vtepSubnet: 172.30.12.0/22
+  configuredVPCSubnets:
+    vpc-01/subnet-01: true
+    vpc-02/subnet-01: true
+  connections:
+    leaf-01--gateway--gateway-1:
+      gateway:
+        links:
+        - gateway:
+            ip: 172.30.128.1/31
+            port: gateway-1/enp2s1
+          switch:
+            ip: 172.30.128.0/31
+            port: leaf-01/E1/8
+    leaf-01--mesh--leaf-02:
+      mesh:
+        links:
+        - leaf1:
+            port: leaf-01/E1/4
+          leaf2:
+            port: leaf-02/E1/5
+        - leaf1:
+            port: leaf-01/E1/5
+          leaf2:
+            port: leaf-02/E1/6
+    leaf-01--mesh--leaf-03:
+      mesh:
+        links:
+        - leaf1:
+            port: leaf-01/E1/6
+          leaf2:
+            port: leaf-03/E1/5
+        - leaf1:
+            port: leaf-01/E1/7
+          leaf2:
+            port: leaf-03/E1/6
+    server-01--eslag--leaf-01--leaf-02:
+      eslag:
+        links:
+        - server:
+            port: server-01/enp2s1
+          switch:
+            port: leaf-01/E1/1
+        - server:
+            port: server-01/enp2s2
+          switch:
+            port: leaf-02/E1/1
+    server-02--eslag--leaf-01--leaf-02:
+      eslag:
+        links:
+        - server:
+            port: server-02/enp2s1
+          switch:
+            port: leaf-01/E1/2
+        - server:
+            port: server-02/enp2s2
+          switch:
+            port: leaf-02/E1/2
+    server-03--unbundled--leaf-01:
+      unbundled:
+        link:
+          server:
+            port: server-03/enp2s1
+          switch:
+            port: leaf-01/E1/3
+  description: VS-01 ESLAG 1
+  externals:
+    ext-bgp-01:
+      inboundCommunity: 65102:1000
+      ipv4Namespace: default
+      outboundCommunity: 64102:1000
+  ipv4Namespaces:
+    default:
+      subnets:
+      - 10.0.0.0/16
+  redundancyGroupPeers:
+  - leaf-02
+  role: server-leaf
+  statusUpdates:
+  - apiVersion: wiring.githedgehog.com/v1beta1
+    generation: 1
+    kind: Switch
+    name: leaf-01
+    namespace: default
+  switch:
+    asn: 65101
+    boot:
+      mac: 0c:20:12:ff:00:00
+    description: VS-01 ESLAG 1
+    ecmp: {}
+    linkFlapErrDisable:
+      flapThreshold: 3
+      samplingInterval: 30
+      recoveryInterval: 300
+    groups:
+    - eslag-1
+    ip: 172.30.0.7/21
+    profile: vs
+    protocolIP: 172.30.8.0/32
+    redundancy:
+      group: eslag-1
+      type: eslag
+    role: server-leaf
+    vlanNamespaces:
+    - default
+    vtepIP: 172.30.12.0/32
+  switchProfile:
+    config:
+      maxPathsEBGP: 16
+    displayName: Virtual Switch
+    features:
+      eslag: true
+      l2vni: true
+      l3vni: true
+      mclag: true
+      roce: true
+      subinterfaces: true
+    nosType: sonic-bcm-vs
+    platform: x86_64-kvm_x86_64-r0
+    portGroups:
+      "1":
+        nos: "1"
+        profile: SFP28-25G
+      "2":
+        nos: "2"
+        profile: SFP28-25G
+      "3":
+        nos: "3"
+        profile: SFP28-25G
+      "4":
+        nos: "4"
+        profile: SFP28-25G
+      "5":
+        nos: "5"
+        profile: SFP28-25G
+      "6":
+        nos: "6"
+        profile: SFP28-25G
+      "7":
+        nos: "7"
+        profile: SFP28-25G
+      "8":
+        nos: "8"
+        profile: SFP28-25G
+      "9":
+        nos: "9"
+        profile: SFP28-25G
+      "10":
+        nos: "10"
+        profile: SFP28-25G
+      "11":
+        nos: "11"
+        profile: SFP28-25G
+      "12":
+        nos: "12"
+        profile: SFP28-25G
+    portProfiles:
+      SFP28-25G:
+        speed:
+          default: 25G
+          supported:
+          - 10G
+          - 25G
+    ports:
+      E1/1:
+        group: "1"
+        label: "1"
+        nos: Ethernet0
+      E1/2:
+        group: "1"
+        label: "2"
+        nos: Ethernet1
+      E1/3:
+        group: "1"
+        label: "3"
+        nos: Ethernet2
+      E1/4:
+        group: "1"
+        label: "4"
+        nos: Ethernet3
+      E1/5:
+        group: "2"
+        label: "5"
+        nos: Ethernet4
+      E1/6:
+        group: "2"
+        label: "6"
+        nos: Ethernet5
+      E1/7:
+        group: "2"
+        label: "7"
+        nos: Ethernet6
+      E1/8:
+        group: "2"
+        label: "8"
+        nos: Ethernet7
+      E1/9:
+        group: "3"
+        label: "9"
+        nos: Ethernet8
+      E1/10:
+        group: "3"
+        label: "10"
+        nos: Ethernet9
+      E1/11:
+        group: "3"
+        label: "11"
+        nos: Ethernet10
+      E1/12:
+        group: "3"
+        label: "12"
+        nos: Ethernet11
+      E1/13:
+        group: "4"
+        label: "13"
+        nos: Ethernet12
+      E1/14:
+        group: "4"
+        label: "14"
+        nos: Ethernet13
+      E1/15:
+        group: "4"
+        label: "15"
+        nos: Ethernet14
+      E1/16:
+        group: "4"
+        label: "16"
+        nos: Ethernet15
+      E1/17:
+        group: "5"
+        label: "17"
+        nos: Ethernet16
+      E1/18:
+        group: "5"
+        label: "18"
+        nos: Ethernet17
+      E1/19:
+        group: "5"
+        label: "19"
+        nos: Ethernet18
+      E1/20:
+        group: "5"
+        label: "20"
+        nos: Ethernet19
+      E1/21:
+        group: "6"
+        label: "21"
+        nos: Ethernet20
+      E1/22:
+        group: "6"
+        label: "22"
+        nos: Ethernet21
+      E1/23:
+        group: "6"
+        label: "23"
+        nos: Ethernet22
+      E1/24:
+        group: "6"
+        label: "24"
+        nos: Ethernet23
+      E1/25:
+        group: "7"
+        label: "25"
+        nos: Ethernet24
+      E1/26:
+        group: "7"
+        label: "26"
+        nos: Ethernet25
+      E1/27:
+        group: "7"
+        label: "27"
+        nos: Ethernet26
+      E1/28:
+        group: "7"
+        label: "28"
+        nos: Ethernet27
+      E1/29:
+        group: "8"
+        label: "29"
+        nos: Ethernet28
+      E1/30:
+        group: "8"
+        label: "30"
+        nos: Ethernet29
+      E1/31:
+        group: "8"
+        label: "31"
+        nos: Ethernet30
+      E1/32:
+        group: "8"
+        label: "32"
+        nos: Ethernet31
+      E1/33:
+        group: "9"
+        label: "33"
+        nos: Ethernet32
+      E1/34:
+        group: "9"
+        label: "34"
+        nos: Ethernet33
+      E1/35:
+        group: "9"
+        label: "35"
+        nos: Ethernet34
+      E1/36:
+        group: "9"
+        label: "36"
+        nos: Ethernet35
+      E1/37:
+        group: "10"
+        label: "37"
+        nos: Ethernet36
+      E1/38:
+        group: "10"
+        label: "38"
+        nos: Ethernet37
+      E1/39:
+        group: "10"
+        label: "39"
+        nos: Ethernet38
+      E1/40:
+        group: "10"
+        label: "40"
+        nos: Ethernet39
+      E1/41:
+        group: "11"
+        label: "41"
+        nos: Ethernet40
+      E1/42:
+        group: "11"
+        label: "42"
+        nos: Ethernet41
+      E1/43:
+        group: "11"
+        label: "43"
+        nos: Ethernet42
+      E1/44:
+        group: "11"
+        label: "44"
+        nos: Ethernet43
+      E1/45:
+        group: "12"
+        label: "45"
+        nos: Ethernet44
+      E1/46:
+        group: "12"
+        label: "46"
+        nos: Ethernet45
+      E1/47:
+        group: "12"
+        label: "47"
+        nos: Ethernet46
+      E1/48:
+        group: "12"
+        label: "48"
+        nos: Ethernet47
+      M1:
+        management: true
+        nos: Management0
+        oniePortName: eth0
+    switchSilicon: vs
+  switches:
+    leaf-01:
+      asn: 65101
+      boot:
+        mac: 0c:20:12:ff:00:00
+      description: VS-01 ESLAG 1
+      ecmp: {}
+      groups:
+      - eslag-1
+      ip: 172.30.0.7/21
+      profile: vs
+      protocolIP: 172.30.8.0/32
+      redundancy:
+        group: eslag-1
+        type: eslag
+      role: server-leaf
+      vlanNamespaces:
+      - default
+      vtepIP: 172.30.12.0/32
+    leaf-02:
+      asn: 65102
+      boot:
+        mac: 0c:20:12:ff:01:00
+      description: VS-02 ESLAG 1
+      ecmp: {}
+      groups:
+      - eslag-1
+      ip: 172.30.0.8/21
+      profile: vs
+      protocolIP: 172.30.8.1/32
+      redundancy:
+        group: eslag-1
+        type: eslag
+      role: server-leaf
+      vlanNamespaces:
+      - default
+      vtepIP: 172.30.12.1/32
+    leaf-03:
+      asn: 65103
+      boot:
+        mac: 0c:20:12:ff:02:00
+      description: VS-03
+      ecmp: {}
+      ip: 172.30.0.9/21
+      profile: vs
+      protocolIP: 172.30.8.2/32
+      redundancy: {}
+      role: server-leaf
+      vlanNamespaces:
+      - default
+      vtepIP: 172.30.12.2/32
+  users:
+  - name: op
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: operator
+    sshKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICfKMFTLr3BZ5REx0PpyshgALR5ftql2OQkWGcPhQHP/
+  - name: admin
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: admin
+    sshKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICfKMFTLr3BZ5REx0PpyshgALR5ftql2OQkWGcPhQHP/
+  version:
+    alloyRepo: 172.30.0.1:31000/githedgehog/fabricator/alloy-bin
+    alloyVersion: v1.13.1
+    ca: |
+      -----BEGIN CERTIFICATE-----
+      MIIBbDCCARKgAwIBAgIIMFjA/j8KxygwCgYIKoZIzj0EAwIwGjEYMBYGA1UEAxMP
+      aGVkZ2Vob2ctZmFiLWNhMB4XDTI2MDMwMjE1NDU1NFoXDTM2MDMwMjE2MDA1NFow
+      GjEYMBYGA1UEAxMPaGVkZ2Vob2ctZmFiLWNhMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+      AQcDQgAEvfofpuKtvDD0VVgnxJLF3XecpjHySvLlR5izE6EaOnjZuMYt2sVhEPHw
+      Z9ryWdCs0BtEcax6cJVN29adIUeRg6NCMEAwDgYDVR0PAQH/BAQDAgKEMA8GA1Ud
+      EwEB/wQFMAMBAf8wHQYDVR0OBBYEFJIjkSy0z5j6F5mMH1lVk9xmLO0EMAoGCCqG
+      SM49BAMCA0gAMEUCIQDsKDHUAfoITHKHrmQwA3K/Bp8yn8FdW23EAeGnymmYoAIg
+      WG0HAu92b0ShVDdxeySvUv1rHn23gAWLs7A+nQE7MtY=
+      -----END CERTIFICATE-----
+    default: v0.106.0
+    password: secret
+    repo: 172.30.0.1:31000/githedgehog/fabric/agent
+    username: reader
+  vlanNamespaces:
+    default:
+      ranges:
+      - from: 1000
+        to: 2999
+  vpcAttachments:
+    server-01--eslag--leaf-01--leaf-02--vpc-01--subnet-01:
+      connection: server-01--eslag--leaf-01--leaf-02
+      subnet: vpc-01/subnet-01
+    server-02--eslag--leaf-01--leaf-02--vpc-01--subnet-01:
+      connection: server-02--eslag--leaf-01--leaf-02
+      subnet: vpc-01/subnet-01
+    server-03--unbundled--leaf-01--vpc-02--subnet-01:
+      connection: server-03--unbundled--leaf-01
+      subnet: vpc-02/subnet-01
+  vpcPeers:
+    vpc-01--vpc-02:
+      permit:
+      - vpc-01: {}
+        vpc-02: {}
+  vpcs:
+    vpc-01:
+      ipv4Namespace: default
+      subnets:
+        subnet-01:
+          dhcp:
+            enable: true
+            range:
+              end: 10.0.1.255
+              start: 10.0.1.2
+          gateway: 10.0.1.1
+          subnet: 10.0.1.0/24
+          vlan: 1001
+      vlanNamespace: default
+    vpc-02:
+      ipv4Namespace: default
+      subnets:
+        subnet-01:
+          dhcp:
+            enable: true
+            range:
+              end: 10.0.2.255
+              start: 10.0.2.2
+          gateway: 10.0.2.1
+          subnet: 10.0.2.0/24
+          vlan: 1002
+      vlanNamespace: default
+status: {}
+

--- a/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.out.actions.expected.yaml
@@ -1,0 +1,2927 @@
+- path: /ztp/config
+  summary: Update ZTP
+  type: replace
+  value:
+    config:
+      admin-mode: false
+  weight: 1
+- path: /system/config
+  summary: Update Hostname
+  type: replace
+  value:
+    config:
+      hostname: leaf-01
+  weight: 2
+- path: /lldp/config
+  summary: Create LLDP
+  type: update
+  value:
+    config:
+      enabled: true
+      hello-timer: "5"
+      system-description: Hedgehog Fabric
+      system-name: leaf-01
+  weight: 3
+- path: /system/aaa/authentication/users/user[username=admin]
+  summary: Create User admin
+  type: update
+  value:
+    user:
+    - config:
+        password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+        role: admin
+        username: admin
+      username: admin
+  weight: 4
+- path: /system/aaa/authentication/users/user[username=op]
+  summary: Create User op
+  type: update
+  value:
+    user:
+    - config:
+        password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+        role: operator
+        username: op
+      username: op
+  weight: 4
+- customFunc: true
+  path: ""
+  summary: User admin authorized keys
+  type: ""
+  weight: 5
+- customFunc: true
+  path: ""
+  summary: User op authorized keys
+  type: ""
+  weight: 5
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]
+  summary: Create Prefix List Base all-vtep-prefixes
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: all-vtep-prefixes
+      name: all-vtep-prefixes
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=any-prefix]
+  summary: Create Prefix List Base any-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: any-prefix
+      name: any-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ipns-subnets--default]
+  summary: Create Prefix List Base ipns-subnets--default
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=protocol-loopback-prefix]
+  summary: Create Prefix List Base protocol-loopback-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: protocol-loopback-prefix
+      name: protocol-loopback-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=static-ext-subnets]
+  summary: Create Prefix List Base static-ext-subnets
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: static-ext-subnets
+      name: static-ext-subnets
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-ext-prefixes--vpc-01]
+  summary: Create Prefix List Base vpc-ext-prefixes--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-ext-prefixes--vpc-01
+      name: vpc-ext-prefixes--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-ext-prefixes--vpc-02]
+  summary: Create Prefix List Base vpc-ext-prefixes--vpc-02
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-ext-prefixes--vpc-02
+      name: vpc-ext-prefixes--vpc-02
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-loopback-prefix]
+  summary: Create Prefix List Base vpc-loopback-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-loopback-prefix
+      name: vpc-loopback-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-01]
+  summary: Create Prefix List Base vpc-not-subnets--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-not-subnets--vpc-01
+      name: vpc-not-subnets--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-02]
+  summary: Create Prefix List Base vpc-not-subnets--vpc-02
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-not-subnets--vpc-02
+      name: vpc-not-subnets--vpc-02
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-01]
+  summary: Create Prefix List Base vpc-peers--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-peers--vpc-01
+      name: vpc-peers--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-02]
+  summary: Create Prefix List Base vpc-peers--vpc-02
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-peers--vpc-02
+      name: vpc-peers--vpc-02
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-static-ext-subnets--vpc-01]
+  summary: Create Prefix List Base vpc-static-ext-subnets--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-static-ext-subnets--vpc-01
+      name: vpc-static-ext-subnets--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-static-ext-subnets--vpc-02]
+  summary: Create Prefix List Base vpc-static-ext-subnets--vpc-02
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-static-ext-subnets--vpc-02
+      name: vpc-static-ext-subnets--vpc-02
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-01]
+  summary: Create Prefix List Base vpc-subnets--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-subnets--vpc-01
+      name: vpc-subnets--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-02]
+  summary: Create Prefix List Base vpc-subnets--vpc-02
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-subnets--vpc-02
+      name: vpc-subnets--vpc-02
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.0/22
+        masklength-range: 22..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.0/22
+      masklength-range: 22..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=any-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 10
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ipns-subnets--default]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.0.0/16][masklength-range=16..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.0.0/16
+        masklength-range: 16..32
+        sequence-number: 1
+      ip-prefix: 10.0.0.0/16
+      masklength-range: 16..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=protocol-loopback-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.8.0/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.8.0/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.8.0/32
+      masklength-range: 32..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-loopback-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.96.0/19][masklength-range=19..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.96.0/19
+        masklength-range: 19..32
+        sequence-number: 10
+      ip-prefix: 172.30.96.0/19
+      masklength-range: 19..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.1.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.1.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.1.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=65535][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 65535
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 65535
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 65535
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-02]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.2.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.2.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.2.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-02]/extended-prefixes/extended-prefix[sequence-number=65535][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 65535
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 65535
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 65535
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-01]/extended-prefixes/extended-prefix[sequence-number=301][ip-prefix=10.0.2.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 301
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.2.0/24
+        masklength-range: 24..32
+        sequence-number: 301
+      ip-prefix: 10.0.2.0/24
+      masklength-range: 24..32
+      sequence-number: 301
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-02]/extended-prefixes/extended-prefix[sequence-number=201][ip-prefix=10.0.1.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 201
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.1.0/24
+        masklength-range: 24..32
+        sequence-number: 201
+      ip-prefix: 10.0.1.0/24
+      masklength-range: 24..32
+      sequence-number: 201
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.1.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.1.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.1.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-02]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.2.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.2.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.2.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
+  summary: Create Community Lists all-externals
+  type: update
+  value:
+    community-set:
+    - community-set-name: all-externals
+      config:
+        action: PERMIT
+        community-member:
+        - 65102:1000
+        community-set-name: all-externals
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-gw-prios]
+  summary: Create Community Lists all-gw-prios
+  type: update
+  value:
+    community-set:
+    - community-set-name: all-gw-prios
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:0"
+        - "50001:1"
+        - "50001:2"
+        - "50001:3"
+        - "50001:4"
+        - "50001:5"
+        - "50001:6"
+        - "50001:7"
+        - "50001:8"
+        - "50001:9"
+        community-set-name: all-gw-prios
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-0]
+  summary: Create Community Lists gw-prio-0
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-0
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:0"
+        community-set-name: gw-prio-0
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-1]
+  summary: Create Community Lists gw-prio-1
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-1
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:1"
+        community-set-name: gw-prio-1
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-2]
+  summary: Create Community Lists gw-prio-2
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-2
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:2"
+        community-set-name: gw-prio-2
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-3]
+  summary: Create Community Lists gw-prio-3
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-3
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:3"
+        community-set-name: gw-prio-3
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-4]
+  summary: Create Community Lists gw-prio-4
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-4
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:4"
+        community-set-name: gw-prio-4
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-5]
+  summary: Create Community Lists gw-prio-5
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-5
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:5"
+        community-set-name: gw-prio-5
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-6]
+  summary: Create Community Lists gw-prio-6
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-6
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:6"
+        community-set-name: gw-prio-6
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-7]
+  summary: Create Community Lists gw-prio-7
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-7
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:7"
+        community-set-name: gw-prio-7
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-8]
+  summary: Create Community Lists gw-prio-8
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-8
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:8"
+        community-set-name: gw-prio-8
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-9]
+  summary: Create Community Lists gw-prio-9
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-9
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:9"
+        community-set-name: gw-prio-9
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=no-community]
+  summary: Create Community Lists no-community
+  type: update
+  value:
+    community-set:
+    - community-set-name: no-community
+      config:
+        action: PERMIT
+        community-member:
+        - REGEX:^$
+        community-set-name: no-community
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=vpc-peers--vpc-01]
+  summary: Create Community Lists vpc-peers--vpc-01
+  type: update
+  value:
+    community-set:
+    - community-set-name: vpc-peers--vpc-01
+      config:
+        action: PERMIT
+        community-member:
+        - "50000:2"
+        - "50000:3"
+        community-set-name: vpc-peers--vpc-01
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=vpc-peers--vpc-02]
+  summary: Create Community Lists vpc-peers--vpc-02
+  type: update
+  value:
+    community-set:
+    - community-set-name: vpc-peers--vpc-02
+      config:
+        action: PERMIT
+        community-member:
+        - "50000:2"
+        - "50000:3"
+        community-set-name: vpc-peers--vpc-02
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/as-path-sets/as-path-set[as-path-set-name=fabric-gw-aspath]
+  summary: Create AS Path Lists fabric-gw-aspath
+  type: update
+  value:
+    as-path-set:
+    - as-path-set-name: fabric-gw-aspath
+      config:
+        action: PERMIT
+        as-path-set-member:
+        - _65534_
+        as-path-set-name: fabric-gw-aspath
+  weight: 12
+- path: /interfaces/interface[name=PortChannel1]
+  summary: Create Interface PortChannel1 Base PortChannels
+  type: update
+  value:
+    interface:
+    - config:
+        description: ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+        enabled: true
+        mtu: 9036
+        name: PortChannel1
+      name: PortChannel1
+  weight: 15
+- path: /interfaces/interface[name=PortChannel2]
+  summary: Create Interface PortChannel2 Base PortChannels
+  type: update
+  value:
+    interface:
+    - config:
+        description: ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+        enabled: true
+        mtu: 9036
+        name: PortChannel2
+      name: PortChannel2
+  weight: 15
+- path: /interfaces/interface[name=Ethernet0]
+  summary: Create Interface Ethernet0 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: PC2 ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+        enabled: true
+        mtu: 9036
+        name: Ethernet0
+      name: Ethernet0
+  weight: 16
+- path: /interfaces/interface[name=Ethernet1]
+  summary: Create Interface Ethernet1 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: PC1 ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+        enabled: true
+        mtu: 9036
+        name: Ethernet1
+      name: Ethernet1
+  weight: 16
+- path: /interfaces/interface[name=Ethernet2]
+  summary: Create Interface Ethernet2 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Unbundled server-03 server-03--unbundled--leaf-01
+        enabled: true
+        mtu: 9036
+        name: Ethernet2
+      name: Ethernet2
+  weight: 16
+- path: /interfaces/interface[name=Ethernet3]
+  summary: Create Interface Ethernet3 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Mesh leaf-02/E1/5 leaf-01--mesh--leaf-02
+        enabled: true
+        name: Ethernet3
+      name: Ethernet3
+  weight: 16
+- path: /interfaces/interface[name=Ethernet4]
+  summary: Create Interface Ethernet4 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Mesh leaf-02/E1/6 leaf-01--mesh--leaf-02
+        enabled: true
+        name: Ethernet4
+      name: Ethernet4
+  weight: 16
+- path: /interfaces/interface[name=Ethernet5]
+  summary: Create Interface Ethernet5 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Mesh leaf-03/E1/5 leaf-01--mesh--leaf-03
+        enabled: true
+        name: Ethernet5
+      name: Ethernet5
+  weight: 16
+- path: /interfaces/interface[name=Ethernet6]
+  summary: Create Interface Ethernet6 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Mesh leaf-03/E1/6 leaf-01--mesh--leaf-03
+        enabled: true
+        name: Ethernet6
+      name: Ethernet6
+  weight: 16
+- path: /interfaces/interface[name=Ethernet7]
+  summary: Create Interface Ethernet7 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+        enabled: true
+        name: Ethernet7
+      name: Ethernet7
+  weight: 16
+- path: /interfaces/interface[name=Loopback1]
+  summary: Create Interface Loopback1 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Protocol loopback
+        enabled: true
+        name: Loopback1
+      name: Loopback1
+  weight: 16
+- path: /interfaces/interface[name=Loopback2]
+  summary: Create Interface Loopback2 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VTEP loopback
+        enabled: true
+        name: Loopback2
+      name: Loopback2
+  weight: 16
+- path: /interfaces/interface[name=Management0]
+  summary: Create Interface Management0 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Management link
+        enabled: true
+        name: Management0
+      name: Management0
+  weight: 16
+- path: /interfaces/interface[name=Vlan1001]
+  summary: Create Interface Vlan1001 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-01/subnet-01
+        enabled: true
+        name: Vlan1001
+      name: Vlan1001
+  weight: 16
+- path: /interfaces/interface[name=Vlan1002]
+  summary: Create Interface Vlan1002 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-02/subnet-01
+        enabled: true
+        name: Vlan1002
+      name: Vlan1002
+  weight: 16
+- path: /interfaces/interface[name=Vlan3000]
+  summary: Create Interface Vlan3000 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-01 IRB
+        enabled: true
+        name: Vlan3000
+      name: Vlan3000
+  weight: 16
+- path: /interfaces/interface[name=Vlan3001]
+  summary: Create Interface Vlan3001 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-02 IRB
+        enabled: true
+        name: Vlan3001
+      name: Vlan3001
+  weight: 16
+- path: /network-instances/network-instance[name=VrfVvpc-01]
+  summary: Create VRF VrfVvpc-01 base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: VrfVvpc-01
+      name: VrfVvpc-01
+  weight: 17
+- path: /network-instances/network-instance[name=VrfVvpc-02]
+  summary: Create VRF VrfVvpc-02 base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: VrfVvpc-02
+      name: VrfVvpc-02
+  weight: 17
+- path: /network-instances/network-instance[name=default]
+  summary: Create VRF default base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: default
+      name: default
+  weight: 17
+- path: /sonic-vrf/VRF/VRF_LIST[vrf_name=VrfVvpc-01]/vni
+  summary: Create VRF VNI VrfVvpc-01
+  type: update
+  value:
+    vni: 200
+    vrf_name: VrfVvpc-01
+  weight: 18
+- path: /sonic-vrf/VRF/VRF_LIST[vrf_name=VrfVvpc-02]/vni
+  summary: Create VRF VNI VrfVvpc-02
+  type: update
+  value:
+    vni: 300
+    vrf_name: VrfVvpc-02
+  weight: 18
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]
+  summary: Create Route Maps Base filter-attached-hosts
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]
+  summary: Create Route Maps Base import-vrf--vpc-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-02]
+  summary: Create Route Maps Base import-vrf--vpc-02
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: import-vrf--vpc-02
+      name: import-vrf--vpc-02
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=ipns-subnets--default]
+  summary: Create Route Maps Base ipns-subnets--default
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]
+  summary: Create Route Maps Base l2vpn-neighbors
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]
+  summary: Create Route Maps Base loopback-all-vteps
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
+  summary: Create Route Maps Base protocol-loopback-only
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]
+  summary: Create Route Maps Base vpc-redistribute-connected--vpc-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-02]
+  summary: Create Route Maps Base vpc-redistribute-connected--vpc-02
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-connected--vpc-02
+      name: vpc-redistribute-connected--vpc-02
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]
+  summary: Create Route Maps Base vpc-redistribute-static--vpc-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-02]
+  summary: Create Route Maps Base vpc-redistribute-static--vpc-02
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-static--vpc-02
+      name: vpc-redistribute-static--vpc-02
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        config:
+          install-protocol-eq: ATTACHED_HOST
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            next-hop-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=10003]
+  summary: Create Route Map Statement 10003
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-not-subnets--vpc-02
+        match-src-network-instance:
+          config:
+            name: VrfVvpc-02
+      config:
+        name: "10003"
+      name: "10003"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=50000]
+  summary: Create Route Map Statement 50000
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: vpc-peers--vpc-01
+      config:
+        name: "50000"
+      name: "50000"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=50001]
+  summary: Create Route Map Statement 50001
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: no-community
+        match-prefix-set:
+          config:
+            prefix-set: vpc-peers--vpc-01
+      config:
+        name: "50001"
+      name: "50001"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-02]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            next-hop-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-02]/statements/statement[name=10002]
+  summary: Create Route Map Statement 10002
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-not-subnets--vpc-01
+        match-src-network-instance:
+          config:
+            name: VrfVvpc-01
+      config:
+        name: "10002"
+      name: "10002"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-02]/statements/statement[name=50000]
+  summary: Create Route Map Statement 50000
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: vpc-peers--vpc-02
+      config:
+        name: "50000"
+      name: "50000"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-02]/statements/statement[name=50001]
+  summary: Create Route Map Statement 50001
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: no-community
+        match-prefix-set:
+          config:
+            prefix-set: vpc-peers--vpc-02
+      config:
+        name: "50001"
+      name: "50001"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-02]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ipns-subnets--default]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ipns-subnets--default
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 210
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-0
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 201
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-9
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=2]
+  summary: Create Route Map Statement 2
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 209
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-1
+      config:
+        name: "2"
+      name: "2"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=3]
+  summary: Create Route Map Statement 3
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 208
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-2
+      config:
+        name: "3"
+      name: "3"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=4]
+  summary: Create Route Map Statement 4
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 207
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-3
+      config:
+        name: "4"
+      name: "4"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 206
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-4
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=6]
+  summary: Create Route Map Statement 6
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 205
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-5
+      config:
+        name: "6"
+      name: "6"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=65525]
+  summary: Create Route Map Statement 65525
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 150
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: all-externals
+      config:
+        name: "65525"
+      name: "65525"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=7]
+  summary: Create Route Map Statement 7
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 204
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-6
+      config:
+        name: "7"
+      name: "7"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=8]
+  summary: Create Route Map Statement 8
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 203
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-7
+      config:
+        name: "8"
+      name: "8"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=9]
+  summary: Create Route Map Statement 9
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 202
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-8
+      config:
+        name: "9"
+      name: "9"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: all-vtep-prefixes
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: protocol-loopback-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          set-community:
+            config:
+              method: INLINE
+              options: ADD
+            inline:
+              config:
+                communities:
+                - "50000:2"
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-subnets--vpc-01
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=6]
+  summary: Create Route Map Statement 6
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-01
+      config:
+        name: "6"
+      name: "6"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-02]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-02]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-02]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          set-community:
+            config:
+              method: INLINE
+              options: ADD
+            inline:
+              config:
+                communities:
+                - "50000:3"
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-subnets--vpc-02
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-02]/statements/statement[name=6]
+  summary: Create Route Map Statement 6
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-02
+      config:
+        name: "6"
+      name: "6"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-ext-prefixes--vpc-01
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-01
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-02]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-02]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-ext-prefixes--vpc-02
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-02]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-02
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /interfaces/interface[name=PortChannel1]/aggregation/switched-vlan/config/trunk-vlans
+  summary: Create PortChannel PortChannel1 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1001
+  weight: 24
+- path: /interfaces/interface[name=PortChannel2]/aggregation/switched-vlan/config/trunk-vlans
+  summary: Create PortChannel PortChannel2 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1001
+  weight: 24
+- path: /interfaces/interface[name=Ethernet0]/ethernet
+  summary: Create Interface Ethernet0 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet1]/ethernet
+  summary: Create Interface Ethernet1 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet2]/ethernet
+  summary: Create Interface Ethernet2 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet3]/ethernet
+  summary: Create Interface Ethernet3 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet4]/ethernet
+  summary: Create Interface Ethernet4 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet5]/ethernet
+  summary: Create Interface Ethernet5 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet6]/ethernet
+  summary: Create Interface Ethernet6 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet7]/ethernet
+  summary: Create Interface Ethernet7 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Vlan1001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan1001 VLAN Anycast Gateway
+  type: update
+  value:
+    static-anycast-gateway:
+    - 10.0.1.1/24
+  weight: 26
+- path: /interfaces/interface[name=Vlan1002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan1002 VLAN Anycast Gateway
+  type: update
+  value:
+    static-anycast-gateway:
+    - 10.0.2.1/24
+  weight: 26
+- path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan3000 VLAN Anycast Gateway
+  type: update
+  weight: 26
+- path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan3001 VLAN Anycast Gateway
+  type: update
+  weight: 26
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/system_mac
+  summary: Create PortChannel System MAC PortChannel1
+  type: update
+  value:
+    system_mac: f2:00:00:00:00:02
+  weight: 28
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/system_mac
+  summary: Create PortChannel System MAC PortChannel2
+  type: update
+  value:
+    system_mac: f2:00:00:00:00:01
+  weight: 28
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
+  summary: Create PortChannel Fallback PortChannel1
+  type: update
+  value:
+    fallback: false
+  weight: 29
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/fallback
+  summary: Create PortChannel Fallback PortChannel2
+  type: update
+  value:
+    fallback: false
+  weight: 29
+- path: /interfaces/interface[name=Ethernet2]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet2 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1002
+  weight: 43
+- path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan1001]
+  summary: Create VRF interface Vlan1001
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan1001
+      id: Vlan1001
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3000]
+  summary: Create VRF interface Vlan3000
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan3000
+      id: Vlan3000
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan1002]
+  summary: Create VRF interface Vlan1002
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan1002
+      id: Vlan1002
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-02]/interfaces/interface[id=Vlan3001]
+  summary: Create VRF interface Vlan3001
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan3001
+      id: Vlan3001
+  weight: 47
+- path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1001]
+  summary: Create VRF attached host
+  type: update
+  value:
+    interface:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        interface-id: Vlan1001
+      interface-id: Vlan1001
+  weight: 50
+- path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1002]
+  summary: Create VRF attached host
+  type: update
+  value:
+    interface:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        interface-id: Vlan1002
+      interface-id: Vlan1002
+  weight: 50
+- path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.128.0
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.128.0
+        prefix-length: 31
+        secondary: false
+      ip: 172.30.128.0
+  weight: 51
+- path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.8.0
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.8.0
+        prefix-length: 32
+        secondary: false
+      ip: 172.30.8.0
+  weight: 51
+- path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.12.0
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.12.0
+        prefix-length: 32
+        secondary: false
+      ip: 172.30.12.0
+  weight: 51
+- path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.0.7
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.0.7
+        prefix-length: 21
+        secondary: false
+      ip: 172.30.0.7
+  weight: 51
+- path: /system/ntp/config
+  summary: Create NTP
+  type: update
+  value:
+    config:
+      source-interface:
+      - Management0
+  weight: 55
+- path: /system/ntp/servers/server[address=172.30.0.1]
+  summary: Create NTP server 172.30.0.1
+  type: update
+  value:
+    server:
+    - address: 172.30.0.1
+      config:
+        address: 172.30.0.1
+        prefer: true
+  weight: 56
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan1001
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1001
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan1002
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1002
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan3000
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan3000
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan3001
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan3001
+      suppress: "on"
+  weight: 61
+- path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
+  summary: Create VRF VrfVvpc-01 SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=VrfVvpc-02]/global-sag/config
+  summary: Create VRF VrfVvpc-02 SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=default]/global-sag/config
+  summary: Create VRF default SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
+  summary: Create VRF VrfVvpc-01 EVPNMH
+  type: update
+  weight: 65
+- path: /network-instances/network-instance[name=VrfVvpc-02]/evpn/evpn-mh/config
+  summary: Create VRF VrfVvpc-02 EVPNMH
+  type: update
+  weight: 65
+- path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
+  summary: Create VRF default EVPNMH
+  type: update
+  value:
+    config:
+      mac-holdtime: 60
+      startup-delay: 60
+  weight: 65
+- path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
+  summary: Create VRF PortChannel1 EVPN ethernet segment
+  type: update
+  value:
+    ethernet-segment:
+    - config:
+        esi: 00f20000f20000000002
+        esi-type: TYPE_0_OPERATOR_CONFIGURED
+        interface: PortChannel1
+        name: PortChannel1
+      name: PortChannel1
+  weight: 66
+- path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
+  summary: Create VRF PortChannel2 EVPN ethernet segment
+  type: update
+  value:
+    ethernet-segment:
+    - config:
+        esi: 00f20000f20000000001
+        esi-type: TYPE_0_OPERATOR_CONFIGURED
+        interface: PortChannel2
+        name: PortChannel2
+      name: PortChannel2
+  weight: 66
+- path: /lst/lst-groups/lst-group
+  summary: Create LST Group spinelink
+  type: update
+  value:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+  weight: 67
+- path: /lst/interfaces/interface[id=Ethernet3]
+  summary: Create LST Interface Ethernet3
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet3
+      id: Ethernet3
+      interface-ref:
+        config:
+          interface: Ethernet3
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /lst/interfaces/interface[id=Ethernet4]
+  summary: Create LST Interface Ethernet4
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /lst/interfaces/interface[id=Ethernet5]
+  summary: Create LST Interface Ethernet5
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /lst/interfaces/interface[id=Ethernet6]
+  summary: Create LST Interface Ethernet6
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
+  summary: Create VXLAN tunnel vtepfabric
+  type: update
+  value:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.0
+  weight: 71
+- path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
+  summary: Create VXLAN EVPN NVO nvo1
+  type: update
+  value:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  weight: 73
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_200_Vlan3000
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_200_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 200
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_201_Vlan1001
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_201_Vlan1001
+      name: vtepfabric
+      vlan: Vlan1001
+      vni: 201
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_300_Vlan3001
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_300_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 300
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_301_Vlan1002
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_301_Vlan1002
+      name: vtepfabric
+      vlan: Vlan1002
+      vni: 301
+  weight: 75
+- path: /acl/acl-sets/acl-set
+  summary: Create ACL no-ipns-peering--default base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 1
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 1
+      ipv4:
+        config:
+          destination-address: 10.0.0.0/16
+          source-address: 10.0.0.0/16
+      sequence-id: 1
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 78
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF VrfVvpc-01 BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65101
+          network-import-check: true
+          router-id: 172.30.8.0
+  weight: 80
+- path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF VrfVvpc-02 BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65101
+          network-import-check: true
+          router-id: 172.30.8.0
+  weight: 80
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF default BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65101
+          network-import-check: true
+          router-id: 172.30.8.0
+  weight: 80
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF VrfVvpc-01 BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        route-advertise:
+          route-advertise-list:
+          - advertise-afi-safi: IPV4_UNICAST
+            config:
+              advertise-afi-safi: IPV4_UNICAST
+              route-map:
+              - filter-attached-hosts
+  weight: 81
+- path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF VrfVvpc-02 BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        route-advertise:
+          route-advertise-list:
+          - advertise-afi-safi: IPV4_UNICAST
+            config:
+              advertise-afi-safi: IPV4_UNICAST
+              route-map:
+              - filter-attached-hosts
+  weight: 81
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF default BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        config:
+          advertise-all-vni: true
+        route-advertise:
+          route-advertise-list: []
+  weight: 81
+- path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
+  summary: Create BFD Profile fabric
+  type: update
+  value:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+  weight: 82
+- path: /openconfig-errdisable-ext:errdisable/config
+  summary: Create ErrDisable Global
+  type: update
+  value:
+    config:
+      cause:
+      - LINK_FLAP
+      interval: 300
+  weight: 83
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
+  summary: Create ErrDisable Interface Ethernet3
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
+  summary: Create ErrDisable Interface Ethernet4
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
+  summary: Create ErrDisable Interface Ethernet5
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
+  summary: Create ErrDisable Interface Ethernet6
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
+  summary: Create ErrDisable Interface Ethernet7
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 86
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.1]
+  summary: Create VRF BGP neighbor 172.30.128.1
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          allow-own-as:
+            config:
+              enabled: true
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+        enabled: true
+        neighbor-address: 172.30.128.1
+        peer-as: 65534
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: 172.30.128.1
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
+  summary: Create VRF BGP neighbor 172.30.8.1
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric leaf-02 loopback (mesh)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.1
+        peer-as: 65102
+      neighbor-address: 172.30.8.1
+      transport:
+        config:
+          local-address: 172.30.8.0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
+  summary: Create VRF BGP neighbor 172.30.8.2
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric leaf-03 loopback (mesh)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.2
+        peer-as: 65103
+      neighbor-address: 172.30.8.2
+      transport:
+        config:
+          local-address: 172.30.8.0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3]
+  summary: Create VRF BGP neighbor Ethernet3
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-02/E1/5 leaf-01--mesh--leaf-02
+        enabled: true
+        neighbor-address: Ethernet3
+        peer-as: 65102
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet3
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet4]
+  summary: Create VRF BGP neighbor Ethernet4
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-02/E1/6 leaf-01--mesh--leaf-02
+        enabled: true
+        neighbor-address: Ethernet4
+        peer-as: 65102
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet4
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet5]
+  summary: Create VRF BGP neighbor Ethernet5
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-03/E1/5 leaf-01--mesh--leaf-03
+        enabled: true
+        neighbor-address: Ethernet5
+        peer-as: 65103
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet5
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet6]
+  summary: Create VRF BGP neighbor Ethernet6
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-03/E1/6 leaf-01--mesh--leaf-03
+        enabled: true
+        neighbor-address: Ethernet6
+        peer-as: 65103
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet6
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
+  summary: Create VRF BGP network 172.30.8.0/32
+  type: update
+  value:
+    network:
+    - config:
+        prefix: 172.30.8.0/32
+      prefix: 172.30.8.0/32
+  weight: 88
+- path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
+  summary: Create VRF table connection attachedhost
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      dst-protocol: BGP
+      src-protocol: ATTACHED_HOST
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-connected--vpc-01
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-static--vpc-01
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
+  summary: Create VRF table connection attachedhost
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      dst-protocol: BGP
+      src-protocol: ATTACHED_HOST
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-connected--vpc-02
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-02]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-static--vpc-02
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /network-instances/network-instance[name=default]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=default]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
+  summary: Create VRF BGP import policy VrfVvpc-01
+  type: update
+  value:
+    policy-name: import-vrf--vpc-01
+  weight: 90
+- path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
+  summary: Create VRF BGP import policy VrfVvpc-02
+  type: update
+  value:
+    policy-name: import-vrf--vpc-02
+  weight: 90
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
+  summary: Create VRF BGP import VRF VrfVvpc-01
+  type: update
+  value:
+    name:
+    - VrfVvpc-02
+  weight: 91
+- path: /network-instances/network-instance[name=VrfVvpc-02]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
+  summary: Create VRF BGP import VRF VrfVvpc-02
+  type: update
+  value:
+    name:
+    - VrfVvpc-01
+  weight: 91
+- path: relay-agent/dhcp/interfaces/interface[id=Vlan1001]
+  summary: Create DHCP relay Vlan1001
+  type: update
+  value:
+    interface:
+    - agent-information-option:
+        config:
+          link-select: ENABLE
+          vrf-select: ENABLE
+      config:
+        helper-address:
+        - 172.30.0.1
+        src-intf: Management0
+      id: Vlan1001
+  weight: 92
+- path: relay-agent/dhcp/interfaces/interface[id=Vlan1002]
+  summary: Create DHCP relay Vlan1002
+  type: update
+  value:
+    interface:
+    - agent-information-option:
+        config:
+          link-select: ENABLE
+          vrf-select: ENABLE
+      config:
+        helper-address:
+        - 172.30.0.1
+        src-intf: Management0
+      id: Vlan1002
+  weight: 92
+- path: /loadshare/roce-attrs
+  summary: Update ECMP RoCE
+  type: replace
+  value:
+    roce-attrs:
+      config:
+        hash: hash
+        qpn: false
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.out.gnmi.expected.yaml
@@ -1,0 +1,1777 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+errdisable:
+  config:
+    cause:
+    - LINK_FLAP
+    interval: 300
+errdisable-port:
+  port:
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet3
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet4
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet5
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet6
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet7
+interfaces:
+  interface:
+  - config:
+      description: PC2 ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet0
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Unbundled server-03 server-03--unbundled--leaf-01
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1002
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Mesh leaf-02/E1/5 leaf-01--mesh--leaf-02
+      enabled: true
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Mesh leaf-02/E1/6 leaf-01--mesh--leaf-02
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Mesh leaf-03/E1/5 leaf-01--mesh--leaf-03
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Mesh leaf-03/E1/6 leaf-01--mesh--leaf-03
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.0
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.0
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.0
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.0
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.7
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.7
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1001
+    config:
+      description: ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1001
+    config:
+      description: ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+      enabled: true
+      mtu: 9036
+      name: PortChannel2
+    name: PortChannel2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: VPC vpc-01/subnet-01
+      enabled: true
+      name: Vlan1001
+    name: Vlan1001
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.1.1/24
+  - config:
+      description: VPC vpc-02/subnet-01
+      enabled: true
+      name: Vlan1002
+    name: Vlan1002
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.2.1/24
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-02 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-01
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+lst:
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet3
+      id: Ethernet3
+      interface-ref:
+        config:
+          interface: Ethernet3
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  lst-groups:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1001
+        id: Vlan1001
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1001
+              interface-id: Vlan1001
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-02
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.0
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-02
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1002
+        id: Vlan1002
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-02
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1002
+              interface-id: Vlan1002
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    policy-name: import-vrf--vpc-02
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.0
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-02
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-02
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    evpn:
+      ethernet-segments:
+        ethernet-segment:
+        - config:
+            esi: 00f20000f20000000002
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel1
+            name: PortChannel1
+          name: PortChannel1
+        - config:
+            esi: 00f20000f20000000001
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel2
+            name: PortChannel2
+          name: PortChannel2
+      evpn-mh:
+        config:
+          mac-holdtime: 60
+          startup-delay: 60
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.0/32
+                    prefix: 172.30.8.0/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65101
+              network-import-check: true
+              router-id: 172.30.8.0
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+                enabled: true
+                neighbor-address: 172.30.128.1
+                peer-as: 65534
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: 172.30.128.1
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-02 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65102
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-03 loopback (mesh)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.2
+                peer-as: 65103
+              neighbor-address: 172.30.8.2
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-02/E1/5 leaf-01--mesh--leaf-02
+                enabled: true
+                neighbor-address: Ethernet3
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet3
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-02/E1/6 leaf-01--mesh--leaf-02
+                enabled: true
+                neighbor-address: Ethernet4
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-03/E1/5 leaf-01--mesh--leaf-03
+                enabled: true
+                neighbor-address: Ethernet5
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet5
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-03/E1/6 leaf-01--mesh--leaf-03
+                enabled: true
+                neighbor-address: Ethernet6
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet6
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1001
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1002
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:3"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-02
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            - "50000:3"
+            community-set-name: vpc-peers--vpc-02
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.0/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.0/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-02
+        name: vpc-ext-prefixes--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 201
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 201
+        name: vpc-peers--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-02
+        name: vpc-static-ext-subnets--vpc-02
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-02
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+        name: vpc-subnets--vpc-02
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-02
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-02
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-02
+      name: import-vrf--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-01
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-01
+          config:
+            name: "10002"
+          name: "10002"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-02
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-02
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:2"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-02
+      name: vpc-redistribute-connected--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-02
+      name: vpc-redistribute-static--vpc-02
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-02
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-02
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+      system_mac: f2:00:00:00:00:02
+    - fallback: false
+      name: PortChannel2
+      system_mac: f2:00:00:00:00:01
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 200
+      vrf_name: VrfVvpc-01
+    - vni: 300
+      vrf_name: VrfVvpc-02
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1001
+      suppress: "on"
+    - name: Vlan1002
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.0
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_200_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 200
+    - mapname: map_201_Vlan1001
+      name: vtepfabric
+      vlan: Vlan1001
+      vni: 201
+    - mapname: map_300_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 300
+    - mapname: map_301_Vlan1002
+      name: vtepfabric
+      vlan: Vlan1002
+      vni: 301
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-01
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-mesh-leaf-01.out.spec.expected.yaml
@@ -1,0 +1,786 @@
+acls:
+  no-ipns-peering--default:
+    description: Prevent VPCs to cross-talk via the external
+    entries:
+      "1":
+        action: DROP
+        destinationAddress: 10.0.0.0/16
+        protocol: IP
+        sourceAddress: 10.0.0.0/16
+      "65535":
+        action: ACCEPT
+        protocol: IP
+asPathLists:
+  fabric-gw-aspath:
+    members:
+    - _65534_
+bfdProfiles:
+  fabric:
+    desiredMinimumTxInterval: 300
+    detectionMultiplier: 3
+    passiveMode: false
+    requiredMinimumReceive: 300
+communityLists:
+  all-externals:
+    members:
+    - 65102:1000
+  all-gw-prios:
+    members:
+    - "50001:0"
+    - "50001:1"
+    - "50001:2"
+    - "50001:3"
+    - "50001:4"
+    - "50001:5"
+    - "50001:6"
+    - "50001:7"
+    - "50001:8"
+    - "50001:9"
+  gw-prio-0:
+    members:
+    - "50001:0"
+  gw-prio-1:
+    members:
+    - "50001:1"
+  gw-prio-2:
+    members:
+    - "50001:2"
+  gw-prio-3:
+    members:
+    - "50001:3"
+  gw-prio-4:
+    members:
+    - "50001:4"
+  gw-prio-5:
+    members:
+    - "50001:5"
+  gw-prio-6:
+    members:
+    - "50001:6"
+  gw-prio-7:
+    members:
+    - "50001:7"
+  gw-prio-8:
+    members:
+    - "50001:8"
+  gw-prio-9:
+    members:
+    - "50001:9"
+  no-community:
+    members:
+    - REGEX:^$
+  vpc-peers--vpc-01:
+    members:
+    - "50000:2"
+    - "50000:3"
+  vpc-peers--vpc-02:
+    members:
+    - "50000:2"
+    - "50000:3"
+dhcpRelays:
+  Vlan1001:
+    linkSelect: true
+    relayAddress:
+    - 172.30.0.1
+    sourceInterface: Management0
+    vrfSelect: true
+  Vlan1002:
+    linkSelect: true
+    relayAddress:
+    - 172.30.0.1
+    sourceInterface: Management0
+    vrfSelect: true
+ecmpRoCEQPN: false
+errDisableGlobal:
+  recoveryInterval: 300
+errDisableInterfaces:
+  Ethernet3:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet4:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet5:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet6:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet7:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+hostname: leaf-01
+interfaces:
+  Ethernet0:
+    autoNegotiate: false
+    description: PC2 ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+    enabled: true
+    mtu: 9036
+    portChannel: PortChannel2
+    subinterfaces:
+      "0": {}
+  Ethernet1:
+    autoNegotiate: false
+    description: PC1 ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+    enabled: true
+    mtu: 9036
+    portChannel: PortChannel1
+    subinterfaces:
+      "0": {}
+  Ethernet2:
+    autoNegotiate: false
+    description: Unbundled server-03 server-03--unbundled--leaf-01
+    enabled: true
+    mtu: 9036
+    subinterfaces:
+      "0": {}
+    trunkVLANs:
+    - "1002"
+  Ethernet3:
+    autoNegotiate: false
+    description: Mesh leaf-02/E1/5 leaf-01--mesh--leaf-02
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet4:
+    autoNegotiate: false
+    description: Mesh leaf-02/E1/6 leaf-01--mesh--leaf-02
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet5:
+    autoNegotiate: false
+    description: Mesh leaf-03/E1/5 leaf-01--mesh--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet6:
+    autoNegotiate: false
+    description: Mesh leaf-03/E1/6 leaf-01--mesh--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet7:
+    autoNegotiate: false
+    description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.128.0:
+            prefixLen: 31
+  Loopback1:
+    description: Protocol loopback
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.8.0:
+            prefixLen: 32
+  Loopback2:
+    description: VTEP loopback
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.12.0:
+            prefixLen: 32
+  Management0:
+    autoNegotiate: true
+    description: Management link
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.0.7:
+            prefixLen: 21
+  PortChannel1:
+    description: ESLAG server-02 server-02--eslag--leaf-01--leaf-02
+    enabled: true
+    mtu: 9036
+    subinterfaces:
+      "0": {}
+    trunkVLANs:
+    - "1001"
+  PortChannel2:
+    description: ESLAG server-01 server-01--eslag--leaf-01--leaf-02
+    enabled: true
+    mtu: 9036
+    subinterfaces:
+      "0": {}
+    trunkVLANs:
+    - "1001"
+  Vlan1001:
+    description: VPC vpc-01/subnet-01
+    enabled: true
+    vlanAnycastGateway:
+    - 10.0.1.1/24
+  Vlan1002:
+    description: VPC vpc-02/subnet-01
+    enabled: true
+    vlanAnycastGateway:
+    - 10.0.2.1/24
+  Vlan3000:
+    description: VPC vpc-01 IRB
+    enabled: true
+  Vlan3001:
+    description: VPC vpc-02 IRB
+    enabled: true
+lldp:
+  enabled: true
+  helloTimer: 5
+  systemDescription: Hedgehog Fabric
+  systemName: leaf-01
+lstGroups:
+  spinelink:
+    allEvpnEsDownstream: true
+    timeout: 60
+lstInterfaces:
+  Ethernet3:
+    groups:
+    - spinelink
+  Ethernet4:
+    groups:
+    - spinelink
+  Ethernet5:
+    groups:
+    - spinelink
+  Ethernet6:
+    groups:
+    - spinelink
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
+ntp:
+  sourceInterface:
+  - Management0
+ntpServers:
+  172.30.0.1:
+    prefer: true
+portChannelConfigs:
+  PortChannel1:
+    fallback: false
+    systemMAC: f2:00:00:00:00:02
+  PortChannel2:
+    fallback: false
+    systemMAC: f2:00:00:00:00:01
+prefixLists:
+  all-vtep-prefixes:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.0/22
+  any-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  ipns-subnets--default:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.0.0/16
+  protocol-loopback-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.8.0/32
+  static-ext-subnets: {}
+  vpc-ext-prefixes--vpc-01: {}
+  vpc-ext-prefixes--vpc-02: {}
+  vpc-loopback-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.96.0/19
+  vpc-not-subnets--vpc-01:
+    prefixes:
+      "1":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.1.0/24
+      "65535":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  vpc-not-subnets--vpc-02:
+    prefixes:
+      "1":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.2.0/24
+      "65535":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  vpc-peers--vpc-01:
+    prefixes:
+      "301":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.2.0/24
+  vpc-peers--vpc-02:
+    prefixes:
+      "201":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.1.0/24
+  vpc-static-ext-subnets--vpc-01: {}
+  vpc-static-ext-subnets--vpc-02: {}
+  vpc-subnets--vpc-01:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.1.0/24
+  vpc-subnets--vpc-02:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.2.0/24
+routeMaps:
+  filter-attached-hosts:
+    statements:
+      "10":
+        conditions:
+          attachedHost: true
+        result: reject
+      "100":
+        conditions: {}
+        result: accept
+  import-vrf--vpc-01:
+    statements:
+      "1":
+        conditions:
+          matchNextHopPrefixLists: vpc-loopback-prefix
+        result: reject
+      "10003":
+        conditions:
+          matchPrefixLists: vpc-not-subnets--vpc-02
+          matchSourceVrf: VrfVvpc-02
+        result: reject
+      "50000":
+        conditions:
+          matchCommunityLists: vpc-peers--vpc-01
+        result: accept
+      "50001":
+        conditions:
+          matchCommunityLists: no-community
+          matchPrefixLists: vpc-peers--vpc-01
+        result: accept
+      "65535":
+        conditions: {}
+        result: reject
+  import-vrf--vpc-02:
+    statements:
+      "1":
+        conditions:
+          matchNextHopPrefixLists: vpc-loopback-prefix
+        result: reject
+      "10002":
+        conditions:
+          matchPrefixLists: vpc-not-subnets--vpc-01
+          matchSourceVrf: VrfVvpc-01
+        result: reject
+      "50000":
+        conditions:
+          matchCommunityLists: vpc-peers--vpc-02
+        result: accept
+      "50001":
+        conditions:
+          matchCommunityLists: no-community
+          matchPrefixLists: vpc-peers--vpc-02
+        result: accept
+      "65535":
+        conditions: {}
+        result: reject
+  ipns-subnets--default:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ipns-subnets--default
+        result: accept
+  l2vpn-neighbors:
+    statements:
+      "1":
+        conditions:
+          matchCommunityLists: gw-prio-0
+        result: accept
+        setLocalPreference: 210
+      "2":
+        conditions:
+          matchCommunityLists: gw-prio-1
+        result: accept
+        setLocalPreference: 209
+      "3":
+        conditions:
+          matchCommunityLists: gw-prio-2
+        result: accept
+        setLocalPreference: 208
+      "4":
+        conditions:
+          matchCommunityLists: gw-prio-3
+        result: accept
+        setLocalPreference: 207
+      "5":
+        conditions:
+          matchCommunityLists: gw-prio-4
+        result: accept
+        setLocalPreference: 206
+      "6":
+        conditions:
+          matchCommunityLists: gw-prio-5
+        result: accept
+        setLocalPreference: 205
+      "7":
+        conditions:
+          matchCommunityLists: gw-prio-6
+        result: accept
+        setLocalPreference: 204
+      "8":
+        conditions:
+          matchCommunityLists: gw-prio-7
+        result: accept
+        setLocalPreference: 203
+      "9":
+        conditions:
+          matchCommunityLists: gw-prio-8
+        result: accept
+        setLocalPreference: 202
+      "10":
+        conditions:
+          matchCommunityLists: gw-prio-9
+        result: accept
+        setLocalPreference: 201
+      "65525":
+        conditions:
+          matchCommunityLists: all-externals
+        result: accept
+        setLocalPreference: 150
+      "65535":
+        conditions: {}
+        result: accept
+  loopback-all-vteps:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  protocol-loopback-only:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: protocol-loopback-prefix
+        result: accept
+  vpc-redistribute-connected--vpc-01:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-subnets--vpc-01
+        result: accept
+        setCommunities:
+        - "50000:2"
+      "6":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-01
+        result: accept
+      "10":
+        conditions: {}
+        result: reject
+  vpc-redistribute-connected--vpc-02:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-subnets--vpc-02
+        result: accept
+        setCommunities:
+        - "50000:3"
+      "6":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-02
+        result: accept
+      "10":
+        conditions: {}
+        result: reject
+  vpc-redistribute-static--vpc-01:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-01
+        result: accept
+      "10":
+        conditions:
+          matchPrefixLists: vpc-ext-prefixes--vpc-01
+        result: accept
+  vpc-redistribute-static--vpc-02:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-02
+        result: accept
+      "10":
+        conditions:
+          matchPrefixLists: vpc-ext-prefixes--vpc-02
+        result: accept
+suppressVLANNeighs:
+  Vlan1001: {}
+  Vlan1002: {}
+  Vlan3000: {}
+  Vlan3001: {}
+users:
+  admin:
+    authorizedKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICfKMFTLr3BZ5REx0PpyshgALR5ftql2OQkWGcPhQHP/
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: admin
+  op:
+    authorizedKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICfKMFTLr3BZ5REx0PpyshgALR5ftql2OQkWGcPhQHP/
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: operator
+vrfVNIMap:
+  VrfVvpc-01:
+    vni: 200
+  VrfVvpc-02:
+    vni: 300
+vrfs:
+  VrfVvpc-01:
+    anycastMAC: "00:00:00:11:11:11"
+    attachedHosts:
+      Vlan1001: {}
+    bgp:
+      as: 65101
+      ipv4Unicast:
+        enable: true
+        importPolicy: import-vrf--vpc-01
+        importVRFs:
+          VrfVvpc-02: {}
+        maxPaths: 16
+      l2vpnEvpn:
+        advertiseIPv4Unicast: true
+        advertiseIPv4UnicastRouteMaps:
+        - filter-attached-hosts
+        enable: true
+      networkImportCheck: true
+      routerID: 172.30.8.0
+    enabled: true
+    evpnMH: {}
+    interfaces:
+      Vlan1001: {}
+      Vlan3000: {}
+    tableConnections:
+      attachedhost: {}
+      connected:
+        importPolicies:
+        - vpc-redistribute-connected--vpc-01
+      static:
+        importPolicies:
+        - vpc-redistribute-static--vpc-01
+  VrfVvpc-02:
+    anycastMAC: "00:00:00:11:11:11"
+    attachedHosts:
+      Vlan1002: {}
+    bgp:
+      as: 65101
+      ipv4Unicast:
+        enable: true
+        importPolicy: import-vrf--vpc-02
+        importVRFs:
+          VrfVvpc-01: {}
+        maxPaths: 16
+      l2vpnEvpn:
+        advertiseIPv4Unicast: true
+        advertiseIPv4UnicastRouteMaps:
+        - filter-attached-hosts
+        enable: true
+      networkImportCheck: true
+      routerID: 172.30.8.0
+    enabled: true
+    evpnMH: {}
+    interfaces:
+      Vlan1002: {}
+      Vlan3001: {}
+    tableConnections:
+      attachedhost: {}
+      connected:
+        importPolicies:
+        - vpc-redistribute-connected--vpc-02
+      static:
+        importPolicies:
+        - vpc-redistribute-static--vpc-02
+  default:
+    anycastMAC: "00:00:00:11:11:11"
+    bgp:
+      as: 65101
+      ipv4Unicast:
+        enable: true
+        maxPaths: 16
+        networks:
+          172.30.8.0/32: {}
+      l2vpnEvpn:
+        advertiseAllVnis: true
+        enable: true
+      neighbors:
+        172.30.8.1:
+          description: Fabric leaf-02 loopback (mesh)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65102
+          updateSource: 172.30.8.0
+        172.30.8.2:
+          description: Fabric leaf-03 loopback (mesh)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65103
+          updateSource: 172.30.8.0
+        172.30.128.1:
+          bfdProfile: fabric
+          description: Gateway gateway-1/enp2s1 leaf-01--gateway--gateway-1
+          enabled: true
+          ipv4Unicast: true
+          l2vpnEvpn: true
+          l2vpnEvpnAllowOwnAS: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65534
+        Ethernet3:
+          bfdProfile: fabric
+          description: Fabric leaf-02/E1/5 leaf-01--mesh--leaf-02
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65102
+        Ethernet4:
+          bfdProfile: fabric
+          description: Fabric leaf-02/E1/6 leaf-01--mesh--leaf-02
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65102
+        Ethernet5:
+          bfdProfile: fabric
+          description: Fabric leaf-03/E1/5 leaf-01--mesh--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65103
+        Ethernet6:
+          bfdProfile: fabric
+          description: Fabric leaf-03/E1/6 leaf-01--mesh--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65103
+      networkImportCheck: true
+      routerID: 172.30.8.0
+    enabled: true
+    ethernetSegments:
+      PortChannel1:
+        esi: 00f20000f20000000002
+      PortChannel2:
+        esi: 00f20000f20000000001
+    evpnMH:
+      macHoldtime: 60
+      startupDelay: 60
+    tableConnections:
+      connected: {}
+      static: {}
+vxlanEVPNNVOs:
+  nvo1:
+    sourceVtep: vtepfabric
+vxlanTunnelMap:
+  map_200_Vlan3000:
+    vlan: 3000
+    vni: 200
+    vtep: vtepfabric
+  map_201_Vlan1001:
+    vlan: 1001
+    vni: 201
+    vtep: vtepfabric
+  map_300_Vlan3001:
+    vlan: 3001
+    vni: 300
+    vtep: vtepfabric
+  map_301_Vlan1002:
+    vlan: 1002
+    vni: 301
+    vtep: vtepfabric
+vxlanTunnels:
+  vtepfabric:
+    qosUniform: false
+    sourceIP: 172.30.12.0
+    sourceInterface: Loopback2
+ztp: false

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.in.agent.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.in.agent.yaml
@@ -1,0 +1,740 @@
+apiVersion: agent.githedgehog.com/v1beta1
+kind: Agent
+metadata:
+  creationTimestamp: "2026-01-16T00:09:01Z"
+  generation: 8
+  labels:
+    fabric.githedgehog.com/profile: vs
+    switchgroup.fabric.githedgehog.com/eslag-1: "true"
+    vlanns.fabric.githedgehog.com/default: "true"
+  name: leaf-03
+  namespace: default
+  resourceVersion: "31829"
+  uid: 5195a27e-a1b7-4f2d-8cf3-4b7fe5bf7a08
+spec:
+  alloy: {}
+  attachedVPCs:
+    vpc-03: true
+    vpc-04: true
+  catalog:
+    connectionIDs:
+      server-05--eslag--leaf-03--leaf-04: 1
+      server-06--eslag--leaf-03--leaf-04: 2
+    externalIDs:
+      external-01: 10
+    irbVLANs:
+      ext@external-01: 3003
+      vpc-01: 3001
+      vpc-03: 3002
+      vpc-04: 3000
+    portChannelIDs:
+      server-05--eslag--leaf-03--leaf-04: 2
+      server-06--eslag--leaf-03--leaf-04: 1
+      server-08--bundled--leaf-04: 3
+    subnetIDs:
+      0.0.0.0/0: 106
+      10.0.1.0/24: 105
+      10.0.2.0/24: 104
+      10.0.5.0/24: 103
+      10.0.6.0/24: 100
+      10.0.7.0/24: 102
+      10.0.8.0/24: 101
+    vpcSubnetVNIs:
+      vpc-01:
+        subnet-01: 201
+        subnet-02: 202
+      vpc-03:
+        subnet-01: 302
+        subnet-02: 301
+      vpc-04:
+        subnet-01: 401
+        subnet-02: 402
+    vpcVNIs:
+      ext@external-01: 100
+      vpc-01: 200
+      vpc-03: 300
+      vpc-04: 400
+  config:
+    alloy:
+      hostname: leaf-03
+      kube: {}
+      logFiles:
+        agent:
+          pathTargets:
+            - path: /var/log/agent.log
+        syslog:
+          pathTargets:
+            - path: /var/log/syslog
+      proxyURL: http://172.30.0.1:31028
+      pyroscope: {}
+      scrapes:
+        agent:
+          address: 127.0.0.1:7042
+          intervalSeconds: 60
+          relabel:
+            - action: keep
+              regex: .*(_in_bits|_status|_generation|_temperature|_transceiver).*
+              sourceLabels:
+                - __name__
+          self: {}
+          unix: {}
+        node:
+          intervalSeconds: 60
+          relabel:
+            - action: keep
+              regex: .*(_load).*
+              sourceLabels:
+                - __name__
+          self: {}
+          unix:
+            collectors:
+              - cpu
+              - loadavg
+              - meminfo
+              - filesystem
+            enable: true
+      targets: {}
+    baseVPCCommunity: "50000:0"
+    controlVIP: 172.30.0.1/32
+    defaultMaxPathsEBGP: 64
+    eslagESIPrefix: "00:f2:00:00:"
+    eslagMACBase: f2:00:00:00:00:00
+    fabricMTU: 9100
+    fabricSubnet: 172.30.128.0/17
+    gatewayASN: 65534
+    gatewayCommunities:
+      "0": "50001:0"
+      "1": "50001:1"
+      "2": "50001:2"
+      "3": "50001:3"
+      "4": "50001:4"
+      "5": "50001:5"
+      "6": "50001:6"
+      "7": "50001:7"
+      "8": "50001:8"
+      "9": "50001:9"
+    mclagSessionSubnet: 172.30.95.0/31
+    protocolSubnet: 172.30.8.0/22
+    serverFacingMTUOffset: 64
+    spineASN: 65100
+    spineLeaf: {}
+    vpcLoopbackSubnet: 172.30.96.0/19
+    vtepSubnet: 172.30.12.0/22
+  configuredVPCSubnets:
+    vpc-03/subnet-01: true
+    vpc-03/subnet-02: true
+    vpc-04/subnet-01: true
+  connections:
+    leaf-03--external:
+      external:
+        link:
+          switch:
+            port: leaf-03/E1/1
+    server-05--eslag--leaf-03--leaf-04:
+      eslag:
+        links:
+          - server:
+              port: server-05/enp2s1
+            switch:
+              port: leaf-03/E1/2
+          - server:
+              port: server-05/enp2s2
+            switch:
+              port: leaf-04/E1/1
+    server-06--eslag--leaf-03--leaf-04:
+      eslag:
+        links:
+          - server:
+              port: server-06/enp2s1
+            switch:
+              port: leaf-03/E1/3
+          - server:
+              port: server-06/enp2s2
+            switch:
+              port: leaf-04/E1/2
+    server-07--unbundled--leaf-03:
+      unbundled:
+        link:
+          server:
+            port: server-07/enp2s1
+          switch:
+            port: leaf-03/E1/4
+    spine-01--fabric--leaf-03:
+      fabric:
+        links:
+          - leaf:
+              port: leaf-03/E1/5
+            spine:
+              port: spine-01/E1/5
+          - leaf:
+              port: leaf-03/E1/6
+            spine:
+              port: spine-01/E1/6
+    spine-02--fabric--leaf-03:
+      fabric:
+        links:
+          - leaf:
+              port: leaf-03/E1/7
+            spine:
+              port: spine-02/E1/5
+          - leaf:
+              port: leaf-03/E1/8
+            spine:
+              port: spine-02/E1/6
+  description: VS-03 ESLAG 1
+  externalAttachments:
+    leaf-03--external-01:
+      connection: leaf-03--external
+      external: external-01
+      neighbor:
+        asn: 64102
+        ip: 100.1.10.6
+      switch:
+        ip: 100.1.10.1/24
+        vlan: 10
+  externalPeerings:
+    vpc-01--external-01:
+      permit:
+        external:
+          name: external-01
+          prefixes:
+            - prefix: 0.0.0.0/0
+        vpc:
+          name: vpc-01
+          subnets:
+            - subnet-01
+    vpc-03--external-01:
+      permit:
+        external:
+          name: external-01
+          prefixes:
+            - prefix: 0.0.0.0/0
+        vpc:
+          name: vpc-03
+          subnets:
+            - subnet-01
+  externals:
+    external-01:
+      inboundCommunity: 65102:1000
+      ipv4Namespace: default
+      outboundCommunity: 64102:1000
+  ipv4Namespaces:
+    default:
+      subnets:
+        - 10.0.0.0/16
+  redundancyGroupPeers:
+    - leaf-04
+  role: server-leaf
+  statusUpdates:
+    - apiVersion: wiring.githedgehog.com/v1beta1
+      generation: 1
+      kind: Switch
+      name: leaf-03
+      namespace: default
+  switch:
+    asn: 65102
+    boot:
+      mac: 0c:20:12:ff:02:00
+    description: VS-03 ESLAG 1
+    ecmp: {}
+    linkFlapErrDisable:
+      flapThreshold: 3
+      samplingInterval: 30
+      recoveryInterval: 300
+    groups:
+      - eslag-1
+    ip: 172.30.0.11/21
+    profile: vs
+    protocolIP: 172.30.8.4/32
+    redundancy:
+      group: eslag-1
+      type: eslag
+    role: server-leaf
+    vlanNamespaces:
+      - default
+    vtepIP: 172.30.12.1/32
+  switchProfile:
+    config:
+      maxPathsEBGP: 16
+    displayName: Virtual Switch
+    features:
+      eslag: true
+      l2vni: true
+      l3vni: true
+      mclag: true
+      roce: true
+      subinterfaces: true
+    nosType: sonic-bcm-vs
+    platform: x86_64-kvm_x86_64-r0
+    portGroups:
+      "1":
+        nos: "1"
+        profile: SFP28-25G
+      "2":
+        nos: "2"
+        profile: SFP28-25G
+      "3":
+        nos: "3"
+        profile: SFP28-25G
+      "4":
+        nos: "4"
+        profile: SFP28-25G
+      "5":
+        nos: "5"
+        profile: SFP28-25G
+      "6":
+        nos: "6"
+        profile: SFP28-25G
+      "7":
+        nos: "7"
+        profile: SFP28-25G
+      "8":
+        nos: "8"
+        profile: SFP28-25G
+      "9":
+        nos: "9"
+        profile: SFP28-25G
+      "10":
+        nos: "10"
+        profile: SFP28-25G
+      "11":
+        nos: "11"
+        profile: SFP28-25G
+      "12":
+        nos: "12"
+        profile: SFP28-25G
+    portProfiles:
+      SFP28-25G:
+        speed:
+          default: 25G
+          supported:
+            - 10G
+            - 25G
+    ports:
+      E1/1:
+        group: "1"
+        label: "1"
+        nos: Ethernet0
+      E1/2:
+        group: "1"
+        label: "2"
+        nos: Ethernet1
+      E1/3:
+        group: "1"
+        label: "3"
+        nos: Ethernet2
+      E1/4:
+        group: "1"
+        label: "4"
+        nos: Ethernet3
+      E1/5:
+        group: "2"
+        label: "5"
+        nos: Ethernet4
+      E1/6:
+        group: "2"
+        label: "6"
+        nos: Ethernet5
+      E1/7:
+        group: "2"
+        label: "7"
+        nos: Ethernet6
+      E1/8:
+        group: "2"
+        label: "8"
+        nos: Ethernet7
+      E1/9:
+        group: "3"
+        label: "9"
+        nos: Ethernet8
+      E1/10:
+        group: "3"
+        label: "10"
+        nos: Ethernet9
+      E1/11:
+        group: "3"
+        label: "11"
+        nos: Ethernet10
+      E1/12:
+        group: "3"
+        label: "12"
+        nos: Ethernet11
+      E1/13:
+        group: "4"
+        label: "13"
+        nos: Ethernet12
+      E1/14:
+        group: "4"
+        label: "14"
+        nos: Ethernet13
+      E1/15:
+        group: "4"
+        label: "15"
+        nos: Ethernet14
+      E1/16:
+        group: "4"
+        label: "16"
+        nos: Ethernet15
+      E1/17:
+        group: "5"
+        label: "17"
+        nos: Ethernet16
+      E1/18:
+        group: "5"
+        label: "18"
+        nos: Ethernet17
+      E1/19:
+        group: "5"
+        label: "19"
+        nos: Ethernet18
+      E1/20:
+        group: "5"
+        label: "20"
+        nos: Ethernet19
+      E1/21:
+        group: "6"
+        label: "21"
+        nos: Ethernet20
+      E1/22:
+        group: "6"
+        label: "22"
+        nos: Ethernet21
+      E1/23:
+        group: "6"
+        label: "23"
+        nos: Ethernet22
+      E1/24:
+        group: "6"
+        label: "24"
+        nos: Ethernet23
+      E1/25:
+        group: "7"
+        label: "25"
+        nos: Ethernet24
+      E1/26:
+        group: "7"
+        label: "26"
+        nos: Ethernet25
+      E1/27:
+        group: "7"
+        label: "27"
+        nos: Ethernet26
+      E1/28:
+        group: "7"
+        label: "28"
+        nos: Ethernet27
+      E1/29:
+        group: "8"
+        label: "29"
+        nos: Ethernet28
+      E1/30:
+        group: "8"
+        label: "30"
+        nos: Ethernet29
+      E1/31:
+        group: "8"
+        label: "31"
+        nos: Ethernet30
+      E1/32:
+        group: "8"
+        label: "32"
+        nos: Ethernet31
+      E1/33:
+        group: "9"
+        label: "33"
+        nos: Ethernet32
+      E1/34:
+        group: "9"
+        label: "34"
+        nos: Ethernet33
+      E1/35:
+        group: "9"
+        label: "35"
+        nos: Ethernet34
+      E1/36:
+        group: "9"
+        label: "36"
+        nos: Ethernet35
+      E1/37:
+        group: "10"
+        label: "37"
+        nos: Ethernet36
+      E1/38:
+        group: "10"
+        label: "38"
+        nos: Ethernet37
+      E1/39:
+        group: "10"
+        label: "39"
+        nos: Ethernet38
+      E1/40:
+        group: "10"
+        label: "40"
+        nos: Ethernet39
+      E1/41:
+        group: "11"
+        label: "41"
+        nos: Ethernet40
+      E1/42:
+        group: "11"
+        label: "42"
+        nos: Ethernet41
+      E1/43:
+        group: "11"
+        label: "43"
+        nos: Ethernet42
+      E1/44:
+        group: "11"
+        label: "44"
+        nos: Ethernet43
+      E1/45:
+        group: "12"
+        label: "45"
+        nos: Ethernet44
+      E1/46:
+        group: "12"
+        label: "46"
+        nos: Ethernet45
+      E1/47:
+        group: "12"
+        label: "47"
+        nos: Ethernet46
+      E1/48:
+        group: "12"
+        label: "48"
+        nos: Ethernet47
+      M1:
+        management: true
+        nos: Management0
+        oniePortName: eth0
+    switchSilicon: vs
+  switches:
+    leaf-03:
+      asn: 65102
+      boot:
+        mac: 0c:20:12:ff:02:00
+      description: VS-03 ESLAG 1
+      ecmp: {}
+      groups:
+        - eslag-1
+      ip: 172.30.0.11/21
+      profile: vs
+      protocolIP: 172.30.8.4/32
+      redundancy:
+        group: eslag-1
+        type: eslag
+      role: server-leaf
+      vlanNamespaces:
+        - default
+      vtepIP: 172.30.12.1/32
+    leaf-04:
+      asn: 65103
+      boot:
+        mac: 0c:20:12:ff:03:00
+      description: VS-04 ESLAG 1
+      ecmp: {}
+      groups:
+        - eslag-1
+      ip: 172.30.0.12/21
+      profile: vs
+      protocolIP: 172.30.8.5/32
+      redundancy:
+        group: eslag-1
+        type: eslag
+      role: server-leaf
+      vlanNamespaces:
+        - default
+      vtepIP: 172.30.12.2/32
+    spine-01:
+      asn: 65100
+      boot:
+        mac: 0c:20:12:ff:05:00
+      description: VS-06
+      ecmp: {}
+      ip: 172.30.0.7/21
+      profile: vs
+      protocolIP: 172.30.8.0/32
+      redundancy: {}
+      role: spine
+      vlanNamespaces:
+        - default
+    spine-02:
+      asn: 65100
+      boot:
+        mac: 0c:20:12:ff:06:00
+      description: VS-07
+      ecmp: {}
+      ip: 172.30.0.8/21
+      profile: vs
+      protocolIP: 172.30.8.1/32
+      redundancy: {}
+      role: spine
+      vlanNamespaces:
+        - default
+  users:
+    - name: admin
+      password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+      role: admin
+      sshKeys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+    - name: op
+      password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+      role: operator
+      sshKeys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+  version:
+    alloyRepo: 172.30.0.1:31000/githedgehog/fabricator/alloy-bin
+    alloyVersion: v1.12.0
+    ca: |
+      -----BEGIN CERTIFICATE-----
+      MIIBbDCCARKgAwIBAgIIU7sCtD49Jk4wCgYIKoZIzj0EAwIwGjEYMBYGA1UEAxMP
+      aGVkZ2Vob2ctZmFiLWNhMB4XDTI2MDExNTIzNTA1MVoXDTM2MDExNjAwMDU1MVow
+      GjEYMBYGA1UEAxMPaGVkZ2Vob2ctZmFiLWNhMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+      AQcDQgAEP6J/5s4F1PMFXvG3169JWNSJFxPuf9DCFT/996laqBYQZ0kaUi1cbbnZ
+      X9BkbVFOzf6XeXwcwd05QogN4OR53KNCMEAwDgYDVR0PAQH/BAQDAgKEMA8GA1Ud
+      EwEB/wQFMAMBAf8wHQYDVR0OBBYEFI1jiNjtzv+EQyttQdHSj0Jo2rBNMAoGCCqG
+      SM49BAMCA0gAMEUCIG+0vOhexIbmX3qH9uUaXTgDzVVm96UogLxbVtWgja5DAiEA
+      lpqId7PcDURp1T5e1wtiaQlDhZLcPnVxE3mcQaKbuzk=
+      -----END CERTIFICATE-----
+    default: v0.100.0
+    password: secret
+    repo: 172.30.0.1:31000/githedgehog/fabric/agent
+    username: reader
+  vlanNamespaces:
+    default:
+      ranges:
+        - from: 1000
+          to: 2999
+  vpcAttachments:
+    server-05--eslag--leaf-03--leaf-04--vpc-03--subnet-01:
+      connection: server-05--eslag--leaf-03--leaf-04
+      subnet: vpc-03/subnet-01
+    server-06--eslag--leaf-03--leaf-04--vpc-03--subnet-02:
+      connection: server-06--eslag--leaf-03--leaf-04
+      subnet: vpc-03/subnet-02
+    server-07--unbundled--leaf-03--vpc-04--subnet-01:
+      connection: server-07--unbundled--leaf-03
+      subnet: vpc-04/subnet-01
+  vpcPeers:
+    vpc-03--vpc-04:
+      permit:
+        - vpc-03: {}
+          vpc-04: {}
+  vpcs:
+    vpc-01:
+      ipv4Namespace: default
+      subnets:
+        subnet-01:
+          dhcp:
+            enable: true
+            options:
+              dnsServers:
+                - 1.0.0.1
+                - 1.1.1.1
+              interfaceMTU: 9036
+              leaseTimeSeconds: 3600
+              timeServers:
+                - 219.239.35.0
+            range:
+              end: 10.0.1.255
+              start: 10.0.1.2
+          gateway: 10.0.1.1
+          subnet: 10.0.1.0/24
+          vlan: 1001
+        subnet-02:
+          dhcp:
+            enable: true
+            options:
+              dnsServers:
+                - 1.0.0.1
+                - 1.1.1.1
+              interfaceMTU: 9036
+              leaseTimeSeconds: 3600
+              timeServers:
+                - 219.239.35.0
+            range:
+              end: 10.0.2.255
+              start: 10.0.2.2
+          gateway: 10.0.2.1
+          subnet: 10.0.2.0/24
+          vlan: 1002
+      vlanNamespace: default
+    vpc-03:
+      ipv4Namespace: default
+      subnets:
+        subnet-01:
+          dhcp:
+            enable: true
+            options:
+              dnsServers:
+                - 1.0.0.1
+                - 1.1.1.1
+              interfaceMTU: 9036
+              leaseTimeSeconds: 3600
+              timeServers:
+                - 219.239.35.0
+            range:
+              end: 10.0.5.255
+              start: 10.0.5.2
+          gateway: 10.0.5.1
+          subnet: 10.0.5.0/24
+          vlan: 1005
+        subnet-02:
+          dhcp:
+            enable: true
+            options:
+              dnsServers:
+                - 1.0.0.1
+                - 1.1.1.1
+              interfaceMTU: 9036
+              leaseTimeSeconds: 3600
+              timeServers:
+                - 219.239.35.0
+            range:
+              end: 10.0.6.255
+              start: 10.0.6.2
+          gateway: 10.0.6.1
+          subnet: 10.0.6.0/24
+          vlan: 1006
+      vlanNamespace: default
+    vpc-04:
+      ipv4Namespace: default
+      subnets:
+        subnet-01:
+          dhcp:
+            enable: true
+            options:
+              dnsServers:
+                - 1.0.0.1
+                - 1.1.1.1
+              interfaceMTU: 9036
+              leaseTimeSeconds: 3600
+              timeServers:
+                - 219.239.35.0
+            range:
+              end: 10.0.7.255
+              start: 10.0.7.2
+          gateway: 10.0.7.1
+          subnet: 10.0.7.0/24
+          vlan: 1007
+        subnet-02:
+          dhcp:
+            enable: true
+            options:
+              dnsServers:
+                - 1.0.0.1
+                - 1.1.1.1
+              interfaceMTU: 9036
+              leaseTimeSeconds: 3600
+              timeServers:
+                - 219.239.35.0
+            range:
+              end: 10.0.8.255
+              start: 10.0.8.2
+          gateway: 10.0.8.1
+          subnet: 10.0.8.0/24
+          vlan: 1008
+      vlanNamespace: default
+status: {}

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.actions.expected.yaml
@@ -1,0 +1,4290 @@
+- path: /ztp/config
+  summary: Update ZTP
+  type: replace
+  value:
+    config:
+      admin-mode: false
+  weight: 1
+- path: /system/config
+  summary: Update Hostname
+  type: replace
+  value:
+    config:
+      hostname: leaf-03
+  weight: 2
+- path: /lldp/config
+  summary: Create LLDP
+  type: update
+  value:
+    config:
+      enabled: true
+      hello-timer: "5"
+      system-description: Hedgehog Fabric
+      system-name: leaf-03
+  weight: 3
+- path: /system/aaa/authentication/users/user[username=admin]
+  summary: Create User admin
+  type: update
+  value:
+    user:
+    - config:
+        password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+        role: admin
+        username: admin
+      username: admin
+  weight: 4
+- path: /system/aaa/authentication/users/user[username=op]
+  summary: Create User op
+  type: update
+  value:
+    user:
+    - config:
+        password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+        role: operator
+        username: op
+      username: op
+  weight: 4
+- customFunc: true
+  path: ""
+  summary: User admin authorized keys
+  type: ""
+  weight: 5
+- customFunc: true
+  path: ""
+  summary: User op authorized keys
+  type: ""
+  weight: 5
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]
+  summary: Create Prefix List Base all-vtep-prefixes
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: all-vtep-prefixes
+      name: all-vtep-prefixes
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=any-prefix]
+  summary: Create Prefix List Base any-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: any-prefix
+      name: any-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ext-import--external-01]
+  summary: Create Prefix List Base ext-import--external-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: ext-import--external-01
+      name: ext-import--external-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=import-vrf--vpc-01--external-01]
+  summary: Create Prefix List Base import-vrf--vpc-01--external-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: import-vrf--vpc-01--external-01
+      name: import-vrf--vpc-01--external-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=import-vrf--vpc-03--external-01]
+  summary: Create Prefix List Base import-vrf--vpc-03--external-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: import-vrf--vpc-03--external-01
+      name: import-vrf--vpc-03--external-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ipns-subnets--default]
+  summary: Create Prefix List Base ipns-subnets--default
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=protocol-loopback-prefix]
+  summary: Create Prefix List Base protocol-loopback-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: protocol-loopback-prefix
+      name: protocol-loopback-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=static-ext-subnets]
+  summary: Create Prefix List Base static-ext-subnets
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: static-ext-subnets
+      name: static-ext-subnets
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-ext-prefixes--vpc-01]
+  summary: Create Prefix List Base vpc-ext-prefixes--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-ext-prefixes--vpc-01
+      name: vpc-ext-prefixes--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-ext-prefixes--vpc-03]
+  summary: Create Prefix List Base vpc-ext-prefixes--vpc-03
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-ext-prefixes--vpc-03
+      name: vpc-ext-prefixes--vpc-03
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-ext-prefixes--vpc-04]
+  summary: Create Prefix List Base vpc-ext-prefixes--vpc-04
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-ext-prefixes--vpc-04
+      name: vpc-ext-prefixes--vpc-04
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-loopback-prefix]
+  summary: Create Prefix List Base vpc-loopback-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-loopback-prefix
+      name: vpc-loopback-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-01]
+  summary: Create Prefix List Base vpc-not-subnets--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-not-subnets--vpc-01
+      name: vpc-not-subnets--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-03]
+  summary: Create Prefix List Base vpc-not-subnets--vpc-03
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-not-subnets--vpc-03
+      name: vpc-not-subnets--vpc-03
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-04]
+  summary: Create Prefix List Base vpc-not-subnets--vpc-04
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-not-subnets--vpc-04
+      name: vpc-not-subnets--vpc-04
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-01]
+  summary: Create Prefix List Base vpc-peers--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-peers--vpc-01
+      name: vpc-peers--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-03]
+  summary: Create Prefix List Base vpc-peers--vpc-03
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-peers--vpc-03
+      name: vpc-peers--vpc-03
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-04]
+  summary: Create Prefix List Base vpc-peers--vpc-04
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-peers--vpc-04
+      name: vpc-peers--vpc-04
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-static-ext-subnets--vpc-01]
+  summary: Create Prefix List Base vpc-static-ext-subnets--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-static-ext-subnets--vpc-01
+      name: vpc-static-ext-subnets--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-static-ext-subnets--vpc-03]
+  summary: Create Prefix List Base vpc-static-ext-subnets--vpc-03
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-static-ext-subnets--vpc-03
+      name: vpc-static-ext-subnets--vpc-03
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-static-ext-subnets--vpc-04]
+  summary: Create Prefix List Base vpc-static-ext-subnets--vpc-04
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-static-ext-subnets--vpc-04
+      name: vpc-static-ext-subnets--vpc-04
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-01]
+  summary: Create Prefix List Base vpc-subnets--vpc-01
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-subnets--vpc-01
+      name: vpc-subnets--vpc-01
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-03]
+  summary: Create Prefix List Base vpc-subnets--vpc-03
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-subnets--vpc-03
+      name: vpc-subnets--vpc-03
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-04]
+  summary: Create Prefix List Base vpc-subnets--vpc-04
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-subnets--vpc-04
+      name: vpc-subnets--vpc-04
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.0/22
+        masklength-range: 22..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.0/22
+      masklength-range: 22..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=any-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 10
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ext-import--external-01]/extended-prefixes/extended-prefix[sequence-number=103][ip-prefix=10.0.5.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 103
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.5.0/24
+        masklength-range: 24..32
+        sequence-number: 103
+      ip-prefix: 10.0.5.0/24
+      masklength-range: 24..32
+      sequence-number: 103
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ext-import--external-01]/extended-prefixes/extended-prefix[sequence-number=105][ip-prefix=10.0.1.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 105
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.1.0/24
+        masklength-range: 24..32
+        sequence-number: 105
+      ip-prefix: 10.0.1.0/24
+      masklength-range: 24..32
+      sequence-number: 105
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=import-vrf--vpc-01--external-01]/extended-prefixes/extended-prefix[sequence-number=106][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 106
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 106
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 106
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=import-vrf--vpc-03--external-01]/extended-prefixes/extended-prefix[sequence-number=106][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 106
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 106
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 106
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ipns-subnets--default]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.0.0/16][masklength-range=16..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.0.0/16
+        masklength-range: 16..32
+        sequence-number: 1
+      ip-prefix: 10.0.0.0/16
+      masklength-range: 16..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=protocol-loopback-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.8.4/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.8.4/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.8.4/32
+      masklength-range: 32..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-ext-prefixes--vpc-01]/extended-prefixes/extended-prefix[sequence-number=106][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 106
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 106
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 106
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-ext-prefixes--vpc-03]/extended-prefixes/extended-prefix[sequence-number=106][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 106
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 106
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 106
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-loopback-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.96.0/19][masklength-range=19..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.96.0/19
+        masklength-range: 19..32
+        sequence-number: 10
+      ip-prefix: 172.30.96.0/19
+      masklength-range: 19..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.1.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.1.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.1.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=2][ip-prefix=10.0.2.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 2
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.2.0/24
+        masklength-range: 24..32
+        sequence-number: 2
+      ip-prefix: 10.0.2.0/24
+      masklength-range: 24..32
+      sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=65535][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 65535
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 65535
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 65535
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-03]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.6.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.6.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.6.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-03]/extended-prefixes/extended-prefix[sequence-number=2][ip-prefix=10.0.5.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 2
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.5.0/24
+        masklength-range: 24..32
+        sequence-number: 2
+      ip-prefix: 10.0.5.0/24
+      masklength-range: 24..32
+      sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-03]/extended-prefixes/extended-prefix[sequence-number=65535][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 65535
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 65535
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 65535
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-04]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.7.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.7.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.7.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-04]/extended-prefixes/extended-prefix[sequence-number=2][ip-prefix=10.0.8.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 2
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: DENY
+        ip-prefix: 10.0.8.0/24
+        masklength-range: 24..32
+        sequence-number: 2
+      ip-prefix: 10.0.8.0/24
+      masklength-range: 24..32
+      sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-not-subnets--vpc-04]/extended-prefixes/extended-prefix[sequence-number=65535][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 65535
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 65535
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 65535
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-03]/extended-prefixes/extended-prefix[sequence-number=401][ip-prefix=10.0.7.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 401
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.7.0/24
+        masklength-range: 24..32
+        sequence-number: 401
+      ip-prefix: 10.0.7.0/24
+      masklength-range: 24..32
+      sequence-number: 401
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-03]/extended-prefixes/extended-prefix[sequence-number=402][ip-prefix=10.0.8.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 402
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.8.0/24
+        masklength-range: 24..32
+        sequence-number: 402
+      ip-prefix: 10.0.8.0/24
+      masklength-range: 24..32
+      sequence-number: 402
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-04]/extended-prefixes/extended-prefix[sequence-number=301][ip-prefix=10.0.6.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 301
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.6.0/24
+        masklength-range: 24..32
+        sequence-number: 301
+      ip-prefix: 10.0.6.0/24
+      masklength-range: 24..32
+      sequence-number: 301
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-peers--vpc-04]/extended-prefixes/extended-prefix[sequence-number=302][ip-prefix=10.0.5.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 302
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.5.0/24
+        masklength-range: 24..32
+        sequence-number: 302
+      ip-prefix: 10.0.5.0/24
+      masklength-range: 24..32
+      sequence-number: 302
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.1.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.1.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.1.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-01]/extended-prefixes/extended-prefix[sequence-number=2][ip-prefix=10.0.2.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 2
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.2.0/24
+        masklength-range: 24..32
+        sequence-number: 2
+      ip-prefix: 10.0.2.0/24
+      masklength-range: 24..32
+      sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-03]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.6.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.6.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.6.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-03]/extended-prefixes/extended-prefix[sequence-number=2][ip-prefix=10.0.5.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 2
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.5.0/24
+        masklength-range: 24..32
+        sequence-number: 2
+      ip-prefix: 10.0.5.0/24
+      masklength-range: 24..32
+      sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-04]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.7.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.7.0/24
+        masklength-range: 24..32
+        sequence-number: 1
+      ip-prefix: 10.0.7.0/24
+      masklength-range: 24..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-subnets--vpc-04]/extended-prefixes/extended-prefix[sequence-number=2][ip-prefix=10.0.8.0/24][masklength-range=24..32]
+  summary: Create Prefix Lists Entry 2
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.8.0/24
+        masklength-range: 24..32
+        sequence-number: 2
+      ip-prefix: 10.0.8.0/24
+      masklength-range: 24..32
+      sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
+  summary: Create Community Lists all-externals
+  type: update
+  value:
+    community-set:
+    - community-set-name: all-externals
+      config:
+        action: PERMIT
+        community-member:
+        - 65102:1000
+        community-set-name: all-externals
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-gw-prios]
+  summary: Create Community Lists all-gw-prios
+  type: update
+  value:
+    community-set:
+    - community-set-name: all-gw-prios
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:0"
+        - "50001:1"
+        - "50001:2"
+        - "50001:3"
+        - "50001:4"
+        - "50001:5"
+        - "50001:6"
+        - "50001:7"
+        - "50001:8"
+        - "50001:9"
+        community-set-name: all-gw-prios
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=ext-inbound--external-01]
+  summary: Create Community Lists ext-inbound--external-01
+  type: update
+  value:
+    community-set:
+    - community-set-name: ext-inbound--external-01
+      config:
+        action: PERMIT
+        community-member:
+        - 65102:1000
+        community-set-name: ext-inbound--external-01
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-0]
+  summary: Create Community Lists gw-prio-0
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-0
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:0"
+        community-set-name: gw-prio-0
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-1]
+  summary: Create Community Lists gw-prio-1
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-1
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:1"
+        community-set-name: gw-prio-1
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-2]
+  summary: Create Community Lists gw-prio-2
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-2
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:2"
+        community-set-name: gw-prio-2
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-3]
+  summary: Create Community Lists gw-prio-3
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-3
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:3"
+        community-set-name: gw-prio-3
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-4]
+  summary: Create Community Lists gw-prio-4
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-4
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:4"
+        community-set-name: gw-prio-4
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-5]
+  summary: Create Community Lists gw-prio-5
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-5
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:5"
+        community-set-name: gw-prio-5
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-6]
+  summary: Create Community Lists gw-prio-6
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-6
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:6"
+        community-set-name: gw-prio-6
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-7]
+  summary: Create Community Lists gw-prio-7
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-7
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:7"
+        community-set-name: gw-prio-7
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-8]
+  summary: Create Community Lists gw-prio-8
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-8
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:8"
+        community-set-name: gw-prio-8
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=gw-prio-9]
+  summary: Create Community Lists gw-prio-9
+  type: update
+  value:
+    community-set:
+    - community-set-name: gw-prio-9
+      config:
+        action: PERMIT
+        community-member:
+        - "50001:9"
+        community-set-name: gw-prio-9
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=no-community]
+  summary: Create Community Lists no-community
+  type: update
+  value:
+    community-set:
+    - community-set-name: no-community
+      config:
+        action: PERMIT
+        community-member:
+        - REGEX:^$
+        community-set-name: no-community
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=vpc-peers--vpc-01]
+  summary: Create Community Lists vpc-peers--vpc-01
+  type: update
+  value:
+    community-set:
+    - community-set-name: vpc-peers--vpc-01
+      config:
+        action: PERMIT
+        community-member:
+        - "50000:2"
+        community-set-name: vpc-peers--vpc-01
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=vpc-peers--vpc-03]
+  summary: Create Community Lists vpc-peers--vpc-03
+  type: update
+  value:
+    community-set:
+    - community-set-name: vpc-peers--vpc-03
+      config:
+        action: PERMIT
+        community-member:
+        - "50000:3"
+        - "50000:4"
+        community-set-name: vpc-peers--vpc-03
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=vpc-peers--vpc-04]
+  summary: Create Community Lists vpc-peers--vpc-04
+  type: update
+  value:
+    community-set:
+    - community-set-name: vpc-peers--vpc-04
+      config:
+        action: PERMIT
+        community-member:
+        - "50000:3"
+        - "50000:4"
+        community-set-name: vpc-peers--vpc-04
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/as-path-sets/as-path-set[as-path-set-name=fabric-gw-aspath]
+  summary: Create AS Path Lists fabric-gw-aspath
+  type: update
+  value:
+    as-path-set:
+    - as-path-set-name: fabric-gw-aspath
+      config:
+        action: PERMIT
+        as-path-set-member:
+        - _65100_
+        - _65534_
+        as-path-set-name: fabric-gw-aspath
+  weight: 12
+- path: /interfaces/interface[name=PortChannel1]
+  summary: Create Interface PortChannel1 Base PortChannels
+  type: update
+  value:
+    interface:
+    - config:
+        description: ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+        enabled: true
+        mtu: 9036
+        name: PortChannel1
+      name: PortChannel1
+  weight: 15
+- path: /interfaces/interface[name=PortChannel2]
+  summary: Create Interface PortChannel2 Base PortChannels
+  type: update
+  value:
+    interface:
+    - config:
+        description: ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+        enabled: true
+        mtu: 9036
+        name: PortChannel2
+      name: PortChannel2
+  weight: 15
+- path: /interfaces/interface[name=Ethernet0]
+  summary: Create Interface Ethernet0 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: External leaf-03--external
+        enabled: true
+        name: Ethernet0
+      name: Ethernet0
+  weight: 16
+- path: /interfaces/interface[name=Ethernet1]
+  summary: Create Interface Ethernet1 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: PC2 ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+        enabled: true
+        mtu: 9036
+        name: Ethernet1
+      name: Ethernet1
+  weight: 16
+- path: /interfaces/interface[name=Ethernet2]
+  summary: Create Interface Ethernet2 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: PC1 ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+        enabled: true
+        mtu: 9036
+        name: Ethernet2
+      name: Ethernet2
+  weight: 16
+- path: /interfaces/interface[name=Ethernet3]
+  summary: Create Interface Ethernet3 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Unbundled server-07 server-07--unbundled--leaf-03
+        enabled: true
+        mtu: 9036
+        name: Ethernet3
+      name: Ethernet3
+  weight: 16
+- path: /interfaces/interface[name=Ethernet4]
+  summary: Create Interface Ethernet4 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+        enabled: true
+        name: Ethernet4
+      name: Ethernet4
+  weight: 16
+- path: /interfaces/interface[name=Ethernet5]
+  summary: Create Interface Ethernet5 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+        enabled: true
+        name: Ethernet5
+      name: Ethernet5
+  weight: 16
+- path: /interfaces/interface[name=Ethernet6]
+  summary: Create Interface Ethernet6 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+        enabled: true
+        name: Ethernet6
+      name: Ethernet6
+  weight: 16
+- path: /interfaces/interface[name=Ethernet7]
+  summary: Create Interface Ethernet7 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+        enabled: true
+        name: Ethernet7
+      name: Ethernet7
+  weight: 16
+- path: /interfaces/interface[name=Loopback1]
+  summary: Create Interface Loopback1 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Protocol loopback
+        enabled: true
+        name: Loopback1
+      name: Loopback1
+  weight: 16
+- path: /interfaces/interface[name=Loopback2]
+  summary: Create Interface Loopback2 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VTEP loopback
+        enabled: true
+        name: Loopback2
+      name: Loopback2
+  weight: 16
+- path: /interfaces/interface[name=Management0]
+  summary: Create Interface Management0 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Management link
+        enabled: true
+        name: Management0
+      name: Management0
+  weight: 16
+- path: /interfaces/interface[name=Vlan1005]
+  summary: Create Interface Vlan1005 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-03/subnet-01
+        enabled: true
+        name: Vlan1005
+      name: Vlan1005
+  weight: 16
+- path: /interfaces/interface[name=Vlan1006]
+  summary: Create Interface Vlan1006 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-03/subnet-02
+        enabled: true
+        name: Vlan1006
+      name: Vlan1006
+  weight: 16
+- path: /interfaces/interface[name=Vlan1007]
+  summary: Create Interface Vlan1007 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-04/subnet-01
+        enabled: true
+        name: Vlan1007
+      name: Vlan1007
+  weight: 16
+- path: /interfaces/interface[name=Vlan3000]
+  summary: Create Interface Vlan3000 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-04 IRB
+        enabled: true
+        name: Vlan3000
+      name: Vlan3000
+  weight: 16
+- path: /interfaces/interface[name=Vlan3001]
+  summary: Create Interface Vlan3001 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-01 IRB
+        enabled: true
+        name: Vlan3001
+      name: Vlan3001
+  weight: 16
+- path: /interfaces/interface[name=Vlan3002]
+  summary: Create Interface Vlan3002 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: VPC vpc-03 IRB
+        enabled: true
+        name: Vlan3002
+      name: Vlan3002
+  weight: 16
+- path: /interfaces/interface[name=Vlan3003]
+  summary: Create Interface Vlan3003 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: External external-01 IRB
+        enabled: true
+        name: Vlan3003
+      name: Vlan3003
+  weight: 16
+- path: /network-instances/network-instance[name=VrfEexternal-01]
+  summary: Create VRF VrfEexternal-01 base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: VrfEexternal-01
+      name: VrfEexternal-01
+  weight: 17
+- path: /network-instances/network-instance[name=VrfVvpc-01]
+  summary: Create VRF VrfVvpc-01 base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: VrfVvpc-01
+      name: VrfVvpc-01
+  weight: 17
+- path: /network-instances/network-instance[name=VrfVvpc-03]
+  summary: Create VRF VrfVvpc-03 base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: VrfVvpc-03
+      name: VrfVvpc-03
+  weight: 17
+- path: /network-instances/network-instance[name=VrfVvpc-04]
+  summary: Create VRF VrfVvpc-04 base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: VrfVvpc-04
+      name: VrfVvpc-04
+  weight: 17
+- path: /network-instances/network-instance[name=default]
+  summary: Create VRF default base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: default
+      name: default
+  weight: 17
+- path: /sonic-vrf/VRF/VRF_LIST[vrf_name=VrfEexternal-01]/vni
+  summary: Create VRF VNI VrfEexternal-01
+  type: update
+  value:
+    vni: 100
+    vrf_name: VrfEexternal-01
+  weight: 18
+- path: /sonic-vrf/VRF/VRF_LIST[vrf_name=VrfVvpc-01]/vni
+  summary: Create VRF VNI VrfVvpc-01
+  type: update
+  value:
+    vni: 200
+    vrf_name: VrfVvpc-01
+  weight: 18
+- path: /sonic-vrf/VRF/VRF_LIST[vrf_name=VrfVvpc-03]/vni
+  summary: Create VRF VNI VrfVvpc-03
+  type: update
+  value:
+    vni: 300
+    vrf_name: VrfVvpc-03
+  weight: 18
+- path: /sonic-vrf/VRF/VRF_LIST[vrf_name=VrfVvpc-04]/vni
+  summary: Create VRF VNI VrfVvpc-04
+  type: update
+  value:
+    vni: 400
+    vrf_name: VrfVvpc-04
+  weight: 18
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-import--external-01]
+  summary: Create Route Maps Base ext-import--external-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: ext-import--external-01
+      name: ext-import--external-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-inbound--external-01]
+  summary: Create Route Maps Base ext-inbound--external-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: ext-inbound--external-01
+      name: ext-inbound--external-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-outbound--external-01]
+  summary: Create Route Maps Base ext-outbound--external-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: ext-outbound--external-01
+      name: ext-outbound--external-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]
+  summary: Create Route Maps Base filter-attached-hosts
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]
+  summary: Create Route Maps Base import-vrf--vpc-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]
+  summary: Create Route Maps Base import-vrf--vpc-03
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: import-vrf--vpc-03
+      name: import-vrf--vpc-03
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-04]
+  summary: Create Route Maps Base import-vrf--vpc-04
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: import-vrf--vpc-04
+      name: import-vrf--vpc-04
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=ipns-subnets--default]
+  summary: Create Route Maps Base ipns-subnets--default
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]
+  summary: Create Route Maps Base l2vpn-neighbors
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]
+  summary: Create Route Maps Base loopback-all-vteps
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
+  summary: Create Route Maps Base protocol-loopback-only
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]
+  summary: Create Route Maps Base vpc-redistribute-connected--vpc-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-03]
+  summary: Create Route Maps Base vpc-redistribute-connected--vpc-03
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-connected--vpc-03
+      name: vpc-redistribute-connected--vpc-03
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-04]
+  summary: Create Route Maps Base vpc-redistribute-connected--vpc-04
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-connected--vpc-04
+      name: vpc-redistribute-connected--vpc-04
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]
+  summary: Create Route Maps Base vpc-redistribute-static--vpc-01
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-03]
+  summary: Create Route Maps Base vpc-redistribute-static--vpc-03
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-static--vpc-03
+      name: vpc-redistribute-static--vpc-03
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-04]
+  summary: Create Route Maps Base vpc-redistribute-static--vpc-04
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: vpc-redistribute-static--vpc-04
+      name: vpc-redistribute-static--vpc-04
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-import--external-01]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ext-import--external-01
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-inbound--external-01]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ipns-subnets--default
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-inbound--external-01]/statements/statement[name=15]
+  summary: Create Route Map Statement 15
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 150
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: ext-inbound--external-01
+      config:
+        name: "15"
+      name: "15"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-inbound--external-01]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        bgp-conditions:
+          match-as-path-set:
+            config:
+              as-path-set: fabric-gw-aspath
+              match-set-options: ANY
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-outbound--external-01]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          set-community:
+            config:
+              method: INLINE
+              options: ADD
+            inline:
+              config:
+                communities:
+                - 64102:1000
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ipns-subnets--default
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ext-outbound--external-01]/statements/statement[name=20]
+  summary: Create Route Map Statement 20
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          set-community:
+            config:
+              method: INLINE
+              options: ADD
+            inline:
+              config:
+                communities:
+                - 64102:1000
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: all-gw-prios
+      config:
+        name: "20"
+      name: "20"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        config:
+          install-protocol-eq: ATTACHED_HOST
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            next-hop-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=50000]
+  summary: Create Route Map Statement 50000
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: vpc-peers--vpc-01
+      config:
+        name: "50000"
+      name: "50000"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=50001]
+  summary: Create Route Map Statement 50001
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: no-community
+        match-prefix-set:
+          config:
+            prefix-set: vpc-peers--vpc-01
+      config:
+        name: "50001"
+      name: "50001"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=50010]
+  summary: Create Route Map Statement 50010
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 150
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: ext-inbound--external-01
+        match-prefix-set:
+          config:
+            prefix-set: import-vrf--vpc-01--external-01
+      config:
+        name: "50010"
+      name: "50010"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=5010]
+  summary: Create Route Map Statement 5010
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ipns-subnets--default
+        match-src-network-instance:
+          config:
+            name: VrfEexternal-01
+      config:
+        name: "5010"
+      name: "5010"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-01]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            next-hop-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]/statements/statement[name=10004]
+  summary: Create Route Map Statement 10004
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-not-subnets--vpc-04
+        match-src-network-instance:
+          config:
+            name: VrfVvpc-04
+      config:
+        name: "10004"
+      name: "10004"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]/statements/statement[name=50000]
+  summary: Create Route Map Statement 50000
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: vpc-peers--vpc-03
+      config:
+        name: "50000"
+      name: "50000"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]/statements/statement[name=50001]
+  summary: Create Route Map Statement 50001
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: no-community
+        match-prefix-set:
+          config:
+            prefix-set: vpc-peers--vpc-03
+      config:
+        name: "50001"
+      name: "50001"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]/statements/statement[name=50010]
+  summary: Create Route Map Statement 50010
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 150
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: ext-inbound--external-01
+        match-prefix-set:
+          config:
+            prefix-set: import-vrf--vpc-03--external-01
+      config:
+        name: "50010"
+      name: "50010"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]/statements/statement[name=5010]
+  summary: Create Route Map Statement 5010
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ipns-subnets--default
+        match-src-network-instance:
+          config:
+            name: VrfEexternal-01
+      config:
+        name: "5010"
+      name: "5010"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-03]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-04]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            next-hop-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-04]/statements/statement[name=10003]
+  summary: Create Route Map Statement 10003
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-not-subnets--vpc-03
+        match-src-network-instance:
+          config:
+            name: VrfVvpc-03
+      config:
+        name: "10003"
+      name: "10003"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-04]/statements/statement[name=50000]
+  summary: Create Route Map Statement 50000
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: vpc-peers--vpc-04
+      config:
+        name: "50000"
+      name: "50000"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-04]/statements/statement[name=50001]
+  summary: Create Route Map Statement 50001
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: no-community
+        match-prefix-set:
+          config:
+            prefix-set: vpc-peers--vpc-04
+      config:
+        name: "50001"
+      name: "50001"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=import-vrf--vpc-04]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ipns-subnets--default]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ipns-subnets--default
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 210
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-0
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 201
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-9
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=2]
+  summary: Create Route Map Statement 2
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 209
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-1
+      config:
+        name: "2"
+      name: "2"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=3]
+  summary: Create Route Map Statement 3
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 208
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-2
+      config:
+        name: "3"
+      name: "3"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=4]
+  summary: Create Route Map Statement 4
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 207
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-3
+      config:
+        name: "4"
+      name: "4"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 206
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-4
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=6]
+  summary: Create Route Map Statement 6
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 205
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-5
+      config:
+        name: "6"
+      name: "6"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=65525]
+  summary: Create Route Map Statement 65525
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 150
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: all-externals
+      config:
+        name: "65525"
+      name: "65525"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=7]
+  summary: Create Route Map Statement 7
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 204
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-6
+      config:
+        name: "7"
+      name: "7"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=8]
+  summary: Create Route Map Statement 8
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 203
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-7
+      config:
+        name: "8"
+      name: "8"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=9]
+  summary: Create Route Map Statement 9
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 202
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: gw-prio-8
+      config:
+        name: "9"
+      name: "9"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: all-vtep-prefixes
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: protocol-loopback-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          set-community:
+            config:
+              method: INLINE
+              options: ADD
+            inline:
+              config:
+                communities:
+                - "50000:2"
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-subnets--vpc-01
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-01]/statements/statement[name=6]
+  summary: Create Route Map Statement 6
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-01
+      config:
+        name: "6"
+      name: "6"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-03]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-03]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-03]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          set-community:
+            config:
+              method: INLINE
+              options: ADD
+            inline:
+              config:
+                communities:
+                - "50000:3"
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-subnets--vpc-03
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-03]/statements/statement[name=6]
+  summary: Create Route Map Statement 6
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-03
+      config:
+        name: "6"
+      name: "6"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-04]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-04]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-04]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          set-community:
+            config:
+              method: INLINE
+              options: ADD
+            inline:
+              config:
+                communities:
+                - "50000:4"
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-subnets--vpc-04
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-connected--vpc-04]/statements/statement[name=6]
+  summary: Create Route Map Statement 6
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-04
+      config:
+        name: "6"
+      name: "6"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-ext-prefixes--vpc-01
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-01]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-01
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-03]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-03]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-ext-prefixes--vpc-03
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-03]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-03
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-04]/statements/statement[name=1]
+  summary: Create Route Map Statement 1
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-loopback-prefix
+      config:
+        name: "1"
+      name: "1"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-04]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-ext-prefixes--vpc-04
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=vpc-redistribute-static--vpc-04]/statements/statement[name=5]
+  summary: Create Route Map Statement 5
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vpc-static-ext-subnets--vpc-04
+      config:
+        name: "5"
+      name: "5"
+  weight: 21
+- path: /interfaces/interface[name=PortChannel1]/aggregation/switched-vlan/config/trunk-vlans
+  summary: Create PortChannel PortChannel1 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1006
+  weight: 24
+- path: /interfaces/interface[name=PortChannel2]/aggregation/switched-vlan/config/trunk-vlans
+  summary: Create PortChannel PortChannel2 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1005
+  weight: 24
+- path: /interfaces/interface[name=Ethernet0]/ethernet
+  summary: Create Interface Ethernet0 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet1]/ethernet
+  summary: Create Interface Ethernet1 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet2]/ethernet
+  summary: Create Interface Ethernet2 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet3]/ethernet
+  summary: Create Interface Ethernet3 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet4]/ethernet
+  summary: Create Interface Ethernet4 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet5]/ethernet
+  summary: Create Interface Ethernet5 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet6]/ethernet
+  summary: Create Interface Ethernet6 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet7]/ethernet
+  summary: Create Interface Ethernet7 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Vlan1005]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan1005 VLAN Anycast Gateway
+  type: update
+  value:
+    static-anycast-gateway:
+    - 10.0.5.1/24
+  weight: 26
+- path: /interfaces/interface[name=Vlan1006]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan1006 VLAN Anycast Gateway
+  type: update
+  value:
+    static-anycast-gateway:
+    - 10.0.6.1/24
+  weight: 26
+- path: /interfaces/interface[name=Vlan1007]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan1007 VLAN Anycast Gateway
+  type: update
+  value:
+    static-anycast-gateway:
+    - 10.0.7.1/24
+  weight: 26
+- path: /interfaces/interface[name=Vlan3000]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan3000 VLAN Anycast Gateway
+  type: update
+  weight: 26
+- path: /interfaces/interface[name=Vlan3001]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan3001 VLAN Anycast Gateway
+  type: update
+  weight: 26
+- path: /interfaces/interface[name=Vlan3002]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan3002 VLAN Anycast Gateway
+  type: update
+  weight: 26
+- path: /interfaces/interface[name=Vlan3003]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
+  summary: Create Interface Vlan3003 VLAN Anycast Gateway
+  type: update
+  weight: 26
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/system_mac
+  summary: Create PortChannel System MAC PortChannel1
+  type: update
+  value:
+    system_mac: f2:00:00:00:00:02
+  weight: 28
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/system_mac
+  summary: Create PortChannel System MAC PortChannel2
+  type: update
+  value:
+    system_mac: f2:00:00:00:00:01
+  weight: 28
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel1]/fallback
+  summary: Create PortChannel Fallback PortChannel1
+  type: update
+  value:
+    fallback: false
+  weight: 29
+- path: /sonic-portchannel/PORTCHANNEL/PORTCHANNEL_LIST[name=PortChannel2]/fallback
+  summary: Create PortChannel Fallback PortChannel2
+  type: update
+  value:
+    fallback: false
+  weight: 29
+- path: /interfaces/interface[name=Ethernet3]/ethernet/switched-vlan/config/trunk-vlans
+  summary: Create Interface Ethernet3 Switched Trunk VLANs
+  type: update
+  value:
+    trunk-vlans:
+    - 1007
+  weight: 43
+- path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]
+  summary: Create Subinterface Base 10
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 10
+      index: 10
+      vlan:
+        config:
+          vlan-id: 10
+  weight: 44
+- path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=PortChannel1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=PortChannel2]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /network-instances/network-instance[name=VrfEexternal-01]/interfaces/interface[id=Ethernet0.10]
+  summary: Create VRF interface Ethernet0.10
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet0.10
+      id: Ethernet0.10
+  weight: 47
+- path: /network-instances/network-instance[name=VrfEexternal-01]/interfaces/interface[id=Vlan3003]
+  summary: Create VRF interface Vlan3003
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan3003
+      id: Vlan3003
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-01]/interfaces/interface[id=Vlan3001]
+  summary: Create VRF interface Vlan3001
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan3001
+      id: Vlan3001
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1005]
+  summary: Create VRF interface Vlan1005
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan1005
+      id: Vlan1005
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan1006]
+  summary: Create VRF interface Vlan1006
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan1006
+      id: Vlan1006
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-03]/interfaces/interface[id=Vlan3002]
+  summary: Create VRF interface Vlan3002
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan3002
+      id: Vlan3002
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan1007]
+  summary: Create VRF interface Vlan1007
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan1007
+      id: Vlan1007
+  weight: 47
+- path: /network-instances/network-instance[name=VrfVvpc-04]/interfaces/interface[id=Vlan3000]
+  summary: Create VRF interface Vlan3000
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan3000
+      id: Vlan3000
+  weight: 47
+- path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1005]
+  summary: Create VRF attached host
+  type: update
+  value:
+    interface:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        interface-id: Vlan1005
+      interface-id: Vlan1005
+  weight: 50
+- path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1006]
+  summary: Create VRF attached host
+  type: update
+  value:
+    interface:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        interface-id: Vlan1006
+      interface-id: Vlan1006
+  weight: 50
+- path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=ATTACHED_HOST][name=attached-host]/attached-host/interfaces/interface[address-family=IPV4][interface-id=Vlan1007]
+  summary: Create VRF attached host
+  type: update
+  value:
+    interface:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        interface-id: Vlan1007
+      interface-id: Vlan1007
+  weight: 50
+- path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=10]/ipv4/addresses/address
+  summary: Create Subinterface IP 100.1.10.1
+  type: update
+  value:
+    address:
+    - config:
+        ip: 100.1.10.1
+        prefix-length: 24
+        secondary: false
+      ip: 100.1.10.1
+  weight: 51
+- path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.8.4
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.8.4
+        prefix-length: 32
+        secondary: false
+      ip: 172.30.8.4
+  weight: 51
+- path: /interfaces/interface[name=Loopback2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.12.1
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.12.1
+        prefix-length: 32
+        secondary: false
+      ip: 172.30.12.1
+  weight: 51
+- path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.0.11
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.0.11
+        prefix-length: 21
+        secondary: false
+      ip: 172.30.0.11
+  weight: 51
+- path: /system/ntp/config
+  summary: Create NTP
+  type: update
+  value:
+    config:
+      source-interface:
+      - Management0
+  weight: 55
+- path: /system/ntp/servers/server[address=172.30.0.1]
+  summary: Create NTP server 172.30.0.1
+  type: update
+  value:
+    server:
+    - address: 172.30.0.1
+      config:
+        address: 172.30.0.1
+        prefer: true
+  weight: 56
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan1005
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1005
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan1006
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1006
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan1007
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1007
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan3000
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan3000
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan3001
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan3001
+      suppress: "on"
+  weight: 61
+- path: /sonic-vxlan/SUPPRESS_VLAN_NEIGH/SUPPRESS_VLAN_NEIGH_LIST
+  summary: Create Suppress VLAN neigh Vlan3002
+  type: update
+  value:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan3002
+      suppress: "on"
+  weight: 61
+- path: /network-instances/network-instance[name=VrfEexternal-01]/global-sag/config
+  summary: Create VRF VrfEexternal-01 SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=VrfVvpc-01]/global-sag/config
+  summary: Create VRF VrfVvpc-01 SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=VrfVvpc-03]/global-sag/config
+  summary: Create VRF VrfVvpc-03 SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=VrfVvpc-04]/global-sag/config
+  summary: Create VRF VrfVvpc-04 SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=default]/global-sag/config
+  summary: Create VRF default SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=VrfEexternal-01]/evpn/evpn-mh/config
+  summary: Create VRF VrfEexternal-01 EVPNMH
+  type: update
+  weight: 65
+- path: /network-instances/network-instance[name=VrfVvpc-01]/evpn/evpn-mh/config
+  summary: Create VRF VrfVvpc-01 EVPNMH
+  type: update
+  weight: 65
+- path: /network-instances/network-instance[name=VrfVvpc-03]/evpn/evpn-mh/config
+  summary: Create VRF VrfVvpc-03 EVPNMH
+  type: update
+  weight: 65
+- path: /network-instances/network-instance[name=VrfVvpc-04]/evpn/evpn-mh/config
+  summary: Create VRF VrfVvpc-04 EVPNMH
+  type: update
+  weight: 65
+- path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
+  summary: Create VRF default EVPNMH
+  type: update
+  value:
+    config:
+      mac-holdtime: 60
+      startup-delay: 60
+  weight: 65
+- path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel1]
+  summary: Create VRF PortChannel1 EVPN ethernet segment
+  type: update
+  value:
+    ethernet-segment:
+    - config:
+        esi: 00f20000f20000000002
+        esi-type: TYPE_0_OPERATOR_CONFIGURED
+        interface: PortChannel1
+        name: PortChannel1
+      name: PortChannel1
+  weight: 66
+- path: /network-instances/network-instance[name=default]/evpn/ethernet-segments/ethernet-segment[name=PortChannel2]
+  summary: Create VRF PortChannel2 EVPN ethernet segment
+  type: update
+  value:
+    ethernet-segment:
+    - config:
+        esi: 00f20000f20000000001
+        esi-type: TYPE_0_OPERATOR_CONFIGURED
+        interface: PortChannel2
+        name: PortChannel2
+      name: PortChannel2
+  weight: 66
+- path: /lst/lst-groups/lst-group
+  summary: Create LST Group spinelink
+  type: update
+  value:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+  weight: 67
+- path: /lst/interfaces/interface[id=Ethernet4]
+  summary: Create LST Interface Ethernet4
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /lst/interfaces/interface[id=Ethernet5]
+  summary: Create LST Interface Ethernet5
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /lst/interfaces/interface[id=Ethernet6]
+  summary: Create LST Interface Ethernet6
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /lst/interfaces/interface[id=Ethernet7]
+  summary: Create LST Interface Ethernet7
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet7
+      id: Ethernet7
+      interface-ref:
+        config:
+          interface: Ethernet7
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  weight: 68
+- path: /sonic-vxlan/VXLAN_TUNNEL/VXLAN_TUNNEL_LIST
+  summary: Create VXLAN tunnel vtepfabric
+  type: update
+  value:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.1
+  weight: 71
+- path: /sonic-vxlan/VXLAN_EVPN_NVO/VXLAN_EVPN_NVO_LIST
+  summary: Create VXLAN EVPN NVO nvo1
+  type: update
+  value:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  weight: 73
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_100_Vlan3003
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_100_Vlan3003
+      name: vtepfabric
+      vlan: Vlan3003
+      vni: 100
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_200_Vlan3001
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_200_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 200
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_300_Vlan3002
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_300_Vlan3002
+      name: vtepfabric
+      vlan: Vlan3002
+      vni: 300
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_301_Vlan1006
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_301_Vlan1006
+      name: vtepfabric
+      vlan: Vlan1006
+      vni: 301
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_302_Vlan1005
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_302_Vlan1005
+      name: vtepfabric
+      vlan: Vlan1005
+      vni: 302
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_400_Vlan3000
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_400_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 400
+  weight: 75
+- path: /sonic-vxlan/VXLAN_TUNNEL_MAP/VXLAN_TUNNEL_MAP_LIST
+  summary: Create VXLAN tunnel map map_401_Vlan1007
+  type: update
+  value:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_401_Vlan1007
+      name: vtepfabric
+      vlan: Vlan1007
+      vni: 401
+  weight: 75
+- path: /acl/acl-sets/acl-set
+  summary: Create ACL ext-inbound--leaf-03--external-01 base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: Inbound ACL leaf-03--external-01
+        name: ext-inbound--leaf-03--external-01
+        type: ACL_IPV4
+      name: ext-inbound--leaf-03--external-01
+      type: ACL_IPV4
+  weight: 76
+- path: /acl/acl-sets/acl-set
+  summary: Create ACL ipns-egress--default base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: ipns-egress--default
+        name: ipns-egress--default
+        type: ACL_IPV4
+      name: ipns-egress--default
+      type: ACL_IPV4
+  weight: 76
+- path: /acl/acl-sets/acl-set
+  summary: Create ACL no-ipns-peering--default base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 1
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 1
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 1
+      transport:
+        config:
+          destination-port: 443
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 2
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 2
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 2
+      transport:
+        config:
+          destination-port: 8080
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 3
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 3
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 3
+      transport:
+        config:
+          destination-port: 67
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 4
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 4
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 4
+      transport:
+        config:
+          destination-port: 161
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 5
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 5
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_UDP
+      sequence-id: 5
+      transport:
+        config:
+          destination-port: 4789
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 6
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DISCARD
+      config:
+        sequence-id: 6
+      ipv4:
+        config:
+          destination-address: 100.1.10.1/32
+          protocol: IP_TCP
+      sequence-id: 6
+      transport:
+        config:
+          destination-port: 22
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ext-inbound--leaf-03--external-01][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 10
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 10
+      ipv4:
+        config:
+          destination-address: 10.0.0.0/16
+      sequence-id: 10
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=ipns-egress--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 1
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 1
+      ipv4:
+        config:
+          destination-address: 10.0.0.0/16
+          source-address: 10.0.0.0/16
+      sequence-id: 1
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 78
+- path: /acl/interfaces/interface[id=Ethernet0.10]
+  summary: Create ACL interface Ethernet0.10
+  type: update
+  value:
+    interface:
+    - config:
+        id: Ethernet0.10
+      egress-acl-sets:
+        egress-acl-set:
+        - config:
+            set-name: ipns-egress--default
+            type: ACL_IPV4
+          set-name: ipns-egress--default
+          type: ACL_IPV4
+      id: Ethernet0.10
+      interface-ref:
+        config:
+          interface: Ethernet0
+          subinterface: 10
+  weight: 79
+- path: /acl/interfaces/interface[id=Ethernet0.10]/ingress-acl-sets/ingress-acl-set
+  summary: Update ACL interface Ethernet0.10 ingress
+  type: update
+  value:
+    ingress-acl-set:
+    - config:
+        set-name: ext-inbound--leaf-03--external-01
+        type: ACL_IPV4
+      set-name: ext-inbound--leaf-03--external-01
+      type: ACL_IPV4
+  weight: 79
+- path: /acl/interfaces/interface[id=Vlan3003]
+  summary: Create ACL interface Vlan3003
+  type: update
+  value:
+    interface:
+    - config:
+        id: Vlan3003
+      id: Vlan3003
+      interface-ref:
+        config:
+          interface: Vlan3003
+  weight: 79
+- path: /acl/interfaces/interface[id=Vlan3003]/ingress-acl-sets/ingress-acl-set
+  summary: Update ACL interface Vlan3003 ingress
+  type: update
+  value:
+    ingress-acl-set:
+    - config:
+        set-name: no-ipns-peering--default
+        type: ACL_IPV4
+      set-name: no-ipns-peering--default
+      type: ACL_IPV4
+  weight: 79
+- path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF VrfEexternal-01 BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65102
+          network-import-check: true
+          router-id: 172.30.8.4
+  weight: 80
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF VrfVvpc-01 BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65102
+          network-import-check: true
+          router-id: 172.30.8.4
+  weight: 80
+- path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF VrfVvpc-03 BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65102
+          network-import-check: true
+          router-id: 172.30.8.4
+  weight: 80
+- path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF VrfVvpc-04 BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65102
+          network-import-check: true
+          router-id: 172.30.8.4
+  weight: 80
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF default BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65102
+          network-import-check: true
+          router-id: 172.30.8.4
+  weight: 80
+- path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF VrfEexternal-01 BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        route-advertise:
+          route-advertise-list:
+          - advertise-afi-safi: IPV4_UNICAST
+            config:
+              advertise-afi-safi: IPV4_UNICAST
+              route-map:
+              - ext-inbound--external-01
+  weight: 81
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF VrfVvpc-01 BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        route-advertise:
+          route-advertise-list:
+          - advertise-afi-safi: IPV4_UNICAST
+            config:
+              advertise-afi-safi: IPV4_UNICAST
+              route-map:
+              - filter-attached-hosts
+  weight: 81
+- path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF VrfVvpc-03 BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        route-advertise:
+          route-advertise-list:
+          - advertise-afi-safi: IPV4_UNICAST
+            config:
+              advertise-afi-safi: IPV4_UNICAST
+              route-map:
+              - filter-attached-hosts
+  weight: 81
+- path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF VrfVvpc-04 BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        route-advertise:
+          route-advertise-list:
+          - advertise-afi-safi: IPV4_UNICAST
+            config:
+              advertise-afi-safi: IPV4_UNICAST
+              route-map:
+              - filter-attached-hosts
+  weight: 81
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF default BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        config:
+          advertise-all-vni: true
+        route-advertise:
+          route-advertise-list: []
+  weight: 81
+- path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
+  summary: Create BFD Profile fabric
+  type: update
+  value:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+  weight: 82
+- path: /openconfig-errdisable-ext:errdisable/config
+  summary: Create ErrDisable Global
+  type: update
+  value:
+    config:
+      cause:
+      - LINK_FLAP
+      interval: 300
+  weight: 83
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
+  summary: Create ErrDisable Interface Ethernet4
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
+  summary: Create ErrDisable Interface Ethernet5
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
+  summary: Create ErrDisable Interface Ethernet6
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
+  summary: Create ErrDisable Interface Ethernet7
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-neighbor:neighbor-globals/neighbor-global
+  summary: Create Neighbor Global
+  type: update
+  value:
+    neighbor-global:
+    - config:
+        ipv4-drop-neighbor-aging-time: 60
+        name: Values
+      name: Values
+  weight: 86
+- path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=100.1.10.6]
+  summary: Create VRF BGP neighbor 100.1.10.6
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - ext-outbound--external-01
+              import-policy:
+              - ext-inbound--external-01
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        description: External attach leaf-03--external-01
+        enabled: true
+        neighbor-address: 100.1.10.6
+        peer-as: 64102
+      neighbor-address: 100.1.10.6
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.0]
+  summary: Create VRF BGP neighbor 172.30.8.0
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric spine-01 loopback (spine-link)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.0
+        peer-as: 65100
+      neighbor-address: 172.30.8.0
+      transport:
+        config:
+          local-address: 172.30.8.4
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.1]
+  summary: Create VRF BGP neighbor 172.30.8.1
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric spine-02 loopback (spine-link)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.1
+        peer-as: 65100
+      neighbor-address: 172.30.8.1
+      transport:
+        config:
+          local-address: 172.30.8.4
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet4]
+  summary: Create VRF BGP neighbor Ethernet4
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+        enabled: true
+        neighbor-address: Ethernet4
+        peer-as: 65100
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet4
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet5]
+  summary: Create VRF BGP neighbor Ethernet5
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+        enabled: true
+        neighbor-address: Ethernet5
+        peer-as: 65100
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet5
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet6]
+  summary: Create VRF BGP neighbor Ethernet6
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+        enabled: true
+        neighbor-address: Ethernet6
+        peer-as: 65100
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet6
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet7]
+  summary: Create VRF BGP neighbor Ethernet7
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+        enabled: true
+        neighbor-address: Ethernet7
+        peer-as: 65100
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet7
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.4/32]
+  summary: Create VRF BGP network 172.30.8.4/32
+  type: update
+  value:
+    network:
+    - config:
+        prefix: 172.30.8.4/32
+      prefix: 172.30.8.4/32
+  weight: 88
+- path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
+  summary: Create VRF table connection attachedhost
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      dst-protocol: BGP
+      src-protocol: ATTACHED_HOST
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-connected--vpc-01
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-01]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-static--vpc-01
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
+  summary: Create VRF table connection attachedhost
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      dst-protocol: BGP
+      src-protocol: ATTACHED_HOST
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-connected--vpc-03
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-03]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-static--vpc-03
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
+  summary: Create VRF table connection attachedhost
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      dst-protocol: BGP
+      src-protocol: ATTACHED_HOST
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-connected--vpc-04
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=VrfVvpc-04]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        import-policy:
+        - vpc-redistribute-static--vpc-04
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /network-instances/network-instance[name=default]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=default]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
+  summary: Create VRF BGP import policy VrfEexternal-01
+  type: update
+  value:
+    policy-name: ext-import--external-01
+  weight: 90
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
+  summary: Create VRF BGP import policy VrfVvpc-01
+  type: update
+  value:
+    policy-name: import-vrf--vpc-01
+  weight: 90
+- path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
+  summary: Create VRF BGP import policy VrfVvpc-03
+  type: update
+  value:
+    policy-name: import-vrf--vpc-03
+  weight: 90
+- path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/policy-name
+  summary: Create VRF BGP import policy VrfVvpc-04
+  type: update
+  value:
+    policy-name: import-vrf--vpc-04
+  weight: 90
+- path: /network-instances/network-instance[name=VrfEexternal-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
+  summary: Create VRF BGP import VRF VrfEexternal-01
+  type: update
+  value:
+    name:
+    - VrfVvpc-01
+    - VrfVvpc-03
+  weight: 91
+- path: /network-instances/network-instance[name=VrfVvpc-01]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
+  summary: Create VRF BGP import VRF VrfVvpc-01
+  type: update
+  value:
+    name:
+    - VrfEexternal-01
+  weight: 91
+- path: /network-instances/network-instance[name=VrfVvpc-03]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
+  summary: Create VRF BGP import VRF VrfVvpc-03
+  type: update
+  value:
+    name:
+    - VrfEexternal-01
+    - VrfVvpc-04
+  weight: 91
+- path: /network-instances/network-instance[name=VrfVvpc-04]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/import-network-instance/config/name
+  summary: Create VRF BGP import VRF VrfVvpc-04
+  type: update
+  value:
+    name:
+    - VrfVvpc-03
+  weight: 91
+- path: relay-agent/dhcp/interfaces/interface[id=Vlan1005]
+  summary: Create DHCP relay Vlan1005
+  type: update
+  value:
+    interface:
+    - agent-information-option:
+        config:
+          link-select: ENABLE
+          vrf-select: ENABLE
+      config:
+        helper-address:
+        - 172.30.0.1
+        src-intf: Management0
+      id: Vlan1005
+  weight: 92
+- path: relay-agent/dhcp/interfaces/interface[id=Vlan1006]
+  summary: Create DHCP relay Vlan1006
+  type: update
+  value:
+    interface:
+    - agent-information-option:
+        config:
+          link-select: ENABLE
+          vrf-select: ENABLE
+      config:
+        helper-address:
+        - 172.30.0.1
+        src-intf: Management0
+      id: Vlan1006
+  weight: 92
+- path: relay-agent/dhcp/interfaces/interface[id=Vlan1007]
+  summary: Create DHCP relay Vlan1007
+  type: update
+  value:
+    interface:
+    - agent-information-option:
+        config:
+          link-select: ENABLE
+          vrf-select: ENABLE
+      config:
+        helper-address:
+        - 172.30.0.1
+        src-intf: Management0
+      id: Vlan1007
+  weight: 92
+- path: /loadshare/roce-attrs
+  summary: Update ECMP RoCE
+  type: replace
+  value:
+    roce-attrs:
+      config:
+        hash: hash
+        qpn: false
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.gnmi.expected.yaml
@@ -1,0 +1,2589 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 1
+          transport:
+            config:
+              destination-port: 443
+        - actions:
+            config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 2
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 2
+          transport:
+            config:
+              destination-port: 8080
+        - actions:
+            config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 3
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 3
+          transport:
+            config:
+              destination-port: 67
+        - actions:
+            config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 4
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 4
+          transport:
+            config:
+              destination-port: 161
+        - actions:
+            config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 5
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_UDP
+          sequence-id: 5
+          transport:
+            config:
+              destination-port: 4789
+        - actions:
+            config:
+              forwarding-action: DISCARD
+          config:
+            sequence-id: 6
+          ipv4:
+            config:
+              destination-address: 100.1.10.1/32
+              protocol: IP_TCP
+          sequence-id: 6
+          transport:
+            config:
+              destination-port: 22
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Inbound ACL leaf-03--external-01
+        name: ext-inbound--leaf-03--external-01
+        type: ACL_IPV4
+      name: ext-inbound--leaf-03--external-01
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 10
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+          sequence-id: 10
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: ipns-egress--default
+        name: ipns-egress--default
+        type: ACL_IPV4
+      name: ipns-egress--default
+      type: ACL_IPV4
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet0.10
+      egress-acl-sets:
+        egress-acl-set:
+        - config:
+            set-name: ipns-egress--default
+            type: ACL_IPV4
+          set-name: ipns-egress--default
+          type: ACL_IPV4
+      id: Ethernet0.10
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: ext-inbound--leaf-03--external-01
+            type: ACL_IPV4
+          set-name: ext-inbound--leaf-03--external-01
+          type: ACL_IPV4
+      interface-ref:
+        config:
+          interface: Ethernet0
+          subinterface: 10
+    - config:
+        id: Vlan3003
+      id: Vlan3003
+      ingress-acl-sets:
+        ingress-acl-set:
+        - config:
+            set-name: no-ipns-peering--default
+            type: ACL_IPV4
+          set-name: no-ipns-peering--default
+          type: ACL_IPV4
+      interface-ref:
+        config:
+          interface: Vlan3003
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: false
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+errdisable:
+  config:
+    cause:
+    - LINK_FLAP
+    interval: 300
+errdisable-port:
+  port:
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet4
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet5
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet6
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet7
+interfaces:
+  interface:
+  - config:
+      description: External leaf-03--external
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+      - config:
+          index: 10
+        index: 10
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 100.1.10.1
+                prefix-length: 24
+                secondary: false
+              ip: 100.1.10.1
+        vlan:
+          config:
+            vlan-id: 10
+  - config:
+      description: PC2 ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet1
+    ethernet:
+      config:
+        aggregate-id: PortChannel2
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: PC1 ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: Ethernet2
+    ethernet:
+      config:
+        aggregate-id: PortChannel1
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Unbundled server-07 server-07--unbundled--leaf-03
+      enabled: true
+      mtu: 9036
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1007
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.4
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.4
+  - config:
+      description: VTEP loopback
+      enabled: true
+      name: Loopback2
+    name: Loopback2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.12.1
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.12.1
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.11
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.11
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1006
+    config:
+      description: ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: PortChannel1
+    name: PortChannel1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - aggregation:
+      switched-vlan:
+        config:
+          trunk-vlans:
+          - 1005
+    config:
+      description: ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+      enabled: true
+      mtu: 9036
+      name: PortChannel2
+    name: PortChannel2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+  - config:
+      description: VPC vpc-03/subnet-01
+      enabled: true
+      name: Vlan1005
+    name: Vlan1005
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.5.1/24
+  - config:
+      description: VPC vpc-03/subnet-02
+      enabled: true
+      name: Vlan1006
+    name: Vlan1006
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.6.1/24
+  - config:
+      description: VPC vpc-04/subnet-01
+      enabled: true
+      name: Vlan1007
+    name: Vlan1007
+    routed-vlan:
+      ipv4:
+        sag-ipv4:
+          config:
+            static-anycast-gateway:
+            - 10.0.7.1/24
+  - config:
+      description: VPC vpc-04 IRB
+      enabled: true
+      name: Vlan3000
+    name: Vlan3000
+  - config:
+      description: VPC vpc-01 IRB
+      enabled: true
+      name: Vlan3001
+    name: Vlan3001
+  - config:
+      description: VPC vpc-03 IRB
+      enabled: true
+      name: Vlan3002
+    name: Vlan3002
+  - config:
+      description: External external-01 IRB
+      enabled: true
+      name: Vlan3003
+    name: Vlan3003
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: leaf-03
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+lst:
+  interfaces:
+    interface:
+    - config:
+        id: Ethernet4
+      id: Ethernet4
+      interface-ref:
+        config:
+          interface: Ethernet4
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet5
+      id: Ethernet5
+      interface-ref:
+        config:
+          interface: Ethernet5
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet6
+      id: Ethernet6
+      interface-ref:
+        config:
+          interface: Ethernet6
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+    - config:
+        id: Ethernet7
+      id: Ethernet7
+      interface-ref:
+        config:
+          interface: Ethernet7
+      upstream-groups:
+        upstream-group:
+        - config:
+            group-name: spinelink
+          group-name: spinelink
+  lst-groups:
+    lst-group:
+    - config:
+        all-evpn-es-downstream: true
+        name: spinelink
+        timeout: 60
+      name: spinelink
+neighbor-globals:
+  neighbor-global:
+  - config:
+      ipv4-drop-neighbor-aging-time: 60
+      name: Values
+    name: Values
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: VrfEexternal-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Ethernet0.10
+        id: Ethernet0.10
+      - config:
+          id: Vlan3003
+        id: Vlan3003
+    name: VrfEexternal-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-01
+                    - VrfVvpc-03
+                    policy-name: ext-import--external-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - ext-inbound--external-01
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - ext-outbound--external-01
+                      import-policy:
+                      - ext-inbound--external-01
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                description: External attach leaf-03--external-01
+                enabled: true
+                neighbor-address: 100.1.10.6
+                peer-as: 64102
+              neighbor-address: 100.1.10.6
+        identifier: BGP
+        name: bgp
+  - config:
+      enabled: true
+      name: VrfVvpc-01
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan3001
+        id: Vlan3001
+    name: VrfVvpc-01
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfEexternal-01
+                    policy-name: import-vrf--vpc-01
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-01
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-01
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-03
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1005
+        id: Vlan1005
+      - config:
+          id: Vlan1006
+        id: Vlan1006
+      - config:
+          id: Vlan3002
+        id: Vlan3002
+    name: VrfVvpc-03
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1005
+              interface-id: Vlan1005
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1006
+              interface-id: Vlan1006
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfEexternal-01
+                    - VrfVvpc-04
+                    policy-name: import-vrf--vpc-03
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-03
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-03
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: VrfVvpc-04
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    interfaces:
+      interface:
+      - config:
+          id: Vlan1007
+        id: Vlan1007
+      - config:
+          id: Vlan3000
+        id: Vlan3000
+    name: VrfVvpc-04
+    protocols:
+      protocol:
+      - attached-host:
+          interfaces:
+            interface:
+            - address-family: IPV4
+              config:
+                address-family: IPV4
+                interface-id: Vlan1007
+              interface-id: Vlan1007
+        identifier: ATTACHED_HOST
+        name: attached-host
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                import-network-instance:
+                  config:
+                    name:
+                    - VrfVvpc-03
+                    policy-name: import-vrf--vpc-04
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  route-advertise:
+                    route-advertise-list:
+                    - advertise-afi-safi: IPV4_UNICAST
+                      config:
+                        advertise-afi-safi: IPV4_UNICAST
+                        route-map:
+                        - filter-attached-hosts
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: ATTACHED_HOST
+        dst-protocol: BGP
+        src-protocol: ATTACHED_HOST
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-connected--vpc-04
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          import-policy:
+          - vpc-redistribute-static--vpc-04
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+  - config:
+      enabled: true
+      name: default
+    evpn:
+      ethernet-segments:
+        ethernet-segment:
+        - config:
+            esi: 00f20000f20000000002
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel1
+            name: PortChannel1
+          name: PortChannel1
+        - config:
+            esi: 00f20000f20000000001
+            esi-type: TYPE_0_OPERATOR_CONFIGURED
+            interface: PortChannel2
+            name: PortChannel2
+          name: PortChannel2
+      evpn-mh:
+        config:
+          mac-holdtime: 60
+          startup-delay: 60
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.4/32
+                    prefix: 172.30.8.4/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65102
+              network-import-check: true
+              router-id: 172.30.8.4
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.0
+                peer-as: 65100
+              neighbor-address: 172.30.8.0
+              transport:
+                config:
+                  local-address: 172.30.8.4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric spine-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.1
+                peer-as: 65100
+              neighbor-address: 172.30.8.1
+              transport:
+                config:
+                  local-address: 172.30.8.4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: Ethernet4
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: Ethernet5
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet5
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+                enabled: true
+                neighbor-address: Ethernet6
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet6
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+                enabled: true
+                neighbor-address: Ethernet7
+                peer-as: 65100
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet7
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+relay-agent:
+  dhcp:
+    interfaces:
+      interface:
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1005
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1006
+      - agent-information-option:
+          config:
+            link-select: ENABLE
+            vrf-select: ENABLE
+        config:
+          helper-address:
+          - 172.30.0.1
+          src-intf: Management0
+        id: Vlan1007
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: all-gw-prios
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            - "50001:1"
+            - "50001:2"
+            - "50001:3"
+            - "50001:4"
+            - "50001:5"
+            - "50001:6"
+            - "50001:7"
+            - "50001:8"
+            - "50001:9"
+            community-set-name: all-gw-prios
+            match-set-options: ANY
+        - community-set-name: ext-inbound--external-01
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: ext-inbound--external-01
+            match-set-options: ANY
+        - community-set-name: gw-prio-0
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:0"
+            community-set-name: gw-prio-0
+            match-set-options: ANY
+        - community-set-name: gw-prio-1
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:1"
+            community-set-name: gw-prio-1
+            match-set-options: ANY
+        - community-set-name: gw-prio-2
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:2"
+            community-set-name: gw-prio-2
+            match-set-options: ANY
+        - community-set-name: gw-prio-3
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:3"
+            community-set-name: gw-prio-3
+            match-set-options: ANY
+        - community-set-name: gw-prio-4
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:4"
+            community-set-name: gw-prio-4
+            match-set-options: ANY
+        - community-set-name: gw-prio-5
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:5"
+            community-set-name: gw-prio-5
+            match-set-options: ANY
+        - community-set-name: gw-prio-6
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:6"
+            community-set-name: gw-prio-6
+            match-set-options: ANY
+        - community-set-name: gw-prio-7
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:7"
+            community-set-name: gw-prio-7
+            match-set-options: ANY
+        - community-set-name: gw-prio-8
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:8"
+            community-set-name: gw-prio-8
+            match-set-options: ANY
+        - community-set-name: gw-prio-9
+          config:
+            action: PERMIT
+            community-member:
+            - "50001:9"
+            community-set-name: gw-prio-9
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-01
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:2"
+            community-set-name: vpc-peers--vpc-01
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-03
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-03
+            match-set-options: ANY
+        - community-set-name: vpc-peers--vpc-04
+          config:
+            action: PERMIT
+            community-member:
+            - "50000:3"
+            - "50000:4"
+            community-set-name: vpc-peers--vpc-04
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ext-import--external-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 103
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 103
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 105
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 105
+        name: ext-import--external-01
+      - config:
+          mode: IPV4
+          name: import-vrf--vpc-01--external-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: import-vrf--vpc-01--external-01
+      - config:
+          mode: IPV4
+          name: import-vrf--vpc-03--external-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: import-vrf--vpc-03--external-01
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.4/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.4/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: vpc-ext-prefixes--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 106
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 106
+        name: vpc-ext-prefixes--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-ext-prefixes--vpc-04
+        name: vpc-ext-prefixes--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-not-subnets--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: DENY
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: DENY
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 65535
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 65535
+        name: vpc-not-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-01
+        name: vpc-peers--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 401
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 401
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 402
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 402
+        name: vpc-peers--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-peers--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 301
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 301
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 302
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 302
+        name: vpc-peers--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-01
+        name: vpc-static-ext-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-03
+        name: vpc-static-ext-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-static-ext-subnets--vpc-04
+        name: vpc-static-ext-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-01
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.1.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.1.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.2.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.2.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-01
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-03
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.6.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.6.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.5.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.5.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vpc-subnets--vpc-04
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.7.0/24
+              masklength-range: 24..32
+              sequence-number: 1
+            ip-prefix: 10.0.7.0/24
+            masklength-range: 24..32
+            sequence-number: 1
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.8.0/24
+              masklength-range: 24..32
+              sequence-number: 2
+            ip-prefix: 10.0.8.0/24
+            masklength-range: 24..32
+            sequence-number: 2
+        name: vpc-subnets--vpc-04
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: ext-import--external-01
+      name: ext-import--external-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ext-import--external-01
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: ext-inbound--external-01
+      name: ext-inbound--external-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--external-01
+          config:
+            name: "15"
+          name: "15"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              match-as-path-set:
+                config:
+                  as-path-set: fabric-gw-aspath
+                  match-set-options: ANY
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: ext-outbound--external-01
+      name: ext-outbound--external-01
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - 64102:1000
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - 64102:1000
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-gw-prios
+          config:
+            name: "20"
+          name: "20"
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: import-vrf--vpc-01
+      name: import-vrf--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-01
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-01
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--external-01
+            match-prefix-set:
+              config:
+                prefix-set: import-vrf--vpc-01--external-01
+          config:
+            name: "50010"
+          name: "50010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+            match-src-network-instance:
+              config:
+                name: VrfEexternal-01
+          config:
+            name: "5010"
+          name: "5010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-03
+      name: import-vrf--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-04
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-04
+          config:
+            name: "10004"
+          name: "10004"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-03
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-03
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: ext-inbound--external-01
+            match-prefix-set:
+              config:
+                prefix-set: import-vrf--vpc-03--external-01
+          config:
+            name: "50010"
+          name: "50010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+            match-src-network-instance:
+              config:
+                name: VrfEexternal-01
+          config:
+            name: "5010"
+          name: "5010"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: import-vrf--vpc-04
+      name: import-vrf--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                next-hop-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-not-subnets--vpc-03
+            match-src-network-instance:
+              config:
+                name: VrfVvpc-03
+          config:
+            name: "10003"
+          name: "10003"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: vpc-peers--vpc-04
+          config:
+            name: "50000"
+          name: "50000"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: no-community
+            match-prefix-set:
+              config:
+                prefix-set: vpc-peers--vpc-04
+          config:
+            name: "50001"
+          name: "50001"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 210
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-0
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 201
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-9
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 209
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-1
+          config:
+            name: "2"
+          name: "2"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 208
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-2
+          config:
+            name: "3"
+          name: "3"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 207
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-3
+          config:
+            name: "4"
+          name: "4"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 206
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-4
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 205
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-5
+          config:
+            name: "6"
+          name: "6"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 204
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-6
+          config:
+            name: "7"
+          name: "7"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 203
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-7
+          config:
+            name: "8"
+          name: "8"
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 202
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: gw-prio-8
+          config:
+            name: "9"
+          name: "9"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: vpc-redistribute-connected--vpc-01
+      name: vpc-redistribute-connected--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:2"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-03
+      name: vpc-redistribute-connected--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:3"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-connected--vpc-04
+      name: vpc-redistribute-connected--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            bgp-actions:
+              set-community:
+                config:
+                  method: INLINE
+                  options: ADD
+                inline:
+                  config:
+                    communities:
+                    - "50000:4"
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-subnets--vpc-04
+          config:
+            name: "5"
+          name: "5"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-04
+          config:
+            name: "6"
+          name: "6"
+    - config:
+        name: vpc-redistribute-static--vpc-01
+      name: vpc-redistribute-static--vpc-01
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-01
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-01
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-03
+      name: vpc-redistribute-static--vpc-03
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-03
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-03
+          config:
+            name: "5"
+          name: "5"
+    - config:
+        name: vpc-redistribute-static--vpc-04
+      name: vpc-redistribute-static--vpc-04
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-loopback-prefix
+          config:
+            name: "1"
+          name: "1"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-ext-prefixes--vpc-04
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vpc-static-ext-subnets--vpc-04
+          config:
+            name: "5"
+          name: "5"
+sonic-portchannel:
+  PORTCHANNEL:
+    PORTCHANNEL_LIST:
+    - fallback: false
+      name: PortChannel1
+      system_mac: f2:00:00:00:00:02
+    - fallback: false
+      name: PortChannel2
+      system_mac: f2:00:00:00:00:01
+sonic-vrf:
+  VRF:
+    VRF_LIST:
+    - vni: 100
+      vrf_name: VrfEexternal-01
+    - vni: 200
+      vrf_name: VrfVvpc-01
+    - vni: 300
+      vrf_name: VrfVvpc-03
+    - vni: 400
+      vrf_name: VrfVvpc-04
+sonic-vxlan:
+  SUPPRESS_VLAN_NEIGH:
+    SUPPRESS_VLAN_NEIGH_LIST:
+    - name: Vlan1005
+      suppress: "on"
+    - name: Vlan1006
+      suppress: "on"
+    - name: Vlan1007
+      suppress: "on"
+    - name: Vlan3000
+      suppress: "on"
+    - name: Vlan3001
+      suppress: "on"
+    - name: Vlan3002
+      suppress: "on"
+  VXLAN_EVPN_NVO:
+    VXLAN_EVPN_NVO_LIST:
+    - name: nvo1
+      source_vtep: vtepfabric
+  VXLAN_TUNNEL:
+    VXLAN_TUNNEL_LIST:
+    - name: vtepfabric
+      src_intf: Loopback2
+      src_ip: 172.30.12.1
+  VXLAN_TUNNEL_MAP:
+    VXLAN_TUNNEL_MAP_LIST:
+    - mapname: map_100_Vlan3003
+      name: vtepfabric
+      vlan: Vlan3003
+      vni: 100
+    - mapname: map_200_Vlan3001
+      name: vtepfabric
+      vlan: Vlan3001
+      vni: 200
+    - mapname: map_300_Vlan3002
+      name: vtepfabric
+      vlan: Vlan3002
+      vni: 300
+    - mapname: map_301_Vlan1006
+      name: vtepfabric
+      vlan: Vlan1006
+      vni: 301
+    - mapname: map_302_Vlan1005
+      name: vtepfabric
+      vlan: Vlan1005
+      vni: 302
+    - mapname: map_400_Vlan3000
+      name: vtepfabric
+      vlan: Vlan3000
+      vni: 400
+    - mapname: map_401_Vlan1007
+      name: vtepfabric
+      vlan: Vlan1007
+      vni: 401
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: leaf-03
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.spec.expected.yaml
@@ -1,0 +1,1140 @@
+aclInterfaces:
+  Ethernet0.10:
+    egress: ipns-egress--default
+    ingress: ext-inbound--leaf-03--external-01
+  Vlan3003:
+    ingress: no-ipns-peering--default
+acls:
+  ext-inbound--leaf-03--external-01:
+    description: Inbound ACL leaf-03--external-01
+    entries:
+      "1":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 443
+        protocol: TCP
+      "2":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 8080
+        protocol: TCP
+      "3":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 67
+        protocol: UDP
+      "4":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 161
+        protocol: UDP
+      "5":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 4789
+        protocol: UDP
+      "6":
+        action: DISCARD
+        destinationAddress: 100.1.10.1/32
+        destinationPort: 22
+        protocol: TCP
+      "65535":
+        action: ACCEPT
+        protocol: IP
+  ipns-egress--default:
+    entries:
+      "10":
+        action: DROP
+        destinationAddress: 10.0.0.0/16
+        protocol: IP
+      "65535":
+        action: ACCEPT
+        protocol: IP
+  no-ipns-peering--default:
+    description: Prevent VPCs to cross-talk via the external
+    entries:
+      "1":
+        action: DROP
+        destinationAddress: 10.0.0.0/16
+        protocol: IP
+        sourceAddress: 10.0.0.0/16
+      "65535":
+        action: ACCEPT
+        protocol: IP
+asPathLists:
+  fabric-gw-aspath:
+    members:
+    - _65100_
+    - _65534_
+bfdProfiles:
+  fabric:
+    desiredMinimumTxInterval: 300
+    detectionMultiplier: 3
+    passiveMode: false
+    requiredMinimumReceive: 300
+communityLists:
+  all-externals:
+    members:
+    - 65102:1000
+  all-gw-prios:
+    members:
+    - "50001:0"
+    - "50001:1"
+    - "50001:2"
+    - "50001:3"
+    - "50001:4"
+    - "50001:5"
+    - "50001:6"
+    - "50001:7"
+    - "50001:8"
+    - "50001:9"
+  ext-inbound--external-01:
+    members:
+    - 65102:1000
+  gw-prio-0:
+    members:
+    - "50001:0"
+  gw-prio-1:
+    members:
+    - "50001:1"
+  gw-prio-2:
+    members:
+    - "50001:2"
+  gw-prio-3:
+    members:
+    - "50001:3"
+  gw-prio-4:
+    members:
+    - "50001:4"
+  gw-prio-5:
+    members:
+    - "50001:5"
+  gw-prio-6:
+    members:
+    - "50001:6"
+  gw-prio-7:
+    members:
+    - "50001:7"
+  gw-prio-8:
+    members:
+    - "50001:8"
+  gw-prio-9:
+    members:
+    - "50001:9"
+  no-community:
+    members:
+    - REGEX:^$
+  vpc-peers--vpc-01:
+    members:
+    - "50000:2"
+  vpc-peers--vpc-03:
+    members:
+    - "50000:3"
+    - "50000:4"
+  vpc-peers--vpc-04:
+    members:
+    - "50000:3"
+    - "50000:4"
+dhcpRelays:
+  Vlan1005:
+    linkSelect: true
+    relayAddress:
+    - 172.30.0.1
+    sourceInterface: Management0
+    vrfSelect: true
+  Vlan1006:
+    linkSelect: true
+    relayAddress:
+    - 172.30.0.1
+    sourceInterface: Management0
+    vrfSelect: true
+  Vlan1007:
+    linkSelect: true
+    relayAddress:
+    - 172.30.0.1
+    sourceInterface: Management0
+    vrfSelect: true
+ecmpRoCEQPN: false
+errDisableGlobal:
+  recoveryInterval: 300
+errDisableInterfaces:
+  Ethernet4:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet5:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet6:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet7:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+hostname: leaf-03
+interfaces:
+  Ethernet0:
+    autoNegotiate: false
+    description: External leaf-03--external
+    enabled: true
+    subinterfaces:
+      "0": {}
+      "10":
+        ips:
+          100.1.10.1:
+            prefixLen: 24
+        vlan: 10
+  Ethernet1:
+    autoNegotiate: false
+    description: PC2 ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+    enabled: true
+    mtu: 9036
+    portChannel: PortChannel2
+    subinterfaces:
+      "0": {}
+  Ethernet2:
+    autoNegotiate: false
+    description: PC1 ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+    enabled: true
+    mtu: 9036
+    portChannel: PortChannel1
+    subinterfaces:
+      "0": {}
+  Ethernet3:
+    autoNegotiate: false
+    description: Unbundled server-07 server-07--unbundled--leaf-03
+    enabled: true
+    mtu: 9036
+    subinterfaces:
+      "0": {}
+    trunkVLANs:
+    - "1007"
+  Ethernet4:
+    autoNegotiate: false
+    description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet5:
+    autoNegotiate: false
+    description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet6:
+    autoNegotiate: false
+    description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet7:
+    autoNegotiate: false
+    description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Loopback1:
+    description: Protocol loopback
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.8.4:
+            prefixLen: 32
+  Loopback2:
+    description: VTEP loopback
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.12.1:
+            prefixLen: 32
+  Management0:
+    autoNegotiate: true
+    description: Management link
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.0.11:
+            prefixLen: 21
+  PortChannel1:
+    description: ESLAG server-06 server-06--eslag--leaf-03--leaf-04
+    enabled: true
+    mtu: 9036
+    subinterfaces:
+      "0": {}
+    trunkVLANs:
+    - "1006"
+  PortChannel2:
+    description: ESLAG server-05 server-05--eslag--leaf-03--leaf-04
+    enabled: true
+    mtu: 9036
+    subinterfaces:
+      "0": {}
+    trunkVLANs:
+    - "1005"
+  Vlan1005:
+    description: VPC vpc-03/subnet-01
+    enabled: true
+    vlanAnycastGateway:
+    - 10.0.5.1/24
+  Vlan1006:
+    description: VPC vpc-03/subnet-02
+    enabled: true
+    vlanAnycastGateway:
+    - 10.0.6.1/24
+  Vlan1007:
+    description: VPC vpc-04/subnet-01
+    enabled: true
+    vlanAnycastGateway:
+    - 10.0.7.1/24
+  Vlan3000:
+    description: VPC vpc-04 IRB
+    enabled: true
+  Vlan3001:
+    description: VPC vpc-01 IRB
+    enabled: true
+  Vlan3002:
+    description: VPC vpc-03 IRB
+    enabled: true
+  Vlan3003:
+    description: External external-01 IRB
+    enabled: true
+lldp:
+  enabled: true
+  helloTimer: 5
+  systemDescription: Hedgehog Fabric
+  systemName: leaf-03
+lstGroups:
+  spinelink:
+    allEvpnEsDownstream: true
+    timeout: 60
+lstInterfaces:
+  Ethernet4:
+    groups:
+    - spinelink
+  Ethernet5:
+    groups:
+    - spinelink
+  Ethernet6:
+    groups:
+    - spinelink
+  Ethernet7:
+    groups:
+    - spinelink
+neighborGlobal:
+  ipv4DropNeighborAgingTime: 60
+ntp:
+  sourceInterface:
+  - Management0
+ntpServers:
+  172.30.0.1:
+    prefer: true
+portChannelConfigs:
+  PortChannel1:
+    fallback: false
+    systemMAC: f2:00:00:00:00:02
+  PortChannel2:
+    fallback: false
+    systemMAC: f2:00:00:00:00:01
+prefixLists:
+  all-vtep-prefixes:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.0/22
+  any-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  ext-import--external-01:
+    prefixes:
+      "103":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.5.0/24
+      "105":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.1.0/24
+  import-vrf--vpc-01--external-01:
+    prefixes:
+      "106":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  import-vrf--vpc-03--external-01:
+    prefixes:
+      "106":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  ipns-subnets--default:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.0.0/16
+  protocol-loopback-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.8.4/32
+  static-ext-subnets: {}
+  vpc-ext-prefixes--vpc-01:
+    prefixes:
+      "106":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  vpc-ext-prefixes--vpc-03:
+    prefixes:
+      "106":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  vpc-ext-prefixes--vpc-04: {}
+  vpc-loopback-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.96.0/19
+  vpc-not-subnets--vpc-01:
+    prefixes:
+      "1":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.1.0/24
+      "2":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.2.0/24
+      "65535":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  vpc-not-subnets--vpc-03:
+    prefixes:
+      "1":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.6.0/24
+      "2":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.5.0/24
+      "65535":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  vpc-not-subnets--vpc-04:
+    prefixes:
+      "1":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.7.0/24
+      "2":
+        action: deny
+        prefix:
+          le: 32
+          prefix: 10.0.8.0/24
+      "65535":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  vpc-peers--vpc-01: {}
+  vpc-peers--vpc-03:
+    prefixes:
+      "401":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.7.0/24
+      "402":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.8.0/24
+  vpc-peers--vpc-04:
+    prefixes:
+      "301":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.6.0/24
+      "302":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.5.0/24
+  vpc-static-ext-subnets--vpc-01: {}
+  vpc-static-ext-subnets--vpc-03: {}
+  vpc-static-ext-subnets--vpc-04: {}
+  vpc-subnets--vpc-01:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.1.0/24
+      "2":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.2.0/24
+  vpc-subnets--vpc-03:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.6.0/24
+      "2":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.5.0/24
+  vpc-subnets--vpc-04:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.7.0/24
+      "2":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.8.0/24
+routeMaps:
+  ext-import--external-01:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ext-import--external-01
+        result: accept
+  ext-inbound--external-01:
+    statements:
+      "5":
+        conditions:
+          matchAsPathList: fabric-gw-aspath
+        result: reject
+      "10":
+        conditions:
+          matchPrefixLists: ipns-subnets--default
+        result: reject
+      "15":
+        conditions:
+          matchCommunityLists: ext-inbound--external-01
+        result: accept
+        setLocalPreference: 150
+  ext-outbound--external-01:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ipns-subnets--default
+        result: accept
+        setCommunities:
+        - 64102:1000
+      "20":
+        conditions:
+          matchCommunityLists: all-gw-prios
+        result: accept
+        setCommunities:
+        - 64102:1000
+  filter-attached-hosts:
+    statements:
+      "10":
+        conditions:
+          attachedHost: true
+        result: reject
+      "100":
+        conditions: {}
+        result: accept
+  import-vrf--vpc-01:
+    statements:
+      "1":
+        conditions:
+          matchNextHopPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5010":
+        conditions:
+          matchPrefixLists: ipns-subnets--default
+          matchSourceVrf: VrfEexternal-01
+        result: reject
+      "50000":
+        conditions:
+          matchCommunityLists: vpc-peers--vpc-01
+        result: accept
+      "50001":
+        conditions:
+          matchCommunityLists: no-community
+          matchPrefixLists: vpc-peers--vpc-01
+        result: accept
+      "50010":
+        conditions:
+          matchCommunityLists: ext-inbound--external-01
+          matchPrefixLists: import-vrf--vpc-01--external-01
+        result: accept
+        setLocalPreference: 150
+      "65535":
+        conditions: {}
+        result: reject
+  import-vrf--vpc-03:
+    statements:
+      "1":
+        conditions:
+          matchNextHopPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5010":
+        conditions:
+          matchPrefixLists: ipns-subnets--default
+          matchSourceVrf: VrfEexternal-01
+        result: reject
+      "10004":
+        conditions:
+          matchPrefixLists: vpc-not-subnets--vpc-04
+          matchSourceVrf: VrfVvpc-04
+        result: reject
+      "50000":
+        conditions:
+          matchCommunityLists: vpc-peers--vpc-03
+        result: accept
+      "50001":
+        conditions:
+          matchCommunityLists: no-community
+          matchPrefixLists: vpc-peers--vpc-03
+        result: accept
+      "50010":
+        conditions:
+          matchCommunityLists: ext-inbound--external-01
+          matchPrefixLists: import-vrf--vpc-03--external-01
+        result: accept
+        setLocalPreference: 150
+      "65535":
+        conditions: {}
+        result: reject
+  import-vrf--vpc-04:
+    statements:
+      "1":
+        conditions:
+          matchNextHopPrefixLists: vpc-loopback-prefix
+        result: reject
+      "10003":
+        conditions:
+          matchPrefixLists: vpc-not-subnets--vpc-03
+          matchSourceVrf: VrfVvpc-03
+        result: reject
+      "50000":
+        conditions:
+          matchCommunityLists: vpc-peers--vpc-04
+        result: accept
+      "50001":
+        conditions:
+          matchCommunityLists: no-community
+          matchPrefixLists: vpc-peers--vpc-04
+        result: accept
+      "65535":
+        conditions: {}
+        result: reject
+  ipns-subnets--default:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ipns-subnets--default
+        result: accept
+  l2vpn-neighbors:
+    statements:
+      "1":
+        conditions:
+          matchCommunityLists: gw-prio-0
+        result: accept
+        setLocalPreference: 210
+      "2":
+        conditions:
+          matchCommunityLists: gw-prio-1
+        result: accept
+        setLocalPreference: 209
+      "3":
+        conditions:
+          matchCommunityLists: gw-prio-2
+        result: accept
+        setLocalPreference: 208
+      "4":
+        conditions:
+          matchCommunityLists: gw-prio-3
+        result: accept
+        setLocalPreference: 207
+      "5":
+        conditions:
+          matchCommunityLists: gw-prio-4
+        result: accept
+        setLocalPreference: 206
+      "6":
+        conditions:
+          matchCommunityLists: gw-prio-5
+        result: accept
+        setLocalPreference: 205
+      "7":
+        conditions:
+          matchCommunityLists: gw-prio-6
+        result: accept
+        setLocalPreference: 204
+      "8":
+        conditions:
+          matchCommunityLists: gw-prio-7
+        result: accept
+        setLocalPreference: 203
+      "9":
+        conditions:
+          matchCommunityLists: gw-prio-8
+        result: accept
+        setLocalPreference: 202
+      "10":
+        conditions:
+          matchCommunityLists: gw-prio-9
+        result: accept
+        setLocalPreference: 201
+      "65525":
+        conditions:
+          matchCommunityLists: all-externals
+        result: accept
+        setLocalPreference: 150
+      "65535":
+        conditions: {}
+        result: accept
+  loopback-all-vteps:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  protocol-loopback-only:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: protocol-loopback-prefix
+        result: accept
+  vpc-redistribute-connected--vpc-01:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-subnets--vpc-01
+        result: accept
+        setCommunities:
+        - "50000:2"
+      "6":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-01
+        result: accept
+      "10":
+        conditions: {}
+        result: reject
+  vpc-redistribute-connected--vpc-03:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-subnets--vpc-03
+        result: accept
+        setCommunities:
+        - "50000:3"
+      "6":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-03
+        result: accept
+      "10":
+        conditions: {}
+        result: reject
+  vpc-redistribute-connected--vpc-04:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-subnets--vpc-04
+        result: accept
+        setCommunities:
+        - "50000:4"
+      "6":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-04
+        result: accept
+      "10":
+        conditions: {}
+        result: reject
+  vpc-redistribute-static--vpc-01:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-01
+        result: accept
+      "10":
+        conditions:
+          matchPrefixLists: vpc-ext-prefixes--vpc-01
+        result: accept
+  vpc-redistribute-static--vpc-03:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-03
+        result: accept
+      "10":
+        conditions:
+          matchPrefixLists: vpc-ext-prefixes--vpc-03
+        result: accept
+  vpc-redistribute-static--vpc-04:
+    statements:
+      "1":
+        conditions:
+          matchPrefixLists: vpc-loopback-prefix
+        result: reject
+      "5":
+        conditions:
+          matchPrefixLists: vpc-static-ext-subnets--vpc-04
+        result: accept
+      "10":
+        conditions:
+          matchPrefixLists: vpc-ext-prefixes--vpc-04
+        result: accept
+suppressVLANNeighs:
+  Vlan1005: {}
+  Vlan1006: {}
+  Vlan1007: {}
+  Vlan3000: {}
+  Vlan3001: {}
+  Vlan3002: {}
+users:
+  admin:
+    authorizedKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: admin
+  op:
+    authorizedKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: operator
+vrfVNIMap:
+  VrfEexternal-01:
+    vni: 100
+  VrfVvpc-01:
+    vni: 200
+  VrfVvpc-03:
+    vni: 300
+  VrfVvpc-04:
+    vni: 400
+vrfs:
+  VrfEexternal-01:
+    anycastMAC: "00:00:00:11:11:11"
+    bgp:
+      as: 65102
+      ipv4Unicast:
+        enable: true
+        importPolicy: ext-import--external-01
+        importVRFs:
+          VrfVvpc-01: {}
+          VrfVvpc-03: {}
+        maxPaths: 16
+      l2vpnEvpn:
+        advertiseIPv4Unicast: true
+        advertiseIPv4UnicastRouteMaps:
+        - ext-inbound--external-01
+        enable: true
+      neighbors:
+        100.1.10.6:
+          description: External attach leaf-03--external-01
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - ext-outbound--external-01
+          ipv4UnicastImportPolicies:
+          - ext-inbound--external-01
+          remoteAS: 64102
+      networkImportCheck: true
+      routerID: 172.30.8.4
+    enabled: true
+    evpnMH: {}
+    interfaces:
+      Ethernet0.10: {}
+      Vlan3003: {}
+  VrfVvpc-01:
+    anycastMAC: "00:00:00:11:11:11"
+    bgp:
+      as: 65102
+      ipv4Unicast:
+        enable: true
+        importPolicy: import-vrf--vpc-01
+        importVRFs:
+          VrfEexternal-01: {}
+        maxPaths: 16
+      l2vpnEvpn:
+        advertiseIPv4Unicast: true
+        advertiseIPv4UnicastRouteMaps:
+        - filter-attached-hosts
+        enable: true
+      networkImportCheck: true
+      routerID: 172.30.8.4
+    enabled: true
+    evpnMH: {}
+    interfaces:
+      Vlan3001: {}
+    tableConnections:
+      attachedhost: {}
+      connected:
+        importPolicies:
+        - vpc-redistribute-connected--vpc-01
+      static:
+        importPolicies:
+        - vpc-redistribute-static--vpc-01
+  VrfVvpc-03:
+    anycastMAC: "00:00:00:11:11:11"
+    attachedHosts:
+      Vlan1005: {}
+      Vlan1006: {}
+    bgp:
+      as: 65102
+      ipv4Unicast:
+        enable: true
+        importPolicy: import-vrf--vpc-03
+        importVRFs:
+          VrfEexternal-01: {}
+          VrfVvpc-04: {}
+        maxPaths: 16
+      l2vpnEvpn:
+        advertiseIPv4Unicast: true
+        advertiseIPv4UnicastRouteMaps:
+        - filter-attached-hosts
+        enable: true
+      networkImportCheck: true
+      routerID: 172.30.8.4
+    enabled: true
+    evpnMH: {}
+    interfaces:
+      Vlan1005: {}
+      Vlan1006: {}
+      Vlan3002: {}
+    tableConnections:
+      attachedhost: {}
+      connected:
+        importPolicies:
+        - vpc-redistribute-connected--vpc-03
+      static:
+        importPolicies:
+        - vpc-redistribute-static--vpc-03
+  VrfVvpc-04:
+    anycastMAC: "00:00:00:11:11:11"
+    attachedHosts:
+      Vlan1007: {}
+    bgp:
+      as: 65102
+      ipv4Unicast:
+        enable: true
+        importPolicy: import-vrf--vpc-04
+        importVRFs:
+          VrfVvpc-03: {}
+        maxPaths: 16
+      l2vpnEvpn:
+        advertiseIPv4Unicast: true
+        advertiseIPv4UnicastRouteMaps:
+        - filter-attached-hosts
+        enable: true
+      networkImportCheck: true
+      routerID: 172.30.8.4
+    enabled: true
+    evpnMH: {}
+    interfaces:
+      Vlan1007: {}
+      Vlan3000: {}
+    tableConnections:
+      attachedhost: {}
+      connected:
+        importPolicies:
+        - vpc-redistribute-connected--vpc-04
+      static:
+        importPolicies:
+        - vpc-redistribute-static--vpc-04
+  default:
+    anycastMAC: "00:00:00:11:11:11"
+    bgp:
+      as: 65102
+      ipv4Unicast:
+        enable: true
+        maxPaths: 16
+        networks:
+          172.30.8.4/32: {}
+      l2vpnEvpn:
+        advertiseAllVnis: true
+        enable: true
+      neighbors:
+        172.30.8.0:
+          description: Fabric spine-01 loopback (spine-link)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65100
+          updateSource: 172.30.8.4
+        172.30.8.1:
+          description: Fabric spine-02 loopback (spine-link)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65100
+          updateSource: 172.30.8.4
+        Ethernet4:
+          bfdProfile: fabric
+          description: Fabric spine-01/E1/5 spine-01--fabric--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65100
+        Ethernet5:
+          bfdProfile: fabric
+          description: Fabric spine-01/E1/6 spine-01--fabric--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65100
+        Ethernet6:
+          bfdProfile: fabric
+          description: Fabric spine-02/E1/5 spine-02--fabric--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65100
+        Ethernet7:
+          bfdProfile: fabric
+          description: Fabric spine-02/E1/6 spine-02--fabric--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65100
+      networkImportCheck: true
+      routerID: 172.30.8.4
+    enabled: true
+    ethernetSegments:
+      PortChannel1:
+        esi: 00f20000f20000000002
+      PortChannel2:
+        esi: 00f20000f20000000001
+    evpnMH:
+      macHoldtime: 60
+      startupDelay: 60
+    tableConnections:
+      connected: {}
+      static: {}
+vxlanEVPNNVOs:
+  nvo1:
+    sourceVtep: vtepfabric
+vxlanTunnelMap:
+  map_100_Vlan3003:
+    vlan: 3003
+    vni: 100
+    vtep: vtepfabric
+  map_200_Vlan3001:
+    vlan: 3001
+    vni: 200
+    vtep: vtepfabric
+  map_300_Vlan3002:
+    vlan: 3002
+    vni: 300
+    vtep: vtepfabric
+  map_301_Vlan1006:
+    vlan: 1006
+    vni: 301
+    vtep: vtepfabric
+  map_302_Vlan1005:
+    vlan: 1005
+    vni: 302
+    vtep: vtepfabric
+  map_400_Vlan3000:
+    vlan: 3000
+    vni: 400
+    vtep: vtepfabric
+  map_401_Vlan1007:
+    vlan: 1007
+    vni: 401
+    vtep: vtepfabric
+vxlanTunnels:
+  vtepfabric:
+    qosUniform: false
+    sourceIP: 172.30.12.1
+    sourceInterface: Loopback2
+ztp: false

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.in.agent.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.in.agent.yaml
@@ -1,0 +1,572 @@
+apiVersion: agent.githedgehog.com/v1beta1
+kind: Agent
+metadata:
+  creationTimestamp: "2026-01-16T00:09:01Z"
+  generation: 2
+  labels:
+    fabric.githedgehog.com/profile: vs
+    vlanns.fabric.githedgehog.com/default: "true"
+  name: spine-01
+  namespace: default
+  resourceVersion: "31931"
+  uid: b5034c95-327c-41bb-93e9-71839c8d326e
+spec:
+  alloy: {}
+  catalog: {}
+  config:
+    alloy:
+      hostname: spine-01
+      kube: {}
+      logFiles:
+        agent:
+          pathTargets:
+            - path: /var/log/agent.log
+        syslog:
+          pathTargets:
+            - path: /var/log/syslog
+      proxyURL: http://172.30.0.1:31028
+      pyroscope: {}
+      scrapes:
+        agent:
+          address: 127.0.0.1:7042
+          intervalSeconds: 60
+          relabel:
+            - action: keep
+              regex: .*(_in_bits|_status|_generation|_temperature|_transceiver).*
+              sourceLabels:
+                - __name__
+          self: {}
+          unix: {}
+        node:
+          intervalSeconds: 60
+          relabel:
+            - action: keep
+              regex: .*(_load).*
+              sourceLabels:
+                - __name__
+          self: {}
+          unix:
+            collectors:
+              - cpu
+              - loadavg
+              - meminfo
+              - filesystem
+            enable: true
+      targets: {}
+    baseVPCCommunity: "50000:0"
+    controlVIP: 172.30.0.1/32
+    defaultMaxPathsEBGP: 64
+    eslagESIPrefix: "00:f2:00:00:"
+    eslagMACBase: f2:00:00:00:00:00
+    fabricMTU: 9100
+    fabricSubnet: 172.30.128.0/17
+    gatewayASN: 65534
+    gatewayCommunities:
+      "0": "50001:0"
+      "1": "50001:1"
+      "2": "50001:2"
+      "3": "50001:3"
+      "4": "50001:4"
+      "5": "50001:5"
+      "6": "50001:6"
+      "7": "50001:7"
+      "8": "50001:8"
+      "9": "50001:9"
+    mclagSessionSubnet: 172.30.95.0/31
+    protocolSubnet: 172.30.8.0/22
+    serverFacingMTUOffset: 64
+    spineASN: 65100
+    spineLeaf: {}
+    vpcLoopbackSubnet: 172.30.96.0/19
+    vtepSubnet: 172.30.12.0/22
+  connections:
+    spine-01--fabric--leaf-01:
+      fabric:
+        links:
+          - leaf:
+              port: leaf-01/E1/8
+            spine:
+              port: spine-01/E1/1
+          - leaf:
+              port: leaf-01/E1/9
+            spine:
+              port: spine-01/E1/2
+    spine-01--fabric--leaf-02:
+      fabric:
+        links:
+          - leaf:
+              port: leaf-02/E1/9
+            spine:
+              port: spine-01/E1/3
+          - leaf:
+              port: leaf-02/E1/10
+            spine:
+              port: spine-01/E1/4
+    spine-01--fabric--leaf-03:
+      fabric:
+        links:
+          - leaf:
+              port: leaf-03/E1/5
+            spine:
+              port: spine-01/E1/5
+          - leaf:
+              port: leaf-03/E1/6
+            spine:
+              port: spine-01/E1/6
+    spine-01--fabric--leaf-04:
+      fabric:
+        links:
+          - leaf:
+              port: leaf-04/E1/5
+            spine:
+              port: spine-01/E1/7
+          - leaf:
+              port: leaf-04/E1/6
+            spine:
+              port: spine-01/E1/8
+    spine-01--fabric--leaf-05:
+      fabric:
+        links:
+          - leaf:
+              port: leaf-05/E1/4
+            spine:
+              port: spine-01/E1/9
+          - leaf:
+              port: leaf-05/E1/5
+            spine:
+              port: spine-01/E1/10
+    spine-01--gateway--gateway-1:
+      gateway:
+        links:
+          - gateway:
+              ip: 172.30.128.21/31
+              port: gateway-1/enp2s1
+            switch:
+              ip: 172.30.128.20/31
+              port: spine-01/E1/11
+  description: VS-06
+  externals:
+    external-01:
+      inboundCommunity: 65102:1000
+      ipv4Namespace: default
+      outboundCommunity: 64102:1000
+  ipv4Namespaces:
+    default:
+      subnets:
+        - 10.0.0.0/16
+  role: spine
+  statusUpdates:
+    - apiVersion: wiring.githedgehog.com/v1beta1
+      generation: 1
+      kind: Switch
+      name: spine-01
+      namespace: default
+  switch:
+    asn: 65100
+    boot:
+      mac: 0c:20:12:ff:05:00
+    description: VS-06
+    ecmp: {}
+    linkFlapErrDisable:
+      flapThreshold: 3
+      samplingInterval: 30
+      recoveryInterval: 300
+    ip: 172.30.0.7/21
+    profile: vs
+    protocolIP: 172.30.8.0/32
+    redundancy: {}
+    role: spine
+    vlanNamespaces:
+      - default
+  switchProfile:
+    config:
+      maxPathsEBGP: 16
+    displayName: Virtual Switch
+    features:
+      eslag: true
+      l2vni: true
+      l3vni: true
+      mclag: true
+      roce: true
+      subinterfaces: true
+    nosType: sonic-bcm-vs
+    platform: x86_64-kvm_x86_64-r0
+    portGroups:
+      "1":
+        nos: "1"
+        profile: SFP28-25G
+      "2":
+        nos: "2"
+        profile: SFP28-25G
+      "3":
+        nos: "3"
+        profile: SFP28-25G
+      "4":
+        nos: "4"
+        profile: SFP28-25G
+      "5":
+        nos: "5"
+        profile: SFP28-25G
+      "6":
+        nos: "6"
+        profile: SFP28-25G
+      "7":
+        nos: "7"
+        profile: SFP28-25G
+      "8":
+        nos: "8"
+        profile: SFP28-25G
+      "9":
+        nos: "9"
+        profile: SFP28-25G
+      "10":
+        nos: "10"
+        profile: SFP28-25G
+      "11":
+        nos: "11"
+        profile: SFP28-25G
+      "12":
+        nos: "12"
+        profile: SFP28-25G
+    portProfiles:
+      SFP28-25G:
+        speed:
+          default: 25G
+          supported:
+            - 10G
+            - 25G
+    ports:
+      E1/1:
+        group: "1"
+        label: "1"
+        nos: Ethernet0
+      E1/2:
+        group: "1"
+        label: "2"
+        nos: Ethernet1
+      E1/3:
+        group: "1"
+        label: "3"
+        nos: Ethernet2
+      E1/4:
+        group: "1"
+        label: "4"
+        nos: Ethernet3
+      E1/5:
+        group: "2"
+        label: "5"
+        nos: Ethernet4
+      E1/6:
+        group: "2"
+        label: "6"
+        nos: Ethernet5
+      E1/7:
+        group: "2"
+        label: "7"
+        nos: Ethernet6
+      E1/8:
+        group: "2"
+        label: "8"
+        nos: Ethernet7
+      E1/9:
+        group: "3"
+        label: "9"
+        nos: Ethernet8
+      E1/10:
+        group: "3"
+        label: "10"
+        nos: Ethernet9
+      E1/11:
+        group: "3"
+        label: "11"
+        nos: Ethernet10
+      E1/12:
+        group: "3"
+        label: "12"
+        nos: Ethernet11
+      E1/13:
+        group: "4"
+        label: "13"
+        nos: Ethernet12
+      E1/14:
+        group: "4"
+        label: "14"
+        nos: Ethernet13
+      E1/15:
+        group: "4"
+        label: "15"
+        nos: Ethernet14
+      E1/16:
+        group: "4"
+        label: "16"
+        nos: Ethernet15
+      E1/17:
+        group: "5"
+        label: "17"
+        nos: Ethernet16
+      E1/18:
+        group: "5"
+        label: "18"
+        nos: Ethernet17
+      E1/19:
+        group: "5"
+        label: "19"
+        nos: Ethernet18
+      E1/20:
+        group: "5"
+        label: "20"
+        nos: Ethernet19
+      E1/21:
+        group: "6"
+        label: "21"
+        nos: Ethernet20
+      E1/22:
+        group: "6"
+        label: "22"
+        nos: Ethernet21
+      E1/23:
+        group: "6"
+        label: "23"
+        nos: Ethernet22
+      E1/24:
+        group: "6"
+        label: "24"
+        nos: Ethernet23
+      E1/25:
+        group: "7"
+        label: "25"
+        nos: Ethernet24
+      E1/26:
+        group: "7"
+        label: "26"
+        nos: Ethernet25
+      E1/27:
+        group: "7"
+        label: "27"
+        nos: Ethernet26
+      E1/28:
+        group: "7"
+        label: "28"
+        nos: Ethernet27
+      E1/29:
+        group: "8"
+        label: "29"
+        nos: Ethernet28
+      E1/30:
+        group: "8"
+        label: "30"
+        nos: Ethernet29
+      E1/31:
+        group: "8"
+        label: "31"
+        nos: Ethernet30
+      E1/32:
+        group: "8"
+        label: "32"
+        nos: Ethernet31
+      E1/33:
+        group: "9"
+        label: "33"
+        nos: Ethernet32
+      E1/34:
+        group: "9"
+        label: "34"
+        nos: Ethernet33
+      E1/35:
+        group: "9"
+        label: "35"
+        nos: Ethernet34
+      E1/36:
+        group: "9"
+        label: "36"
+        nos: Ethernet35
+      E1/37:
+        group: "10"
+        label: "37"
+        nos: Ethernet36
+      E1/38:
+        group: "10"
+        label: "38"
+        nos: Ethernet37
+      E1/39:
+        group: "10"
+        label: "39"
+        nos: Ethernet38
+      E1/40:
+        group: "10"
+        label: "40"
+        nos: Ethernet39
+      E1/41:
+        group: "11"
+        label: "41"
+        nos: Ethernet40
+      E1/42:
+        group: "11"
+        label: "42"
+        nos: Ethernet41
+      E1/43:
+        group: "11"
+        label: "43"
+        nos: Ethernet42
+      E1/44:
+        group: "11"
+        label: "44"
+        nos: Ethernet43
+      E1/45:
+        group: "12"
+        label: "45"
+        nos: Ethernet44
+      E1/46:
+        group: "12"
+        label: "46"
+        nos: Ethernet45
+      E1/47:
+        group: "12"
+        label: "47"
+        nos: Ethernet46
+      E1/48:
+        group: "12"
+        label: "48"
+        nos: Ethernet47
+      M1:
+        management: true
+        nos: Management0
+        oniePortName: eth0
+    switchSilicon: vs
+  switches:
+    leaf-01:
+      asn: 65101
+      boot:
+        mac: 0c:20:12:ff:00:00
+      description: VS-01 MCLAG 1
+      ecmp: {}
+      groups:
+        - mclag-1
+      ip: 172.30.0.9/21
+      profile: vs
+      protocolIP: 172.30.8.2/32
+      redundancy:
+        group: mclag-1
+        type: mclag
+      role: server-leaf
+      vlanNamespaces:
+        - default
+      vtepIP: 172.30.12.0/32
+    leaf-02:
+      asn: 65101
+      boot:
+        mac: 0c:20:12:ff:01:00
+      description: VS-02 MCLAG 1
+      ecmp: {}
+      groups:
+        - mclag-1
+      ip: 172.30.0.10/21
+      profile: vs
+      protocolIP: 172.30.8.3/32
+      redundancy:
+        group: mclag-1
+        type: mclag
+      role: server-leaf
+      vlanNamespaces:
+        - default
+      vtepIP: 172.30.12.0/32
+    leaf-03:
+      asn: 65102
+      boot:
+        mac: 0c:20:12:ff:02:00
+      description: VS-03 ESLAG 1
+      ecmp: {}
+      groups:
+        - eslag-1
+      ip: 172.30.0.11/21
+      profile: vs
+      protocolIP: 172.30.8.4/32
+      redundancy:
+        group: eslag-1
+        type: eslag
+      role: server-leaf
+      vlanNamespaces:
+        - default
+      vtepIP: 172.30.12.1/32
+    leaf-04:
+      asn: 65103
+      boot:
+        mac: 0c:20:12:ff:03:00
+      description: VS-04 ESLAG 1
+      ecmp: {}
+      groups:
+        - eslag-1
+      ip: 172.30.0.12/21
+      profile: vs
+      protocolIP: 172.30.8.5/32
+      redundancy:
+        group: eslag-1
+        type: eslag
+      role: server-leaf
+      vlanNamespaces:
+        - default
+      vtepIP: 172.30.12.2/32
+    leaf-05:
+      asn: 65104
+      boot:
+        mac: 0c:20:12:ff:04:00
+      description: VS-05
+      ecmp: {}
+      ip: 172.30.0.13/21
+      profile: vs
+      protocolIP: 172.30.8.6/32
+      redundancy: {}
+      role: server-leaf
+      vlanNamespaces:
+        - default
+      vtepIP: 172.30.12.3/32
+    spine-01:
+      asn: 65100
+      boot:
+        mac: 0c:20:12:ff:05:00
+      description: VS-06
+      ecmp: {}
+      ip: 172.30.0.7/21
+      profile: vs
+      protocolIP: 172.30.8.0/32
+      redundancy: {}
+      role: spine
+      vlanNamespaces:
+        - default
+  users:
+    - name: admin
+      password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+      role: admin
+      sshKeys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+    - name: op
+      password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+      role: operator
+      sshKeys:
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+  version:
+    alloyRepo: 172.30.0.1:31000/githedgehog/fabricator/alloy-bin
+    alloyVersion: v1.12.0
+    ca: |
+      -----BEGIN CERTIFICATE-----
+      MIIBbDCCARKgAwIBAgIIU7sCtD49Jk4wCgYIKoZIzj0EAwIwGjEYMBYGA1UEAxMP
+      aGVkZ2Vob2ctZmFiLWNhMB4XDTI2MDExNTIzNTA1MVoXDTM2MDExNjAwMDU1MVow
+      GjEYMBYGA1UEAxMPaGVkZ2Vob2ctZmFiLWNhMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+      AQcDQgAEP6J/5s4F1PMFXvG3169JWNSJFxPuf9DCFT/996laqBYQZ0kaUi1cbbnZ
+      X9BkbVFOzf6XeXwcwd05QogN4OR53KNCMEAwDgYDVR0PAQH/BAQDAgKEMA8GA1Ud
+      EwEB/wQFMAMBAf8wHQYDVR0OBBYEFI1jiNjtzv+EQyttQdHSj0Jo2rBNMAoGCCqG
+      SM49BAMCA0gAMEUCIG+0vOhexIbmX3qH9uUaXTgDzVVm96UogLxbVtWgja5DAiEA
+      lpqId7PcDURp1T5e1wtiaQlDhZLcPnVxE3mcQaKbuzk=
+      -----END CERTIFICATE-----
+    default: v0.100.0
+    password: secret
+    repo: 172.30.0.1:31000/githedgehog/fabric/agent
+    username: reader
+  vlanNamespaces:
+    default:
+      ranges:
+        - from: 1000
+          to: 2999
+status: {}

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.out.actions.expected.yaml
@@ -1,0 +1,1633 @@
+- path: /ztp/config
+  summary: Update ZTP
+  type: replace
+  value:
+    config:
+      admin-mode: false
+  weight: 1
+- path: /system/config
+  summary: Update Hostname
+  type: replace
+  value:
+    config:
+      hostname: spine-01
+  weight: 2
+- path: /lldp/config
+  summary: Create LLDP
+  type: update
+  value:
+    config:
+      enabled: true
+      hello-timer: "5"
+      system-description: Hedgehog Fabric
+      system-name: spine-01
+  weight: 3
+- path: /system/aaa/authentication/users/user[username=admin]
+  summary: Create User admin
+  type: update
+  value:
+    user:
+    - config:
+        password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+        role: admin
+        username: admin
+      username: admin
+  weight: 4
+- path: /system/aaa/authentication/users/user[username=op]
+  summary: Create User op
+  type: update
+  value:
+    user:
+    - config:
+        password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+        role: operator
+        username: op
+      username: op
+  weight: 4
+- customFunc: true
+  path: ""
+  summary: User admin authorized keys
+  type: ""
+  weight: 5
+- customFunc: true
+  path: ""
+  summary: User op authorized keys
+  type: ""
+  weight: 5
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]
+  summary: Create Prefix List Base all-vtep-prefixes
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: all-vtep-prefixes
+      name: all-vtep-prefixes
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=any-prefix]
+  summary: Create Prefix List Base any-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: any-prefix
+      name: any-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ipns-subnets--default]
+  summary: Create Prefix List Base ipns-subnets--default
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=protocol-loopback-prefix]
+  summary: Create Prefix List Base protocol-loopback-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: protocol-loopback-prefix
+      name: protocol-loopback-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=static-ext-subnets]
+  summary: Create Prefix List Base static-ext-subnets
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: static-ext-subnets
+      name: static-ext-subnets
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-loopback-prefix]
+  summary: Create Prefix List Base vpc-loopback-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vpc-loopback-prefix
+      name: vpc-loopback-prefix
+  weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.0/22
+        masklength-range: 22..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.0/22
+      masklength-range: 22..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=any-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=0.0.0.0/0][masklength-range=0..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 0.0.0.0/0
+        masklength-range: 0..32
+        sequence-number: 10
+      ip-prefix: 0.0.0.0/0
+      masklength-range: 0..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=ipns-subnets--default]/extended-prefixes/extended-prefix[sequence-number=1][ip-prefix=10.0.0.0/16][masklength-range=16..32]
+  summary: Create Prefix Lists Entry 1
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 10.0.0.0/16
+        masklength-range: 16..32
+        sequence-number: 1
+      ip-prefix: 10.0.0.0/16
+      masklength-range: 16..32
+      sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=protocol-loopback-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.8.0/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.8.0/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.8.0/32
+      masklength-range: 32..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vpc-loopback-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.96.0/19][masklength-range=19..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.96.0/19
+        masklength-range: 19..32
+        sequence-number: 10
+      ip-prefix: 172.30.96.0/19
+      masklength-range: 19..32
+      sequence-number: 10
+  weight: 10
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
+  summary: Create Community Lists all-externals
+  type: update
+  value:
+    community-set:
+    - community-set-name: all-externals
+      config:
+        action: PERMIT
+        community-member:
+        - 65102:1000
+        community-set-name: all-externals
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=no-community]
+  summary: Create Community Lists no-community
+  type: update
+  value:
+    community-set:
+    - community-set-name: no-community
+      config:
+        action: PERMIT
+        community-member:
+        - REGEX:^$
+        community-set-name: no-community
+        match-set-options: ANY
+  weight: 11
+- path: /routing-policy/defined-sets/bgp-defined-sets/as-path-sets/as-path-set[as-path-set-name=fabric-gw-aspath]
+  summary: Create AS Path Lists fabric-gw-aspath
+  type: update
+  value:
+    as-path-set:
+    - as-path-set-name: fabric-gw-aspath
+      config:
+        action: PERMIT
+        as-path-set-member:
+        - _65100_
+        - _65534_
+        as-path-set-name: fabric-gw-aspath
+  weight: 12
+- path: /interfaces/interface[name=Ethernet0]
+  summary: Create Interface Ethernet0 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+        enabled: true
+        name: Ethernet0
+      name: Ethernet0
+  weight: 16
+- path: /interfaces/interface[name=Ethernet1]
+  summary: Create Interface Ethernet1 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+        enabled: true
+        name: Ethernet1
+      name: Ethernet1
+  weight: 16
+- path: /interfaces/interface[name=Ethernet10]
+  summary: Create Interface Ethernet10 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+        enabled: true
+        name: Ethernet10
+      name: Ethernet10
+  weight: 16
+- path: /interfaces/interface[name=Ethernet2]
+  summary: Create Interface Ethernet2 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+        enabled: true
+        name: Ethernet2
+      name: Ethernet2
+  weight: 16
+- path: /interfaces/interface[name=Ethernet3]
+  summary: Create Interface Ethernet3 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+        enabled: true
+        name: Ethernet3
+      name: Ethernet3
+  weight: 16
+- path: /interfaces/interface[name=Ethernet4]
+  summary: Create Interface Ethernet4 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+        enabled: true
+        name: Ethernet4
+      name: Ethernet4
+  weight: 16
+- path: /interfaces/interface[name=Ethernet5]
+  summary: Create Interface Ethernet5 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+        enabled: true
+        name: Ethernet5
+      name: Ethernet5
+  weight: 16
+- path: /interfaces/interface[name=Ethernet6]
+  summary: Create Interface Ethernet6 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+        enabled: true
+        name: Ethernet6
+      name: Ethernet6
+  weight: 16
+- path: /interfaces/interface[name=Ethernet7]
+  summary: Create Interface Ethernet7 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+        enabled: true
+        name: Ethernet7
+      name: Ethernet7
+  weight: 16
+- path: /interfaces/interface[name=Ethernet8]
+  summary: Create Interface Ethernet8 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+        enabled: true
+        name: Ethernet8
+      name: Ethernet8
+  weight: 16
+- path: /interfaces/interface[name=Ethernet9]
+  summary: Create Interface Ethernet9 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+        enabled: true
+        name: Ethernet9
+      name: Ethernet9
+  weight: 16
+- path: /interfaces/interface[name=Loopback1]
+  summary: Create Interface Loopback1 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Protocol loopback
+        enabled: true
+        name: Loopback1
+      name: Loopback1
+  weight: 16
+- path: /interfaces/interface[name=Management0]
+  summary: Create Interface Management0 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Management link
+        enabled: true
+        name: Management0
+      name: Management0
+  weight: 16
+- path: /network-instances/network-instance[name=default]
+  summary: Create VRF default base
+  type: update
+  value:
+    network-instance:
+    - config:
+        enabled: true
+        name: default
+      name: default
+  weight: 17
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]
+  summary: Create Route Maps Base filter-attached-hosts
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=ipns-subnets--default]
+  summary: Create Route Maps Base ipns-subnets--default
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]
+  summary: Create Route Maps Base l2vpn-neighbors
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]
+  summary: Create Route Maps Base loopback-all-vteps
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
+  summary: Create Route Maps Base protocol-loopback-only
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: REJECT_ROUTE
+      conditions:
+        config:
+          install-protocol-eq: ATTACHED_HOST
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=filter-attached-hosts]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=ipns-subnets--default]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: ipns-subnets--default
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=65525]
+  summary: Create Route Map Statement 65525
+  type: update
+  value:
+    statement:
+    - actions:
+        bgp-actions:
+          config:
+            set-local-pref: 150
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        bgp-conditions:
+          config:
+            community-set: all-externals
+      config:
+        name: "65525"
+      name: "65525"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=l2vpn-neighbors]/statements/statement[name=65535]
+  summary: Create Route Map Statement 65535
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      config:
+        name: "65535"
+      name: "65535"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: all-vtep-prefixes
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: protocol-loopback-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /interfaces/interface[name=Ethernet0]/ethernet
+  summary: Create Interface Ethernet0 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet1]/ethernet
+  summary: Create Interface Ethernet1 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet10]/ethernet
+  summary: Create Interface Ethernet10 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet2]/ethernet
+  summary: Create Interface Ethernet2 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet3]/ethernet
+  summary: Create Interface Ethernet3 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet4]/ethernet
+  summary: Create Interface Ethernet4 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet5]/ethernet
+  summary: Create Interface Ethernet5 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet6]/ethernet
+  summary: Create Interface Ethernet6 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet7]/ethernet
+  summary: Create Interface Ethernet7 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet8]/ethernet
+  summary: Create Interface Ethernet8 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet9]/ethernet
+  summary: Create Interface Ethernet9 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
+- path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet0]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet1]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet3]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet4]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet5]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet6]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet9]/subinterfaces/subinterface[index=0]/ipv6/config/enabled
+  summary: Create Subinterface 0 IPv6 Enable
+  type: update
+  value:
+    enabled: true
+  weight: 48
+- path: /interfaces/interface[name=Ethernet10]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.128.20
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.128.20
+        prefix-length: 31
+        secondary: false
+      ip: 172.30.128.20
+  weight: 51
+- path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.8.0
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.8.0
+        prefix-length: 32
+        secondary: false
+      ip: 172.30.8.0
+  weight: 51
+- path: /interfaces/interface[name=Management0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.0.7
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.0.7
+        prefix-length: 21
+        secondary: false
+      ip: 172.30.0.7
+  weight: 51
+- path: /system/ntp/config
+  summary: Create NTP
+  type: update
+  value:
+    config:
+      source-interface:
+      - Management0
+  weight: 55
+- path: /system/ntp/servers/server[address=172.30.0.1]
+  summary: Create NTP server 172.30.0.1
+  type: update
+  value:
+    server:
+    - address: 172.30.0.1
+      config:
+        address: 172.30.0.1
+        prefer: true
+  weight: 56
+- path: /network-instances/network-instance[name=default]/global-sag/config
+  summary: Create VRF default SAG
+  type: update
+  value:
+    config:
+      anycast-mac: "00:00:00:11:11:11"
+  weight: 64
+- path: /network-instances/network-instance[name=default]/evpn/evpn-mh/config
+  summary: Create VRF default EVPNMH
+  type: update
+  weight: 65
+- path: /acl/acl-sets/acl-set
+  summary: Create ACL no-ipns-peering--default base
+  type: update
+  value:
+    acl-set:
+    - config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+  weight: 76
+- path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 1
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: DROP
+      config:
+        sequence-id: 1
+      ipv4:
+        config:
+          destination-address: 10.0.0.0/16
+          source-address: 10.0.0.0/16
+      sequence-id: 1
+  weight: 78
+- path: /acl/acl-sets/acl-set[name=no-ipns-peering--default][type=ACL_IPV4]/acl-entries/acl-entry
+  summary: Create ACL entry 65535
+  type: update
+  value:
+    acl-entry:
+    - actions:
+        config:
+          forwarding-action: ACCEPT
+      config:
+        sequence-id: 65535
+      sequence-id: 65535
+  weight: 78
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp
+  summary: Create VRF default BGP base
+  type: update
+  value:
+    bgp:
+      global:
+        afi-safis:
+          afi-safi:
+          - afi-safi-name: IPV4_UNICAST
+            config:
+              afi-safi-name: IPV4_UNICAST
+            use-multiple-paths:
+              ebgp:
+                config:
+                  maximum-paths: 16
+        config:
+          as: 65100
+          network-import-check: true
+          router-id: 172.30.8.0
+  weight: 80
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=L2VPN_EVPN]
+  summary: Create VRF default BGP L2VPN
+  type: update
+  value:
+    afi-safi:
+    - afi-safi-name: L2VPN_EVPN
+      config:
+        afi-safi-name: L2VPN_EVPN
+      l2vpn-evpn:
+        config:
+          advertise-all-vni: true
+        route-advertise:
+          route-advertise-list: []
+  weight: 81
+- path: /openconfig-bfd:bfd/openconfig-bfd-ext:bfd-profile/profile
+  summary: Create BFD Profile fabric
+  type: update
+  value:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: true
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+  weight: 82
+- path: /openconfig-errdisable-ext:errdisable/config
+  summary: Create ErrDisable Global
+  type: update
+  value:
+    config:
+      cause:
+      - LINK_FLAP
+      interval: 300
+  weight: 83
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet0]/link-flap
+  summary: Create ErrDisable Interface Ethernet0
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet1]/link-flap
+  summary: Create ErrDisable Interface Ethernet1
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet10]/link-flap
+  summary: Create ErrDisable Interface Ethernet10
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet2]/link-flap
+  summary: Create ErrDisable Interface Ethernet2
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet3]/link-flap
+  summary: Create ErrDisable Interface Ethernet3
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet4]/link-flap
+  summary: Create ErrDisable Interface Ethernet4
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet5]/link-flap
+  summary: Create ErrDisable Interface Ethernet5
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet6]/link-flap
+  summary: Create ErrDisable Interface Ethernet6
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet7]/link-flap
+  summary: Create ErrDisable Interface Ethernet7
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet8]/link-flap
+  summary: Create ErrDisable Interface Ethernet8
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet9]/link-flap
+  summary: Create ErrDisable Interface Ethernet9
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.21]
+  summary: Create VRF BGP neighbor 172.30.128.21
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          allow-own-as:
+            config:
+              enabled: true
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+        enabled: true
+        neighbor-address: 172.30.128.21
+        peer-as: 65534
+      neighbor-address: 172.30.128.21
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.2]
+  summary: Create VRF BGP neighbor 172.30.8.2
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric leaf-01 loopback (spine-link)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.2
+        peer-as: 65101
+      neighbor-address: 172.30.8.2
+      transport:
+        config:
+          local-address: 172.30.8.0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.3]
+  summary: Create VRF BGP neighbor 172.30.8.3
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric leaf-02 loopback (spine-link)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.3
+        peer-as: 65101
+      neighbor-address: 172.30.8.3
+      transport:
+        config:
+          local-address: 172.30.8.0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.4]
+  summary: Create VRF BGP neighbor 172.30.8.4
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric leaf-03 loopback (spine-link)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.4
+        peer-as: 65102
+      neighbor-address: 172.30.8.4
+      transport:
+        config:
+          local-address: 172.30.8.0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.5]
+  summary: Create VRF BGP neighbor 172.30.8.5
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric leaf-04 loopback (spine-link)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.5
+        peer-as: 65103
+      neighbor-address: 172.30.8.5
+      transport:
+        config:
+          local-address: 172.30.8.0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.8.6]
+  summary: Create VRF BGP neighbor 172.30.8.6
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - loopback-all-vteps
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Fabric leaf-05 loopback (spine-link)
+        disable-ebgp-connected-route-check: true
+        enabled: true
+        neighbor-address: 172.30.8.6
+        peer-as: 65104
+      neighbor-address: 172.30.8.6
+      transport:
+        config:
+          local-address: 172.30.8.0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet0]
+  summary: Create VRF BGP neighbor Ethernet0
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+        enabled: true
+        neighbor-address: Ethernet0
+        peer-as: 65101
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet0
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet1]
+  summary: Create VRF BGP neighbor Ethernet1
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+        enabled: true
+        neighbor-address: Ethernet1
+        peer-as: 65101
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet1
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet2]
+  summary: Create VRF BGP neighbor Ethernet2
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+        enabled: true
+        neighbor-address: Ethernet2
+        peer-as: 65101
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet2
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet3]
+  summary: Create VRF BGP neighbor Ethernet3
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+        enabled: true
+        neighbor-address: Ethernet3
+        peer-as: 65101
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet3
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet4]
+  summary: Create VRF BGP neighbor Ethernet4
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+        enabled: true
+        neighbor-address: Ethernet4
+        peer-as: 65102
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet4
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet5]
+  summary: Create VRF BGP neighbor Ethernet5
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+        enabled: true
+        neighbor-address: Ethernet5
+        peer-as: 65102
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet5
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet6]
+  summary: Create VRF BGP neighbor Ethernet6
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+        enabled: true
+        neighbor-address: Ethernet6
+        peer-as: 65103
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet6
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet7]
+  summary: Create VRF BGP neighbor Ethernet7
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+        enabled: true
+        neighbor-address: Ethernet7
+        peer-as: 65103
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet7
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet8]
+  summary: Create VRF BGP neighbor Ethernet8
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+        enabled: true
+        neighbor-address: Ethernet8
+        peer-as: 65104
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet8
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=Ethernet9]
+  summary: Create VRF BGP neighbor Ethernet9
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          apply-policy:
+            config:
+              export-policy:
+              - protocol-loopback-only
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          config:
+            afi-safi-name: L2VPN_EVPN
+      config:
+        capability-extended-nexthop: true
+        description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+        enabled: true
+        neighbor-address: Ethernet9
+        peer-as: 65104
+      enable-bfd:
+        config:
+          bfd-profile: fabric
+          enabled: true
+      neighbor-address: Ethernet9
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/global/afi-safis/afi-safi[afi-safi-name=IPV4_UNICAST]/network-config/network[prefix=172.30.8.0/32]
+  summary: Create VRF BGP network 172.30.8.0/32
+  type: update
+  value:
+    network:
+    - config:
+        prefix: 172.30.8.0/32
+      prefix: 172.30.8.0/32
+  weight: 88
+- path: /network-instances/network-instance[name=default]/table-connections/table-connection
+  summary: Create VRF table connection connected
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      dst-protocol: BGP
+      src-protocol: DIRECTLY_CONNECTED
+  weight: 89
+- path: /network-instances/network-instance[name=default]/table-connections/table-connection
+  summary: Create VRF table connection static
+  type: update
+  value:
+    table-connection:
+    - address-family: IPV4
+      config:
+        address-family: IPV4
+        dst-protocol: BGP
+        src-protocol: STATIC
+      dst-protocol: BGP
+      src-protocol: STATIC
+  weight: 89
+- path: /loadshare/roce-attrs
+  summary: Update ECMP RoCE
+  type: replace
+  value:
+    roce-attrs:
+      config:
+        hash: hash
+        qpn: false
+  weight: 132

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.out.gnmi.expected.yaml
@@ -1,0 +1,1049 @@
+acl:
+  acl-sets:
+    acl-set:
+    - acl-entries:
+        acl-entry:
+        - actions:
+            config:
+              forwarding-action: DROP
+          config:
+            sequence-id: 1
+          ipv4:
+            config:
+              destination-address: 10.0.0.0/16
+              source-address: 10.0.0.0/16
+          sequence-id: 1
+        - actions:
+            config:
+              forwarding-action: ACCEPT
+          config:
+            sequence-id: 65535
+          sequence-id: 65535
+      config:
+        description: Prevent VPCs to cross-talk via the external
+        name: no-ipns-peering--default
+        type: ACL_IPV4
+      name: no-ipns-peering--default
+      type: ACL_IPV4
+bfd:
+  bfd-profile:
+    profile:
+    - config:
+        desired-minimum-tx-interval: 300
+        detection-multiplier: 3
+        enabled: true
+        passive-mode: true
+        profile-name: fabric
+        required-minimum-receive: 300
+      profile-name: fabric
+errdisable:
+  config:
+    cause:
+    - LINK_FLAP
+    interval: 300
+errdisable-port:
+  port:
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet0
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet1
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet10
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet2
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet3
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet4
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet5
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet6
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet7
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet8
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet9
+interfaces:
+  interface:
+  - config:
+      description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet0
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+      enabled: true
+      name: Ethernet1
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+      enabled: true
+      name: Ethernet10
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet10
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.20
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.20
+  - config:
+      description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet2
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet2
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+      enabled: true
+      name: Ethernet3
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet3
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet4
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet4
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+      enabled: true
+      name: Ethernet5
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet5
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+      enabled: true
+      name: Ethernet6
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet6
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+      enabled: true
+      name: Ethernet7
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet7
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+      enabled: true
+      name: Ethernet8
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet8
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+      enabled: true
+      name: Ethernet9
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet9
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv6:
+          config:
+            enabled: true
+  - config:
+      description: Protocol loopback
+      enabled: true
+      name: Loopback1
+    name: Loopback1
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.8.0
+                prefix-length: 32
+                secondary: false
+              ip: 172.30.8.0
+  - config:
+      description: Management link
+      enabled: true
+      name: Management0
+    name: Management0
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.0.7
+                prefix-length: 21
+                secondary: false
+              ip: 172.30.0.7
+lldp:
+  config:
+    enabled: true
+    hello-timer: "5"
+    system-description: Hedgehog Fabric
+    system-name: spine-01
+loadshare:
+  roce-attrs:
+    config:
+      hash: hash
+      qpn: false
+network-instances:
+  network-instance:
+  - config:
+      enabled: true
+      name: default
+    global-sag:
+      config:
+        anycast-mac: "00:00:00:11:11:11"
+    name: default
+    protocols:
+      protocol:
+      - bgp:
+          global:
+            afi-safis:
+              afi-safi:
+              - afi-safi-name: IPV4_UNICAST
+                config:
+                  afi-safi-name: IPV4_UNICAST
+                network-config:
+                  network:
+                  - config:
+                      prefix: 172.30.8.0/32
+                    prefix: 172.30.8.0/32
+                use-multiple-paths:
+                  ebgp:
+                    config:
+                      maximum-paths: 16
+              - afi-safi-name: L2VPN_EVPN
+                config:
+                  afi-safi-name: L2VPN_EVPN
+                l2vpn-evpn:
+                  config:
+                    advertise-all-vni: true
+                  route-advertise:
+                    route-advertise-list: []
+            config:
+              as: 65100
+              network-import-check: true
+              router-id: 172.30.8.0
+          neighbors:
+            neighbor:
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+                enabled: true
+                neighbor-address: 172.30.128.21
+                peer-as: 65534
+              neighbor-address: 172.30.128.21
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-01 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.2
+                peer-as: 65101
+              neighbor-address: 172.30.8.2
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-02 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.3
+                peer-as: 65101
+              neighbor-address: 172.30.8.3
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-03 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.4
+                peer-as: 65102
+              neighbor-address: 172.30.8.4
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-04 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.5
+                peer-as: 65103
+              neighbor-address: 172.30.8.5
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - loopback-all-vteps
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Fabric leaf-05 loopback (spine-link)
+                disable-ebgp-connected-route-check: true
+                enabled: true
+                neighbor-address: 172.30.8.6
+                peer-as: 65104
+              neighbor-address: 172.30.8.6
+              transport:
+                config:
+                  local-address: 172.30.8.0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: Ethernet0
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet0
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+                enabled: true
+                neighbor-address: Ethernet1
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet1
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: Ethernet2
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet2
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+                enabled: true
+                neighbor-address: Ethernet3
+                peer-as: 65101
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet3
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: Ethernet4
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet4
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+                enabled: true
+                neighbor-address: Ethernet5
+                peer-as: 65102
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet5
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+                enabled: true
+                neighbor-address: Ethernet6
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet6
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+                enabled: true
+                neighbor-address: Ethernet7
+                peer-as: 65103
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet7
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+                enabled: true
+                neighbor-address: Ethernet8
+                peer-as: 65104
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet8
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  apply-policy:
+                    config:
+                      export-policy:
+                      - protocol-loopback-only
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+              config:
+                capability-extended-nexthop: true
+                description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+                enabled: true
+                neighbor-address: Ethernet9
+                peer-as: 65104
+              enable-bfd:
+                config:
+                  bfd-profile: fabric
+                  enabled: true
+              neighbor-address: Ethernet9
+        identifier: BGP
+        name: bgp
+    table-connections:
+      table-connection:
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: DIRECTLY_CONNECTED
+        dst-protocol: BGP
+        src-protocol: DIRECTLY_CONNECTED
+      - address-family: IPV4
+        config:
+          address-family: IPV4
+          dst-protocol: BGP
+          src-protocol: STATIC
+        dst-protocol: BGP
+        src-protocol: STATIC
+routing-policy:
+  defined-sets:
+    bgp-defined-sets:
+      as-path-sets:
+        as-path-set:
+        - as-path-set-name: fabric-gw-aspath
+          config:
+            action: PERMIT
+            as-path-set-member:
+            - _65100_
+            - _65534_
+            as-path-set-name: fabric-gw-aspath
+      community-sets:
+        community-set:
+        - community-set-name: all-externals
+          config:
+            action: PERMIT
+            community-member:
+            - 65102:1000
+            community-set-name: all-externals
+            match-set-options: ANY
+        - community-set-name: no-community
+          config:
+            action: PERMIT
+            community-member:
+            - REGEX:^$
+            community-set-name: no-community
+            match-set-options: ANY
+    prefix-sets:
+      prefix-set:
+      - config:
+          mode: IPV4
+          name: all-vtep-prefixes
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/22
+              masklength-range: 22..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/22
+            masklength-range: 22..32
+            sequence-number: 10
+        name: all-vtep-prefixes
+      - config:
+          mode: IPV4
+          name: any-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 0.0.0.0/0
+              masklength-range: 0..32
+              sequence-number: 10
+            ip-prefix: 0.0.0.0/0
+            masklength-range: 0..32
+            sequence-number: 10
+        name: any-prefix
+      - config:
+          mode: IPV4
+          name: ipns-subnets--default
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 10.0.0.0/16
+              masklength-range: 16..32
+              sequence-number: 1
+            ip-prefix: 10.0.0.0/16
+            masklength-range: 16..32
+            sequence-number: 1
+        name: ipns-subnets--default
+      - config:
+          mode: IPV4
+          name: protocol-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.8.0/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.8.0/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: protocol-loopback-prefix
+      - config:
+          mode: IPV4
+          name: static-ext-subnets
+        name: static-ext-subnets
+      - config:
+          mode: IPV4
+          name: vpc-loopback-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.96.0/19
+              masklength-range: 19..32
+              sequence-number: 10
+            ip-prefix: 172.30.96.0/19
+            masklength-range: 19..32
+            sequence-number: 10
+        name: vpc-loopback-prefix
+  policy-definitions:
+    policy-definition:
+    - config:
+        name: filter-attached-hosts
+      name: filter-attached-hosts
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: REJECT_ROUTE
+          conditions:
+            config:
+              install-protocol-eq: ATTACHED_HOST
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: ipns-subnets--default
+      name: ipns-subnets--default
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: ipns-subnets--default
+          config:
+            name: "10"
+          name: "10"
+    - config:
+        name: l2vpn-neighbors
+      name: l2vpn-neighbors
+      statements:
+        statement:
+        - actions:
+            bgp-actions:
+              config:
+                set-local-pref: 150
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            bgp-conditions:
+              config:
+                community-set: all-externals
+          config:
+            name: "65525"
+          name: "65525"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          config:
+            name: "65535"
+          name: "65535"
+    - config:
+        name: loopback-all-vteps
+      name: loopback-all-vteps
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: protocol-loopback-only
+      name: protocol-loopback-only
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: protocol-loopback-prefix
+          config:
+            name: "10"
+          name: "10"
+system:
+  aaa:
+    authentication:
+      users:
+        user:
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: admin
+            username: admin
+          username: admin
+        - config:
+            password-hashed: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+            role: operator
+            username: op
+          username: op
+  config:
+    hostname: spine-01
+  ntp:
+    config:
+      source-interface:
+      - Management0
+    servers:
+      server:
+      - address: 172.30.0.1
+        config:
+          address: 172.30.0.1
+          prefer: true
+ztp:
+  config:
+    admin-mode: false

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-spine-1.out.spec.expected.yaml
@@ -1,0 +1,470 @@
+acls:
+  no-ipns-peering--default:
+    description: Prevent VPCs to cross-talk via the external
+    entries:
+      "1":
+        action: DROP
+        destinationAddress: 10.0.0.0/16
+        protocol: IP
+        sourceAddress: 10.0.0.0/16
+      "65535":
+        action: ACCEPT
+        protocol: IP
+asPathLists:
+  fabric-gw-aspath:
+    members:
+    - _65100_
+    - _65534_
+bfdProfiles:
+  fabric:
+    desiredMinimumTxInterval: 300
+    detectionMultiplier: 3
+    passiveMode: true
+    requiredMinimumReceive: 300
+communityLists:
+  all-externals:
+    members:
+    - 65102:1000
+  no-community:
+    members:
+    - REGEX:^$
+ecmpRoCEQPN: false
+errDisableGlobal:
+  recoveryInterval: 300
+errDisableInterfaces:
+  Ethernet0:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet1:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet2:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet3:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet4:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet5:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet6:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet7:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet8:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet9:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+  Ethernet10:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
+hostname: spine-01
+interfaces:
+  Ethernet0:
+    autoNegotiate: false
+    description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet1:
+    autoNegotiate: false
+    description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet2:
+    autoNegotiate: false
+    description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet3:
+    autoNegotiate: false
+    description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet4:
+    autoNegotiate: false
+    description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet5:
+    autoNegotiate: false
+    description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet6:
+    autoNegotiate: false
+    description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet7:
+    autoNegotiate: false
+    description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet8:
+    autoNegotiate: false
+    description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet9:
+    autoNegotiate: false
+    description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+    enabled: true
+    subinterfaces:
+      "0":
+        ipv6:
+          ipv6Enabled: true
+  Ethernet10:
+    autoNegotiate: false
+    description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.128.20:
+            prefixLen: 31
+  Loopback1:
+    description: Protocol loopback
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.8.0:
+            prefixLen: 32
+  Management0:
+    autoNegotiate: true
+    description: Management link
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.0.7:
+            prefixLen: 21
+lldp:
+  enabled: true
+  helloTimer: 5
+  systemDescription: Hedgehog Fabric
+  systemName: spine-01
+ntp:
+  sourceInterface:
+  - Management0
+ntpServers:
+  172.30.0.1:
+    prefer: true
+prefixLists:
+  all-vtep-prefixes:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.0/22
+  any-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 0.0.0.0/0
+  ipns-subnets--default:
+    prefixes:
+      "1":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 10.0.0.0/16
+  protocol-loopback-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.8.0/32
+  static-ext-subnets: {}
+  vpc-loopback-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.96.0/19
+routeMaps:
+  filter-attached-hosts:
+    statements:
+      "10":
+        conditions:
+          attachedHost: true
+        result: reject
+      "100":
+        conditions: {}
+        result: accept
+  ipns-subnets--default:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: ipns-subnets--default
+        result: accept
+  l2vpn-neighbors:
+    statements:
+      "65525":
+        conditions:
+          matchCommunityLists: all-externals
+        result: accept
+        setLocalPreference: 150
+      "65535":
+        conditions: {}
+        result: accept
+  loopback-all-vteps:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  protocol-loopback-only:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: protocol-loopback-prefix
+        result: accept
+users:
+  admin:
+    authorizedKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: admin
+  op:
+    authorizedKeys:
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIALAU1RChR27OrcAjD6HFoLrBK3oVKJV6ATWYB3OjdSw
+    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGpF2+9I1Nj4BcN7y6DjzTbq1VcUYIRGyfzId5ZoBEFj
+    password: $5$8nAYPGcl4l6G7Av1$Qi4/gnM0yPtGv9kjpMh78NuNSfQWy7vR1rulHpurL36
+    role: operator
+vrfs:
+  default:
+    anycastMAC: "00:00:00:11:11:11"
+    bgp:
+      as: 65100
+      ipv4Unicast:
+        enable: true
+        maxPaths: 16
+        networks:
+          172.30.8.0/32: {}
+      l2vpnEvpn:
+        advertiseAllVnis: true
+        enable: true
+      neighbors:
+        172.30.8.2:
+          description: Fabric leaf-01 loopback (spine-link)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65101
+          updateSource: 172.30.8.0
+        172.30.8.3:
+          description: Fabric leaf-02 loopback (spine-link)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65101
+          updateSource: 172.30.8.0
+        172.30.8.4:
+          description: Fabric leaf-03 loopback (spine-link)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65102
+          updateSource: 172.30.8.0
+        172.30.8.5:
+          description: Fabric leaf-04 loopback (spine-link)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65103
+          updateSource: 172.30.8.0
+        172.30.8.6:
+          description: Fabric leaf-05 loopback (spine-link)
+          disableConnectedCheck: true
+          enabled: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - loopback-all-vteps
+          l2vpnEvpn: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65104
+          updateSource: 172.30.8.0
+        172.30.128.21:
+          description: Gateway gateway-1/enp2s1 spine-01--gateway--gateway-1
+          enabled: true
+          ipv4Unicast: true
+          l2vpnEvpn: true
+          l2vpnEvpnAllowOwnAS: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65534
+        Ethernet0:
+          bfdProfile: fabric
+          description: Fabric leaf-01/E1/8 spine-01--fabric--leaf-01
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65101
+        Ethernet1:
+          bfdProfile: fabric
+          description: Fabric leaf-01/E1/9 spine-01--fabric--leaf-01
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65101
+        Ethernet2:
+          bfdProfile: fabric
+          description: Fabric leaf-02/E1/9 spine-01--fabric--leaf-02
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65101
+        Ethernet3:
+          bfdProfile: fabric
+          description: Fabric leaf-02/E1/10 spine-01--fabric--leaf-02
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65101
+        Ethernet4:
+          bfdProfile: fabric
+          description: Fabric leaf-03/E1/5 spine-01--fabric--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65102
+        Ethernet5:
+          bfdProfile: fabric
+          description: Fabric leaf-03/E1/6 spine-01--fabric--leaf-03
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65102
+        Ethernet6:
+          bfdProfile: fabric
+          description: Fabric leaf-04/E1/5 spine-01--fabric--leaf-04
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65103
+        Ethernet7:
+          bfdProfile: fabric
+          description: Fabric leaf-04/E1/6 spine-01--fabric--leaf-04
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65103
+        Ethernet8:
+          bfdProfile: fabric
+          description: Fabric leaf-05/E1/4 spine-01--fabric--leaf-05
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65104
+        Ethernet9:
+          bfdProfile: fabric
+          description: Fabric leaf-05/E1/5 spine-01--fabric--leaf-05
+          enabled: true
+          extendedNexthop: true
+          ipv4Unicast: true
+          ipv4UnicastExportPolicies:
+          - protocol-loopback-only
+          remoteAS: 65104
+      networkImportCheck: true
+      routerID: 172.30.8.0
+    enabled: true
+    evpnMH: {}
+    tableConnections:
+      connected: {}
+      static: {}
+ztp: false

--- a/pkg/agent/dozer/dozer.go
+++ b/pkg/agent/dozer/dozer.go
@@ -136,6 +136,7 @@ type SpecInterface struct {
 	AutoNegotiate      *bool                        `json:"autoNegotiate,omitempty"`
 	FEC                *string                      `json:"fec,omitempty"`
 	VLANIPs            map[string]*SpecInterfaceIP  `json:"vlanIPs,omitempty"`
+	VLANIPv6           *SpecInterfaceIPv6           `json:"vlanIPv6,omitempty"`
 	VLANAnycastGateway []string                     `json:"vlanAnycastGateway,omitempty"`
 	Subinterfaces      map[uint32]*SpecSubinterface `json:"subinterfaces,omitempty"`
 	ProxyARP           *SpecProxyARP                `json:"proxyARP,omitempty"`

--- a/pkg/util/apiutil/bgp.go
+++ b/pkg/util/apiutil/bgp.go
@@ -12,6 +12,7 @@ import (
 	"go.githedgehog.com/fabric/api/meta"
 	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
 	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/ctrl/switchprofile"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -31,7 +32,27 @@ const (
 	BGPNeighborTypeFabric   BGPNeighborType = "fabric"
 	BGPNeighborTypeExternal BGPNeighborType = "external"
 	BGPNeighborTypeGateway  BGPNeighborType = "gateway"
+	BGPUnnumberedNeighbor                   = "unnum"
 )
+
+func fabricNeighborKey(ag *agentapi.Agent, local, remote wiringapi.ConnFabricLinkSwitch) (string, error) {
+	if remote.IP != "" {
+		return strings.Split(remote.IP, "/")[0], nil
+	}
+
+	if ag.Spec.SwitchProfile == nil {
+		return "", fmt.Errorf("switch profile is not set for %s", ag.Name) //nolint:goerr113
+	}
+
+	if ag.Spec.SwitchProfile.SwitchSilicon == switchprofile.SiliconBroadcomTH5 {
+		port := local.LocalPortName()
+		if vlan, ok := ag.Spec.Catalog.TH5WorkaroundVLANs[port]; ok {
+			return fmt.Sprintf("%s.%d", BGPUnnumberedNeighbor, vlan), nil
+		}
+	}
+
+	return BGPUnnumberedNeighbor, nil
+}
 
 func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.FabricConfig, sw *wiringapi.Switch) (map[string]map[string]BGPNeighborStatus, error) {
 	if sw == nil {
@@ -109,8 +130,12 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				}
 				fabricPeers[other.DeviceName()] = true
 
-				ip := strings.Split(other.IP, "/")[0]
-				neigh, ok := out["default"][ip]
+				key, err := fabricNeighborKey(ag, curr, other)
+				if err != nil {
+					return nil, fmt.Errorf("fabric connection %s: %w", conn.Name, err)
+				}
+
+				neigh, ok := out["default"][key]
 				if !ok {
 					neigh = BGPNeighborStatus{}
 				}
@@ -122,7 +147,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				neigh.ConnectionType = conn.Spec.Type()
 				neigh.Port = curr.LocalPortName()
 
-				out["default"][ip] = neigh
+				out["default"][key] = neigh
 			}
 		} else if conn.Spec.Mesh != nil {
 			for _, link := range conn.Spec.Mesh.Links {
@@ -134,8 +159,12 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				}
 				fabricPeers[other.DeviceName()] = true
 
-				ip := strings.Split(other.IP, "/")[0]
-				neigh, ok := out["default"][ip]
+				key, err := fabricNeighborKey(ag, curr, other)
+				if err != nil {
+					return nil, fmt.Errorf("mesh connection %s: %w", conn.Name, err)
+				}
+
+				neigh, ok := out["default"][key]
 				if !ok {
 					neigh = BGPNeighborStatus{}
 				}
@@ -147,7 +176,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				neigh.ConnectionType = conn.Spec.Type()
 				neigh.Port = curr.LocalPortName()
 
-				out["default"][ip] = neigh
+				out["default"][key] = neigh
 			}
 		} else if conn.Spec.External != nil {
 			extConns[conn.Name] = &conn


### PR DESCRIPTION
Fix #1002 

Note that without fabricator changes (i.e. the hydration), by default we will still use the old numbered sessions; however one can remove the IPs from the connection objects to enable BGP unnumbered on those links. This process (and the reverse unnumbered->numbered) was tested in a vlab.