### PR TITLE
fix: report unnumbered BGP and BFD peers by their port

### DIFF
--- a/api/agent/v1beta1/agent_types.go
+++ b/api/agent/v1beta1/agent_types.go
@@ -175,9 +175,9 @@ type SwitchState struct {
 	Breakouts map[string]SwitchStateBreakout `json:"breakouts,omitempty"`
 	// Transceivers state (port -> transceiver state)
 	Transceivers map[string]SwitchStateTransceiver `json:"transceivers,omitempty"`
-	// State of all BGP neighbors (VRF -> neighbor address -> state)
+	// State of all BGP neighbors (VRF -> neighbor address, or port (with .VLAN for TH5) for an unnumbered session -> state)
 	BGPNeighbors map[string]map[string]SwitchStateBGPNeighbor `json:"bgpNeighbors,omitempty"`
-	// State of all BFD peers (VRF -> peer address -> state)
+	// State of all BFD peers (VRF -> peer address, or port for an unnumbered session -> state)
 	BFDPeers map[string]map[string]SwitchStateBFDPeer `json:"bfdPeers,omitempty"`
 	// State of the switch platform (fans, PSUs, sensors)
 	Platform SwitchStatePlatform `json:"platform,omitempty"`

--- a/config/crd/bases/agent.githedgehog.com_agents.yaml
+++ b/config/crd/bases/agent.githedgehog.com_agents.yaml
@@ -2237,7 +2237,8 @@ spec:
                             type: string
                         type: object
                       type: object
-                    description: State of all BFD peers (VRF -> peer address -> state)
+                    description: State of all BFD peers (VRF -> peer address, or port
+                      for an unnumbered session -> state)
                     type: object
                   bgpNeighbors:
                     additionalProperties:
@@ -2344,8 +2345,8 @@ spec:
                             type: string
                         type: object
                       type: object
-                    description: State of all BGP neighbors (VRF -> neighbor address
-                      -> state)
+                    description: State of all BGP neighbors (VRF -> neighbor address,
+                      or port (with .VLAN for TH5) for an unnumbered session -> state)
                     type: object
                   breakouts:
                     additionalProperties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,8 +227,8 @@ _Appears in:_
 | `interfaces` _object (keys:string, values:[SwitchStateInterface](#switchstateinterface))_ | Switch interfaces state (incl. physical, management and port channels) |  |  |
 | `breakouts` _object (keys:string, values:[SwitchStateBreakout](#switchstatebreakout))_ | Breakout ports state (port -> breakout state) |  |  |
 | `transceivers` _object (keys:string, values:[SwitchStateTransceiver](#switchstatetransceiver))_ | Transceivers state (port -> transceiver state) |  |  |
-| `bgpNeighbors` _object (keys:string, values:[map[string]SwitchStateBGPNeighbor](#switchstatebgpneighbor))_ | State of all BGP neighbors (VRF -> neighbor address -> state) |  |  |
-| `bfdPeers` _object (keys:string, values:[map[string]SwitchStateBFDPeer](#switchstatebfdpeer))_ | State of all BFD peers (VRF -> peer address -> state) |  |  |
+| `bgpNeighbors` _object (keys:string, values:[map[string]SwitchStateBGPNeighbor](#switchstatebgpneighbor))_ | State of all BGP neighbors (VRF -> neighbor address, or port (with .VLAN for TH5) for an unnumbered session -> state) |  |  |
+| `bfdPeers` _object (keys:string, values:[map[string]SwitchStateBFDPeer](#switchstatebfdpeer))_ | State of all BFD peers (VRF -> peer address, or port for an unnumbered session -> state) |  |  |
 | `platform` _[SwitchStatePlatform](#switchstateplatform)_ | State of the switch platform (fans, PSUs, sensors) |  |  |
 | `criticalResources` _[SwitchStateCRM](#switchstatecrm)_ | State of the critical resources (ACLs, routes, etc.) |  |  |
 | `roce` _boolean_ | State of the roce configuration |  |  |

--- a/pkg/agent/dozer/bcm/README.plan.md
+++ b/pkg/agent/dozer/bcm/README.plan.md
@@ -359,6 +359,11 @@ what keeps a miscabled link from establishing and forming a topology we never in
 The per-node session over the protocol loopbacks is unaffected — it is IPv4-addressed and
 multihop either way.
 
+The session has no peer IP to be reported under, so the agent keys its state (and the BFD
+session under it) by the port instead — `E1/1`, or `E1/1.3123` for the TH5 workaround SVI
+below. The NOS interface name the device actually uses (`Ethernet3`, `Vlan3123`) is
+translated away in `state.go`, so it never reaches the API.
+
 ### Mesh Connections (i.e. leaf-leaf)
 
 Mesh connections are very much similar to fabric ones, with the main difference being

--- a/pkg/agent/dozer/bcm/state.go
+++ b/pkg/agent/dozer/bcm/state.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"math"
 	"net"
+	"net/netip"
 	"slices"
 	"strconv"
 	"strings"
@@ -113,11 +114,11 @@ func (p *BroadcomProcessor) UpdateSwitchState(ctx context.Context, agent *agenta
 		return errors.Wrapf(err, "failed to update errdisable state")
 	}
 
-	if err := p.updateBGPNeighborMetrics(ctx, reg, swState); err != nil {
+	if err := p.updateBGPNeighborMetrics(ctx, reg, swState, agent, portMap); err != nil {
 		return errors.Wrapf(err, "failed to update bgp neighbor metrics")
 	}
 
-	if err := p.updateBFDPeerMetrics(ctx, reg, swState); err != nil {
+	if err := p.updateBFDPeerMetrics(ctx, reg, swState, agent, portMap); err != nil {
 		return errors.Wrapf(err, "failed to update bfd peer metrics")
 	}
 
@@ -950,7 +951,45 @@ func (p *BroadcomProcessor) updateErrDisableState(ctx context.Context, swState *
 	return nil
 }
 
-func (p *BroadcomProcessor) updateBGPNeighborMetrics(ctx context.Context, reg *switchstate.Registry, swState *agentapi.SwitchState) error {
+// apiIfaceName translates the NOS interface an unnumbered BGP session or BFD session runs over
+// into the port name used by the API: Ethernet0 -> E1/1, Ethernet0.1001 -> E1/1.1001 and, for the
+// TH5 workaround SVI, Vlan3123 -> E1/5.3123. Names we cannot map are returned as they are, so an
+// unexpected one shows up in the state instead of being dropped.
+func apiIfaceName(name string, portMap map[string]string, th5VLANs map[string]uint16) string {
+	if isVLAN(name) {
+		vlan, err := strconv.ParseUint(strings.TrimPrefix(name, IfacePrefixVLAN), 10, 16)
+		if err != nil {
+			return name
+		}
+
+		for port, workaroundVLAN := range th5VLANs {
+			if uint64(workaroundVLAN) == vlan {
+				return fmt.Sprintf("%s.%d", port, workaroundVLAN)
+			}
+		}
+
+		return name
+	}
+
+	if !isPhysical(name) {
+		return name
+	}
+
+	base, sub, hasSub := strings.Cut(name, ".")
+	apiName, exists := portMap[base]
+	if !exists {
+		slog.Warn("Port mapping not found for interface-keyed peer", "interface", name)
+
+		return name
+	}
+	if hasSub {
+		return apiName + "." + sub
+	}
+
+	return apiName
+}
+
+func (p *BroadcomProcessor) updateBGPNeighborMetrics(ctx context.Context, reg *switchstate.Registry, swState *agentapi.SwitchState, ag *agentapi.Agent, portMap map[string]string) error {
 	sonicVRFs := &oc.SonicVrf_SonicVrf_VRF{}
 	if err := p.client.Get(ctx, "/sonic-vrf/VRF/VRF_LIST", sonicVRFs, api.DataTypeCONFIG()); err != nil {
 		return errors.Wrapf(err, "failed to get vrfs list")
@@ -973,10 +1012,14 @@ func (p *BroadcomProcessor) updateBGPNeighborMetrics(ctx context.Context, reg *s
 		// The device reports these timers as a delta in seconds relative to now (i.e. "N seconds ago")
 		now := time.Now()
 
-		for neighborAddress, neighbor := range neighs.Neighbor {
+		for neighborAddressRaw, neighbor := range neighs.Neighbor {
 			if neighbor.State == nil {
 				continue
 			}
+
+			// an unnumbered neighbor is keyed by the interface it runs over, which the device
+			// reports under its NOS name
+			neighborAddress := apiIfaceName(neighborAddressRaw, portMap, ag.Spec.Catalog.TH5WorkaroundVLANs)
 
 			ocSt := neighbor.State
 			st := agentapi.SwitchStateBGPNeighbor{
@@ -1968,7 +2011,7 @@ func cleanupFloat(val float64) float64 {
 	return val
 }
 
-func (p *BroadcomProcessor) updateBFDPeerMetrics(ctx context.Context, reg *switchstate.Registry, swState *agentapi.SwitchState) error {
+func (p *BroadcomProcessor) updateBFDPeerMetrics(ctx context.Context, reg *switchstate.Registry, swState *agentapi.SwitchState, ag *agentapi.Agent, portMap map[string]string) error {
 	ocBFD := &oc.OpenconfigBfd_Bfd{}
 	if err := p.client.Get(ctx, "/openconfig-bfd:bfd/openconfig-bfd-ext:bfd-shop-sessions", ocBFD); err != nil {
 		if !strings.Contains(err.Error(), errGRPCNotFound) {
@@ -1991,10 +2034,16 @@ func (p *BroadcomProcessor) updateBFDPeerMetrics(ctx context.Context, reg *switc
 
 		ocSt := session.State
 		vrf := key.Vrf
-		remoteAddress := key.RemoteAddress
+		peer := key.RemoteAddress
 
 		if vrf == "" {
 			vrf = VRFDefault
+		}
+
+		// an unnumbered session runs over an IPv6 link-local address, which is of no use to
+		// anyone: key it by the interface instead, the way the BGP neighbor is reported
+		if addr, err := netip.ParseAddr(peer); err == nil && addr.Is6() && addr.IsLinkLocalUnicast() && key.Interface != "" {
+			peer = apiIfaceName(key.Interface, portMap, ag.Spec.Catalog.TH5WorkaroundVLANs)
 		}
 
 		st := agentapi.SwitchStateBFDPeer{}
@@ -2009,7 +2058,7 @@ func (p *BroadcomProcessor) updateBFDPeerMetrics(ctx context.Context, reg *switc
 		if err != nil {
 			return errors.Wrapf(err, "failed to get bfd session state ID")
 		}
-		reg.BFDPeerMetrics.SessionState.WithLabelValues(vrf, remoteAddress).Set(float64(sessionStateID))
+		reg.BFDPeerMetrics.SessionState.WithLabelValues(vrf, peer).Set(float64(sessionStateID))
 
 		if ocSt.ActiveProfile != nil {
 			st.Profile = *ocSt.ActiveProfile
@@ -2021,13 +2070,13 @@ func (p *BroadcomProcessor) updateBFDPeerMetrics(ctx context.Context, reg *switc
 
 		if ocSt.FailureTransitions != nil {
 			st.FailureTransitions = *ocSt.FailureTransitions
-			reg.BFDPeerMetrics.FailureTransitions.WithLabelValues(vrf, remoteAddress).Set(float64(*ocSt.FailureTransitions))
+			reg.BFDPeerMetrics.FailureTransitions.WithLabelValues(vrf, peer).Set(float64(*ocSt.FailureTransitions))
 		}
 
 		if swState.BFDPeers[vrf] == nil {
 			swState.BFDPeers[vrf] = map[string]agentapi.SwitchStateBFDPeer{}
 		}
-		swState.BFDPeers[vrf][remoteAddress] = st
+		swState.BFDPeers[vrf][peer] = st
 	}
 
 	return nil

--- a/pkg/agent/dozer/bcm/state_unnumbered_test.go
+++ b/pkg/agent/dozer/bcm/state_unnumbered_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package bcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The device reports an unnumbered BGP session, and the BFD session under it, keyed by the NOS
+// interface it runs over. Those names never leave the switch, so the agent reports the API port
+// name instead.
+func TestAPIIfaceName(t *testing.T) {
+	portMap := map[string]string{
+		"Ethernet0": "E1/1",
+		"Ethernet4": "E1/5",
+	}
+	th5VLANs := map[string]uint16{"E1/5": 3123}
+
+	for _, tt := range []struct {
+		in   string
+		want string
+	}{
+		{in: "Ethernet0", want: "E1/1"},
+		{in: "Ethernet0.1001", want: "E1/1.1001"}, // hostBGP subinterface
+		{in: "Vlan3123", want: "E1/5.3123"},       // TH5 workaround SVI
+		{in: "Vlan1001", want: "Vlan1001"},        // not a workaround VLAN, nothing to map it to
+		{in: "PortChannel12", want: "PortChannel12"},
+		{in: "Ethernet96", want: "Ethernet96"}, // no mapping, kept as is rather than dropped
+		{in: "172.30.128.1", want: "172.30.128.1"},
+		{in: "fe80::1", want: "fe80::1"},
+	} {
+		t.Run(tt.in, func(t *testing.T) {
+			require.Equal(t, tt.want, apiIfaceName(tt.in, portMap, th5VLANs))
+		})
+	}
+}

--- a/pkg/hhfctl/inspect/bfd.go
+++ b/pkg/hhfctl/inspect/bfd.go
@@ -76,11 +76,17 @@ func (out *BFDOut) MarshalText(_ BFDIn, now time.Time) (string, error) {
 					last = HumanizeTime(now, p.LastUpTime.Time)
 				}
 
+				// an unnumbered session is keyed by the port it runs over, so say what it is
+				peer := addr
+				if p.Unnumbered {
+					peer += " IPv6 LL"
+				}
+
 				data = append(data, []string{
 					t,
 					p.Port,
 					vrf,
-					addr,
+					peer,
 					p.RemoteName,
 					p.ConnectionName,
 					s,

--- a/pkg/hhfctl/inspect/bgp.go
+++ b/pkg/hhfctl/inspect/bgp.go
@@ -74,11 +74,17 @@ func (out *BGPOut) MarshalText(_ BGPIn, now time.Time) (string, error) {
 					last = HumanizeTime(now, n.LastEstablished.Time)
 				}
 
+				// an unnumbered session is keyed by the port it runs over, so say what it is
+				neighbor := name
+				if n.Unnumbered {
+					neighbor += " IPv6 LL"
+				}
+
 				data = append(data, []string{
 					t,
 					n.Port,
 					vrf,
-					name,
+					neighbor,
 					n.RemoteName,
 					n.ConnectionName,
 					s,

--- a/pkg/util/apiutil/bfd.go
+++ b/pkg/util/apiutil/bfd.go
@@ -16,6 +16,7 @@ import (
 type BFDPeerStatus struct {
 	RemoteName                  string          `json:"remoteName,omitempty"`
 	Type                        BGPNeighborType `json:"type,omitempty"`
+	Unnumbered                  bool            `json:"unnumbered,omitempty"`
 	Expected                    bool            `json:"expected,omitempty"`
 	ConnectionName              string          `json:"connectionName,omitempty"`
 	ConnectionType              string          `json:"connectionType,omitempty"`
@@ -67,6 +68,7 @@ func GetBFDPeers(ctx context.Context, kube kclient.Reader, fabCfg *meta.FabricCo
 			peer := out[vrf][addr]
 			peer.RemoteName = bgpNeighbor.RemoteName
 			peer.Type = bgpNeighbor.Type
+			peer.Unnumbered = bgpNeighbor.Unnumbered
 			peer.Expected = bgpNeighbor.Expected
 			peer.ConnectionName = bgpNeighbor.ConnectionName
 			peer.ConnectionType = bgpNeighbor.ConnectionType

--- a/pkg/util/apiutil/bgp.go
+++ b/pkg/util/apiutil/bgp.go
@@ -19,6 +19,7 @@ import (
 type BGPNeighborStatus struct {
 	RemoteName                      string          `json:"remoteName,omitempty"`
 	Type                            BGPNeighborType `json:"type,omitempty"`
+	Unnumbered                      bool            `json:"unnumbered,omitempty"`
 	Expected                        bool            `json:"expected,omitempty"`
 	ConnectionName                  string          `json:"connectionName,omitempty"`
 	ConnectionType                  string          `json:"connectionType,omitempty"`
@@ -32,26 +33,29 @@ const (
 	BGPNeighborTypeFabric   BGPNeighborType = "fabric"
 	BGPNeighborTypeExternal BGPNeighborType = "external"
 	BGPNeighborTypeGateway  BGPNeighborType = "gateway"
-	BGPUnnumberedNeighbor                   = "unnum"
 )
 
-func fabricNeighborKey(ag *agentapi.Agent, local, remote wiringapi.ConnFabricLinkSwitch) (string, error) {
-	if remote.IP != "" {
-		return strings.Split(remote.IP, "/")[0], nil
+// bgpNeighborKey returns the key the agent reports the session over the given link under: the peer
+// IP for a numbered link, the local port for an unnumbered one, since that is what the session is
+// keyed by. On TH5 the peering runs over the workaround SVI, reported as port.vlan.
+func bgpNeighborKey(ag *agentapi.Agent, local wiringapi.ConnFabricLinkSwitch, remoteIP string) (string, error) {
+	if remoteIP != "" {
+		return strings.Split(remoteIP, "/")[0], nil
 	}
 
 	if ag.Spec.SwitchProfile == nil {
 		return "", fmt.Errorf("switch profile is not set for %s", ag.Name) //nolint:goerr113
 	}
 
+	port := local.LocalPortName()
+
 	if ag.Spec.SwitchProfile.SwitchSilicon == switchprofile.SiliconBroadcomTH5 {
-		port := local.LocalPortName()
 		if vlan, ok := ag.Spec.Catalog.TH5WorkaroundVLANs[port]; ok {
-			return fmt.Sprintf("%s.%d", BGPUnnumberedNeighbor, vlan), nil
+			return fmt.Sprintf("%s.%d", port, vlan), nil
 		}
 	}
 
-	return BGPUnnumberedNeighbor, nil
+	return port, nil
 }
 
 func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.FabricConfig, sw *wiringapi.Switch) (map[string]map[string]BGPNeighborStatus, error) {
@@ -130,7 +134,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				}
 				fabricPeers[other.DeviceName()] = true
 
-				key, err := fabricNeighborKey(ag, curr, other)
+				key, err := bgpNeighborKey(ag, curr, other.IP)
 				if err != nil {
 					return nil, fmt.Errorf("fabric connection %s: %w", conn.Name, err)
 				}
@@ -142,6 +146,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 
 				neigh.RemoteName = other.Port
 				neigh.Type = BGPNeighborTypeFabric
+				neigh.Unnumbered = other.IP == ""
 				neigh.Expected = true
 				neigh.ConnectionName = conn.Name
 				neigh.ConnectionType = conn.Spec.Type()
@@ -159,7 +164,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				}
 				fabricPeers[other.DeviceName()] = true
 
-				key, err := fabricNeighborKey(ag, curr, other)
+				key, err := bgpNeighborKey(ag, curr, other.IP)
 				if err != nil {
 					return nil, fmt.Errorf("mesh connection %s: %w", conn.Name, err)
 				}
@@ -171,6 +176,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 
 				neigh.RemoteName = other.Port
 				neigh.Type = BGPNeighborTypeFabric
+				neigh.Unnumbered = other.IP == ""
 				neigh.Expected = true
 				neigh.ConnectionName = conn.Name
 				neigh.ConnectionType = conn.Spec.Type()
@@ -182,20 +188,25 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 			extConns[conn.Name] = &conn
 		} else if conn.Spec.Gateway != nil {
 			for _, link := range conn.Spec.Gateway.Links {
-				ip := strings.Split(link.Gateway.IP, "/")[0]
-				neigh, ok := out["default"][ip]
+				key, err := bgpNeighborKey(ag, link.Switch, link.Gateway.IP)
+				if err != nil {
+					return nil, fmt.Errorf("gateway connection %s: %w", conn.Name, err)
+				}
+
+				neigh, ok := out["default"][key]
 				if !ok {
 					neigh = BGPNeighborStatus{}
 				}
 
 				neigh.RemoteName = link.Gateway.Port
 				neigh.Type = BGPNeighborTypeGateway
+				neigh.Unnumbered = link.Gateway.IP == ""
 				neigh.Expected = true
 				neigh.ConnectionName = conn.Name
 				neigh.ConnectionType = conn.Spec.Type()
 				neigh.Port = link.Switch.LocalPortName()
 
-				out["default"][ip] = neigh
+				out["default"][key] = neigh
 			}
 		}
 	}

--- a/pkg/util/apiutil/bgp_test.go
+++ b/pkg/util/apiutil/bgp_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package apiutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
+	"go.githedgehog.com/fabric/api/meta"
+	vpcapi "go.githedgehog.com/fabric/api/vpc/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/ctrl/switchprofile"
+	"go.githedgehog.com/fabric/pkg/util/apiutil"
+	kmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Unnumbered sessions are keyed by the port they run over, so the expected neighbors have to line
+// up with what the agent reports for them: one entry per link, rather than every unnumbered link
+// on the switch sharing a single key that matches nothing.
+func TestGetBGPNeighborsUnnumbered(t *testing.T) {
+	const (
+		self     = "leaf-01"
+		spine    = "spine-01"
+		spineASN = uint32(65100)
+		wVLAN    = uint16(3123)
+	)
+
+	sw := &wiringapi.Switch{
+		ObjectMeta: kmetav1.ObjectMeta{Name: self, Namespace: kmetav1.NamespaceDefault},
+		Spec:       wiringapi.SwitchSpec{Role: wiringapi.SwitchRoleServerLeaf},
+	}
+
+	fabricConn := &wiringapi.Connection{
+		ObjectMeta: kmetav1.ObjectMeta{Name: self + "--fabric--" + spine, Namespace: kmetav1.NamespaceDefault},
+		Spec: wiringapi.ConnectionSpec{
+			Fabric: &wiringapi.ConnFabric{
+				Links: []wiringapi.FabricLink{
+					{
+						Spine: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(spine + "/E1/1")},
+						Leaf:  wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(self + "/E1/1")},
+					},
+					{
+						Spine: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(spine + "/E1/2")},
+						Leaf:  wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(self + "/E1/2")},
+					},
+				},
+			},
+		},
+	}
+
+	newAgent := func(silicon string) *agentapi.Agent {
+		ag := &agentapi.Agent{ObjectMeta: kmetav1.ObjectMeta{Name: self, Namespace: kmetav1.NamespaceDefault}}
+		ag.Spec.SwitchProfile = &wiringapi.SwitchProfileSpec{SwitchSilicon: silicon}
+		ag.Spec.Switches = map[string]wiringapi.SwitchSpec{
+			spine: {ASN: spineASN, ProtocolIP: "172.30.11.2/32"},
+		}
+		ag.Spec.Catalog.TH5WorkaroundVLANs = map[string]uint16{"E1/1": wVLAN, "E1/2": wVLAN + 1}
+
+		return ag
+	}
+
+	// what the agent reports once the NOS interface names are translated back to API ports
+	reported := func(keys ...string) map[string]map[string]agentapi.SwitchStateBGPNeighbor {
+		neighs := map[string]agentapi.SwitchStateBGPNeighbor{}
+		for _, key := range keys {
+			neighs[key] = agentapi.SwitchStateBGPNeighbor{SessionState: agentapi.BGPNeighborSessionStateEstablished}
+		}
+
+		return map[string]map[string]agentapi.SwitchStateBGPNeighbor{"default": neighs}
+	}
+
+	for _, tt := range []struct {
+		name     string
+		silicon  string
+		reported []string
+		expected map[string]string // neighbor key -> connection it belongs to
+	}{
+		{
+			name:     "fabric links",
+			silicon:  switchprofile.SiliconVS,
+			reported: []string{"E1/1", "E1/2", "172.30.11.2"},
+			expected: map[string]string{
+				"E1/1":        fabricConn.Name,
+				"E1/2":        fabricConn.Name,
+				"172.30.11.2": "",
+			},
+		},
+		{
+			// the peering runs over the workaround SVI, one per link
+			name:     "on TH5",
+			silicon:  switchprofile.SiliconBroadcomTH5,
+			reported: []string{"E1/1.3123", "E1/2.3124", "172.30.11.2"},
+			expected: map[string]string{
+				"E1/1.3123":   fabricConn.Name,
+				"E1/2.3124":   fabricConn.Name,
+				"172.30.11.2": "",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, wiringapi.AddToScheme(scheme))
+			require.NoError(t, vpcapi.AddToScheme(scheme))
+			require.NoError(t, agentapi.AddToScheme(scheme))
+
+			ag := newAgent(tt.silicon)
+			ag.Status.State.BGPNeighbors = reported(tt.reported...)
+
+			objs := []kclient.Object{sw, ag}
+			for _, conn := range []*wiringapi.Connection{fabricConn} {
+				conn := conn.DeepCopy()
+				conn.Default()
+				objs = append(objs, conn)
+			}
+
+			kube := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).
+				WithStatusSubresource(ag).Build()
+			require.NoError(t, kube.Status().Update(t.Context(), ag))
+
+			neighs, err := apiutil.GetBGPNeighbors(t.Context(), kube, &meta.FabricConfig{}, sw)
+			require.NoError(t, err)
+
+			// an expected key that does not match what the agent reports shows up as an extra
+			// entry, which is what keying every unnumbered session by "unnum" used to do
+			require.Len(t, neighs["default"], len(tt.expected))
+
+			for key, conn := range tt.expected {
+				neigh, ok := neighs["default"][key]
+				require.True(t, ok, "neighbor %s must be present", key)
+				require.True(t, neigh.Expected, "neighbor %s must be expected", key)
+				require.Equal(t, conn, neigh.ConnectionName)
+				require.Equal(t, agentapi.BGPNeighborSessionStateEstablished, neigh.SessionState,
+					"neighbor %s must join the state the agent reports", key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
An unnumbered session has no peer IP to be keyed by, so the device reports it under the NOS interface it runs over: Ethernet3, Ethernet0.1001 for a hostBGP subinterface, Vlan3123 for the TH5 workaround SVI. Those names must not reach the API, so the agent now translates them to the port names we use everywhere else - E1/1, E1/1.1001, E1/5.3123 - and apiutil keys the expected neighbors the same way.

This replaces the "unnum" placeholder, which matched nothing the agent reports: every unnumbered session showed up in `hhfctl inspect bgp` twice, once as an unexpected neighbor and once as a phantom that never established, so `--strict` could not pass on an unnumbered fabric. It also collapsed every unnumbered link on a switch onto one key.

BFD sessions get the same treatment, keyed by their interface rather than by the IPv6 link-local address they run over, which is of no use to anyone and never joined the BGP neighbor it belongs to. Numbered sessions keep their IP keys, so nothing else moves.

Since the port is now what identifies the peer, `hhfctl inspect bgp` and `hhfctl inspect bfd` would otherwise show the same thing in their port and neighbor/peer columns, so those rows are rendered as "E1/1 IPv6 LL". That is display only: the key, and with it the JSON output, stays the plain port name that the agent reports and that --strict matches on. An `unnumbered` flag on the status carries it to the renderer.