### PR TITLE
fix(agent): only advertise all VTEPs on gateway-attached leaves

### DIFF
--- a/pkg/agent/dozer/bcm/README.plan.md
+++ b/pkg/agent/dozer/bcm/README.plan.md
@@ -148,14 +148,27 @@ This route-map serves multiple purposes:
     ip prefix-list all-vtep-prefixes seq 10 permit 172.30.12.0/22 le 32
     ```
     i.e. `172.30.12.0/22` above is the VTEP Subnet as defined in the Fabric config
-1. We create the following route-map, used on both spines and mesh leaves to filter
-which routes are redistributed, as we will see:
+1. We create the following route-map, used to filter which routes are redistributed on
+spines, on mesh leaves and on leaves with a gateway attached, as we will see:
     ```
     route-map loopback-all-vteps permit 10
      match ip address prefix-list all-vtep-prefixes
     !
     route-map loopback-all-vteps permit 100
      match ip address prefix-list static-ext-subnets
+    ```
+1. On a leaf with no gateway connection we create the narrower pair below, matching only
+that leaf's own VTEP. A leaf in a spine-leaf topology uses it towards the spines so that
+it does not re-advertise the VTEPs it learned from them (see
+[Fabric Connections](#fabric-connections-ie-spine-leaf)):
+    ```
+    ip prefix-list vtep-prefix seq 10 permit 172.30.12.0/32 le 32
+    route-map loopback-vtep permit 10
+     match ip address prefix-list vtep-prefix
+    !
+    route-map loopback-vtep permit 100
+     match ip address prefix-list static-ext-subnets
+    !
     ```
 1. We create the following prefix list and corresponding route-map to only advertise
 the protocol loopback on the fabric point-to-point links between switches:
@@ -282,10 +295,14 @@ loopback, e.g.:
 Additionally, once per neighboring node (no matter the number of fabric links to it)
 we create a BGP session with its protocol IP, for which we have learned a route over
 the point-to-point BGP sessions described above. We will use this session for both IPv4
-unicast, where we will advertise all the VTEPs we know of, and for EVPN, where we will
-exchange overlay routes. This session will go down if all of the point-to-point sessions
+unicast, where we will advertise the VTEPs, and for EVPN, where we will exchange overlay
+routes. This session will go down if all of the point-to-point sessions
 above are down, which would mean that this switch is no longer able to reach this
 particular neighbor.
+
+A spine advertises every VTEP it knows about, since that is how the leaves learn of each
+other. A leaf only advertises its own, so that the VTEPs it learned from one spine are not
+sent back into the fabric via another one.
 
 Here's an example config for a leaf:
 ```
@@ -297,7 +314,7 @@ neighbor 172.30.8.0
  !
  address-family ipv4 unicast
   activate
-  route-map loopback-all-vteps out
+  route-map loopback-vtep out
  !
  address-family l2vpn evpn
   activate
@@ -323,6 +340,13 @@ neighbor 172.30.8.3
   route-map evpn-default-remote-block in
 !
 ```
+
+The exception is a leaf with a [gateway connection](#gateway-connections), which uses
+`loopback-all-vteps` like a spine: the gateway VTEP has to reach the rest of the fabric,
+and we cannot match it explicitly because it lives on the `Gateway` object rather than on
+the connection. The cost is that such a leaf also re-advertises the VTEPs it learned from
+the spines, on paths that are either rejected by the peer for having its own AS in the
+path, or long enough to lose bestpath selection against the direct ones.
 
 #### Unnumbered links
 
@@ -405,7 +429,8 @@ Mesh links support [unnumbered](#unnumbered-links) exactly as fabric links do.
 Additionally, once per neighboring node (no matter the number of mesh links to it)
 we create a BGP session with its protocol IP, for which we have learned a route over
 the point-to-point BGP sessions described above. We will use this session for both IPv4
-unicast, where we will advertise all VTEPs we know about, and for EVPN, where we will
+unicast, where we will advertise all VTEPs we know about (a mesh leaf has to transit for
+its peers, so it never uses the narrower `loopback-vtep`), and for EVPN, where we will
 exchange overlay routes. This session will go down if all of the point-to-point sessions
 above are down, which would mean that this leaf is no longer able to reach this particular
 neighbor.
@@ -467,7 +492,9 @@ unnumbered peering over it stays one-to-one with the physical link.
 
 Gateway connections represent a connection between a Fabric switch and a Gateway.
 For spine-leaf topologies the switch is typically a spine, while for mesh topologies
-it will necessarily be a leaf.
+it will necessarily be a leaf. A leaf with a gateway connection in a spine-leaf topology
+advertises all the VTEPs it knows about towards the spines, see
+[Fabric Connections](#fabric-connections-ie-spine-leaf).
 
 For each link in a gateway connection, we:
 1. configure the corresponding interface on the switch, setting it to admin-up

--- a/pkg/agent/dozer/bcm/plan.go
+++ b/pkg/agent/dozer/bcm/plan.go
@@ -51,10 +51,12 @@ const (
 	RouteMapL2VPNNeighbors       = "l2vpn-neighbors"
 	RouteMapFilterAttachedHost   = "filter-attached-hosts"
 	RouteMapLoopbackAllVTEPs     = "loopback-all-vteps"
+	RouteMapLoopbackVTEP         = "loopback-vtep"
 	RouteMapProtocolLoopbackOnly = "protocol-loopback-only"
 	PrefixListAny                = "any-prefix"
 	PrefixListVPCLoopback        = "vpc-loopback-prefix"
 	PrefixListAllVTEPPrefixes    = "all-vtep-prefixes"
+	PrefixListVTEPPrefix         = "vtep-prefix"
 	PrefixListProtocolLoopback   = "protocol-loopback-prefix"
 	PrefixListStaticExternals    = "static-ext-subnets"
 	NoCommunity                  = "no-community"
@@ -496,6 +498,59 @@ func planFabricConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 		},
 	}
 
+	// a fabric leaf only needs to re-advertise the VTEPs of others if it is attached to a gateway, so that
+	// the gateway VTEP is propagated into the fabric; we can't match that VTEP explicitly, as it
+	// lives on the Gateway object and not on the connection
+	advertiseAllVTEPs := !agent.Spec.Switch.Role.IsLeaf()
+	if !advertiseAllVTEPs {
+		for _, conn := range agent.Spec.Connections {
+			if conn.Gateway == nil {
+				continue
+			}
+			advertiseAllVTEPs = true
+
+			break
+		}
+	}
+
+	loopbackRouteMap := RouteMapLoopbackAllVTEPs
+	if !advertiseAllVTEPs {
+		loopbackRouteMap = RouteMapLoopbackVTEP
+
+		if agent.Spec.Switch.VTEPIP == "" {
+			return errors.New("VTEP IP not set in leaf switch spec")
+		}
+
+		spec.PrefixLists[PrefixListVTEPPrefix] = &dozer.SpecPrefixList{
+			Prefixes: map[uint32]*dozer.SpecPrefixListEntry{
+				10: {
+					Prefix: dozer.SpecPrefixListPrefix{
+						Prefix: agent.Spec.Switch.VTEPIP,
+						Le:     32,
+					},
+					Action: dozer.SpecPrefixListActionPermit,
+				},
+			},
+		}
+
+		spec.RouteMaps[RouteMapLoopbackVTEP] = &dozer.SpecRouteMap{
+			Statements: map[string]*dozer.SpecRouteMapStatement{
+				"10": {
+					Conditions: dozer.SpecRouteMapConditions{
+						MatchPrefixList: pointer.To(PrefixListVTEPPrefix),
+					},
+					Result: dozer.SpecRouteMapResultAccept,
+				},
+				"100": {
+					Conditions: dozer.SpecRouteMapConditions{
+						MatchPrefixList: pointer.To(PrefixListStaticExternals),
+					},
+					Result: dozer.SpecRouteMapResultAccept,
+				},
+			},
+		}
+	}
+
 	spec.PrefixLists[PrefixListProtocolLoopback] = &dozer.SpecPrefixList{
 		Prefixes: map[uint32]*dozer.SpecPrefixListEntry{
 			10: {
@@ -642,7 +697,7 @@ func planFabricConnections(agent *agentapi.Agent, spec *dozer.Spec) error {
 			Description:               pointer.To(fmt.Sprintf("Fabric %s loopback (spine-link)", peer)),
 			RemoteAS:                  pointer.To(peerSpec.ASN),
 			IPv4Unicast:               pointer.To(true),
-			IPv4UnicastExportPolicies: []string{RouteMapLoopbackAllVTEPs},
+			IPv4UnicastExportPolicies: []string{loopbackRouteMap},
 			L2VPNEVPN:                 pointer.To(true),
 			L2VPNEVPNImportPolicies:   []string{RouteMapL2VPNNeighbors},
 			DisableConnectedCheck:     pointer.To(true),

--- a/pkg/agent/dozer/bcm/plan_test.go
+++ b/pkg/agent/dozer/bcm/plan_test.go
@@ -185,7 +185,7 @@ func TestPlan(t *testing.T) {
 		// virt ext connected to leaf-3 only, 2 subnets per vpc
 		// peers: 1+2 1+3:gw:vpc1=subnet-01:vpc2=subnet-01 3+4 1~external-01:subnets=subnet-01 3~external-01:subnets=subnet-01
 		{name: "reg-leaf-3"},  // eslag, external connected to it, vpc peering and ext peering
-		{name: "reg-leaf-4"},  // eslag, no external connected to it, vpc peering and no ext peering
+		{name: "reg-leaf-4"},  // eslag, no external, vpc peering, gateway connected to it (so it advertises all VTEPs)
 		{name: "reg-spine-1"}, // spine
 		// group: l3vni
 		// vs vlab with l3vni vpcs, 2 spines, 2 standalone leaves with multihomed servers, 2 hostbgp vpcs (1 and 2) and one regular vpc

--- a/pkg/agent/dozer/bcm/plan_unnumbered_test.go
+++ b/pkg/agent/dozer/bcm/plan_unnumbered_test.go
@@ -76,6 +76,7 @@ func TestPlanUnnumberedFabricMeshLinks(t *testing.T) {
 			},
 		})
 		ag.Spec.Switch.Role = wiringapi.SwitchRoleServerLeaf
+		ag.Spec.Switch.VTEPIP = "172.30.12.1/32"
 		ag.Spec.Config.SpineLeaf = &agentapi.AgentSpecConfigSpineLeaf{}
 		ag.Spec.Config.VTEPSubnet = "172.30.12.0/24"
 		ag.Spec.Config.ProtocolSubnet = "172.30.11.0/24"

--- a/pkg/agent/dozer/bcm/plan_vtep_export_test.go
+++ b/pkg/agent/dozer/bcm/plan_vtep_export_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Hedgehog
+// SPDX-License-Identifier: Apache-2.0
+
+package bcm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	agentapi "go.githedgehog.com/fabric/api/agent/v1beta1"
+	wiringapi "go.githedgehog.com/fabric/api/wiring/v1beta1"
+	"go.githedgehog.com/fabric/pkg/agent/dozer"
+)
+
+// A leaf advertises only its own VTEP to the spines, unless it is attached to a gateway: the
+// gateway VTEP has to reach the rest of the fabric and cannot be matched explicitly, so such a
+// leaf falls back to advertising the whole VTEP subnet.
+func TestPlanFabricVTEPExportPolicy(t *testing.T) {
+	const (
+		self  = "leaf-01"
+		spine = "spine-01"
+	)
+
+	newAgent := func(role wiringapi.SwitchRole, gateway bool) *agentapi.Agent {
+		ag := &agentapi.Agent{}
+		ag.Name = self
+		ag.Spec.Switch.Role = role
+		ag.Spec.Switch.ProtocolIP = "172.30.11.1/32"
+		ag.Spec.Switch.VTEPIP = "172.30.12.1/32"
+		ag.Spec.Config.SpineLeaf = &agentapi.AgentSpecConfigSpineLeaf{}
+		ag.Spec.Config.VTEPSubnet = "172.30.12.0/24"
+		ag.Spec.Config.ProtocolSubnet = "172.30.11.0/24"
+		ag.Spec.Switches = map[string]wiringapi.SwitchSpec{
+			spine: {ASN: 65100, ProtocolIP: "172.30.11.2/32"},
+		}
+		ag.Spec.Connections = map[string]wiringapi.ConnectionSpec{
+			"fabric-1": {Fabric: &wiringapi.ConnFabric{
+				Links: []wiringapi.FabricLink{{
+					Spine: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.BasePortName{Port: spine + "/E1/1"}, IP: "172.30.128.1/31"},
+					Leaf:  wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.BasePortName{Port: self + "/E1/1"}, IP: "172.30.128.0/31"},
+				}},
+			}},
+		}
+		if gateway {
+			ag.Spec.Connections["gw-1"] = wiringapi.ConnectionSpec{Gateway: &wiringapi.ConnGateway{
+				Links: []wiringapi.GatewayLink{{
+					Switch:  wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.BasePortName{Port: self + "/E1/2"}, IP: "172.30.129.0/31"},
+					Gateway: wiringapi.ConnGatewayLinkGateway{BasePortName: wiringapi.BasePortName{Port: "gw-01/enp2s1"}, IP: "172.30.129.1/31"},
+				}},
+			}}
+		}
+
+		return ag
+	}
+
+	newSpec := func() *dozer.Spec {
+		return &dozer.Spec{
+			Interfaces:     map[string]*dozer.SpecInterface{},
+			RouteMaps:      map[string]*dozer.SpecRouteMap{},
+			PrefixLists:    map[string]*dozer.SpecPrefixList{},
+			CommunityLists: map[string]*dozer.SpecCommunityList{},
+			VRFs: map[string]*dozer.SpecVRF{
+				VRFDefault: {BGP: &dozer.SpecVRFBGP{Neighbors: map[string]*dozer.SpecVRFBGPNeighbor{}}},
+			},
+		}
+	}
+
+	// the loopback session with the spine is the one carrying the VTEP routes
+	exportPolicies := func(spec *dozer.Spec) []string {
+		neigh, ok := spec.VRFs[VRFDefault].BGP.Neighbors["172.30.11.2"]
+		require.True(t, ok, "loopback neighbor with the spine must exist")
+
+		return neigh.IPv4UnicastExportPolicies
+	}
+
+	t.Run("leaf without gateway", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planFabricConnections(newAgent(wiringapi.SwitchRoleServerLeaf, false), spec))
+
+		require.Equal(t, []string{RouteMapLoopbackVTEP}, exportPolicies(spec))
+		require.Equal(t, "172.30.12.1/32", spec.PrefixLists[PrefixListVTEPPrefix].Prefixes[10].Prefix.Prefix)
+	})
+
+	t.Run("leaf with gateway", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planFabricConnections(newAgent(wiringapi.SwitchRoleServerLeaf, true), spec))
+
+		require.Equal(t, []string{RouteMapLoopbackAllVTEPs}, exportPolicies(spec))
+		require.NotContains(t, spec.RouteMaps, RouteMapLoopbackVTEP)
+	})
+
+	t.Run("spine", func(t *testing.T) {
+		spec := newSpec()
+		require.NoError(t, planFabricConnections(newAgent(wiringapi.SwitchRoleSpine, false), spec))
+
+		require.Equal(t, []string{RouteMapLoopbackAllVTEPs}, exportPolicies(spec))
+		require.NotContains(t, spec.RouteMaps, RouteMapLoopbackVTEP)
+	})
+}

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.actions.expected.yaml
@@ -314,6 +314,16 @@
         name: vpc-subnets--vpc-03
       name: vpc-subnets--vpc-03
   weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]
+  summary: Create Prefix List Base vtep-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vtep-prefix
+      name: vtep-prefix
+  weight: 8
 - path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
   summary: Create Prefix Lists Entry 10
   type: update
@@ -649,6 +659,20 @@
       ip-prefix: 10.0.3.0/24
       masklength-range: 24..32
       sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.0/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.0/32
+      masklength-range: 32..32
+      sequence-number: 10
   weight: 10
 - path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
   summary: Create Community Lists all-externals
@@ -1246,6 +1270,15 @@
     - config:
         name: loopback-all-vteps
       name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]
+  summary: Create Route Maps Base loopback-vtep
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
   weight: 19
 - path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
   summary: Create Route Maps Base protocol-loopback-only
@@ -1906,6 +1939,38 @@
       name: "10"
   weight: 21
 - path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vtep-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=100]
   summary: Create Route Map Statement 100
   type: update
   value:
@@ -3957,7 +4022,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true
@@ -3991,7 +4056,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.gnmi.expected.yaml
@@ -1221,7 +1221,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -1249,7 +1249,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -1771,6 +1771,20 @@ routing-policy:
             masklength-range: 24..32
             sequence-number: 1
         name: vpc-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vtep-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.0/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.0/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vtep-prefix
   policy-definitions:
     policy-definition:
     - config:
@@ -2188,6 +2202,31 @@ routing-policy:
             match-prefix-set:
               config:
                 prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vtep-prefix
           config:
             name: "10"
           name: "10"

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-01.out.spec.expected.yaml
@@ -492,6 +492,13 @@ prefixLists:
         prefix:
           le: 32
           prefix: 10.0.3.0/24
+  vtep-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.0/32
 routeMaps:
   ext-import--ext-snp-02:
     statements:
@@ -659,6 +666,16 @@ routeMaps:
       "10":
         conditions:
           matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  loopback-vtep:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: vtep-prefix
         result: accept
       "100":
         conditions:
@@ -1014,7 +1031,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors
@@ -1026,7 +1043,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.actions.expected.yaml
@@ -284,6 +284,16 @@
         name: vpc-subnets--vpc-03
       name: vpc-subnets--vpc-03
   weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]
+  summary: Create Prefix List Base vtep-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vtep-prefix
+      name: vtep-prefix
+  weight: 8
 - path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
   summary: Create Prefix Lists Entry 10
   type: update
@@ -577,6 +587,20 @@
       ip-prefix: 10.0.3.0/24
       masklength-range: 24..32
       sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.1/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.1/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.1/32
+      masklength-range: 32..32
+      sequence-number: 10
   weight: 10
 - path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
   summary: Create Community Lists all-externals
@@ -1089,6 +1113,15 @@
     - config:
         name: loopback-all-vteps
       name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]
+  summary: Create Route Maps Base loopback-vtep
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
   weight: 19
 - path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
   summary: Create Route Maps Base protocol-loopback-only
@@ -1679,6 +1712,38 @@
       name: "10"
   weight: 21
 - path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vtep-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=100]
   summary: Create Route Map Statement 100
   type: update
   value:
@@ -3129,7 +3194,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true
@@ -3163,7 +3228,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.gnmi.expected.yaml
@@ -802,7 +802,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -830,7 +830,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -1310,6 +1310,20 @@ routing-policy:
             masklength-range: 24..32
             sequence-number: 1
         name: vpc-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vtep-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.1/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.1/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vtep-prefix
   policy-definitions:
     policy-definition:
     - config:
@@ -1671,6 +1685,31 @@ routing-policy:
             match-prefix-set:
               config:
                 prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vtep-prefix
           config:
             name: "10"
           name: "10"

--- a/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/l3vni-leaf-02.out.spec.expected.yaml
@@ -381,6 +381,13 @@ prefixLists:
         prefix:
           le: 32
           prefix: 10.0.3.0/24
+  vtep-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.1/32
 routeMaps:
   filter-attached-hosts:
     statements:
@@ -526,6 +533,16 @@ routeMaps:
       "10":
         conditions:
           matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  loopback-vtep:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: vtep-prefix
         result: accept
       "100":
         conditions:
@@ -817,7 +834,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors
@@ -829,7 +846,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.actions.expected.yaml
@@ -184,6 +184,16 @@
         name: vpc-subnets--vpc-03
       name: vpc-subnets--vpc-03
   weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]
+  summary: Create Prefix List Base vtep-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vtep-prefix
+      name: vtep-prefix
+  weight: 8
 - path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
   summary: Create Prefix Lists Entry 10
   type: update
@@ -337,6 +347,20 @@
       ip-prefix: 10.0.3.0/24
       masklength-range: 24..32
       sequence-number: 1
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.2/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.2/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.2/32
+      masklength-range: 32..32
+      sequence-number: 10
   weight: 10
 - path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
   summary: Create Community Lists all-externals
@@ -838,6 +862,15 @@
     - config:
         name: loopback-all-vteps
       name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]
+  summary: Create Route Maps Base loopback-vtep
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
   weight: 19
 - path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
   summary: Create Route Maps Base protocol-loopback-only
@@ -1370,6 +1403,38 @@
       name: "10"
   weight: 21
 - path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vtep-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=100]
   summary: Create Route Map Statement 100
   type: update
   value:

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.gnmi.expected.yaml
@@ -1160,6 +1160,20 @@ routing-policy:
             masklength-range: 24..32
             sequence-number: 1
         name: vpc-subnets--vpc-03
+      - config:
+          mode: IPV4
+          name: vtep-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.2/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.2/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vtep-prefix
   policy-definitions:
     policy-definition:
     - config:
@@ -1534,6 +1548,31 @@ routing-policy:
             match-prefix-set:
               config:
                 prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vtep-prefix
           config:
             name: "10"
           name: "10"

--- a/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/mesh-leaf-03.out.spec.expected.yaml
@@ -366,6 +366,13 @@ prefixLists:
         prefix:
           le: 32
           prefix: 10.0.3.0/24
+  vtep-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.2/32
 routeMaps:
   ext-import--ext-bgp-01:
     statements:
@@ -511,6 +518,16 @@ routeMaps:
       "10":
         conditions:
           matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  loopback-vtep:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: vtep-prefix
         result: accept
       "100":
         conditions:

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.actions.expected.yaml
@@ -294,6 +294,16 @@
         name: vpc-subnets--vpc-04
       name: vpc-subnets--vpc-04
   weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]
+  summary: Create Prefix List Base vtep-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vtep-prefix
+      name: vtep-prefix
+  weight: 8
 - path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
   summary: Create Prefix Lists Entry 10
   type: update
@@ -713,6 +723,20 @@
       ip-prefix: 10.0.8.0/24
       masklength-range: 24..32
       sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.1/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.1/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.1/32
+      masklength-range: 32..32
+      sequence-number: 10
   weight: 10
 - path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
   summary: Create Community Lists all-externals
@@ -1351,6 +1375,15 @@
     - config:
         name: loopback-all-vteps
       name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]
+  summary: Create Route Maps Base loopback-vtep
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
   weight: 19
 - path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
   summary: Create Route Maps Base protocol-loopback-only
@@ -2124,6 +2157,38 @@
       name: "10"
   weight: 21
 - path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vtep-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=100]
   summary: Create Route Map Statement 100
   type: update
   value:
@@ -3975,7 +4040,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true
@@ -4009,7 +4074,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.gnmi.expected.yaml
@@ -1082,7 +1082,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -1110,7 +1110,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -1699,6 +1699,20 @@ routing-policy:
             masklength-range: 24..32
             sequence-number: 2
         name: vpc-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vtep-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.1/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.1/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vtep-prefix
   policy-definitions:
     policy-definition:
     - config:
@@ -2216,6 +2230,31 @@ routing-policy:
             match-prefix-set:
               config:
                 prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vtep-prefix
           config:
             name: "10"
           name: "10"

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-3.out.spec.expected.yaml
@@ -546,6 +546,13 @@ prefixLists:
         prefix:
           le: 32
           prefix: 10.0.8.0/24
+  vtep-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.1/32
 routeMaps:
   ext-import--external-01:
     statements:
@@ -748,6 +755,16 @@ routeMaps:
       "10":
         conditions:
           matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  loopback-vtep:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: vtep-prefix
         result: accept
       "100":
         conditions:
@@ -1036,7 +1053,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors
@@ -1048,7 +1065,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.in.agent.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.in.agent.yaml
@@ -113,6 +113,15 @@ spec:
     vpc-03/subnet-02: true
     vpc-04/subnet-02: true
   connections:
+    leaf-04--gateway--gateway-1:
+      gateway:
+        links:
+          - gateway:
+              ip: 172.30.128.23/31
+              port: gateway-1/enp2s2
+            switch:
+              ip: 172.30.128.22/31
+              port: leaf-04/E1/9
     server-05--eslag--leaf-03--leaf-04:
       eslag:
         links:

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.actions.expected.yaml
@@ -827,6 +827,17 @@
         name: Ethernet7
       name: Ethernet7
   weight: 16
+- path: /interfaces/interface[name=Ethernet8]
+  summary: Create Interface Ethernet8 Base
+  type: update
+  value:
+    interface:
+    - config:
+        description: Gateway gateway-1/enp2s2 leaf-04--gateway--gateway-1
+        enabled: true
+        name: Ethernet8
+      name: Ethernet8
+  weight: 16
 - path: /interfaces/interface[name=Loopback1]
   summary: Create Interface Loopback1 Base
   type: update
@@ -1857,6 +1868,14 @@
       config:
         auto-negotiate: false
   weight: 25
+- path: /interfaces/interface[name=Ethernet8]/ethernet
+  summary: Create Interface Ethernet8 Ethernet Base
+  type: update
+  value:
+    ethernet:
+      config:
+        auto-negotiate: false
+  weight: 25
 - path: /interfaces/interface[name=Vlan1005]/routed-vlan/ipv4/sag-ipv4/config/static-anycast-gateway
   summary: Create Interface Vlan1005 VLAN Anycast Gateway
   type: update
@@ -1980,6 +1999,15 @@
       index: 0
   weight: 44
 - path: /interfaces/interface[name=Ethernet7]/subinterfaces/subinterface[index=0]
+  summary: Create Subinterface Base 0
+  type: update
+  value:
+    subinterface:
+    - config:
+        index: 0
+      index: 0
+  weight: 44
+- path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]
   summary: Create Subinterface Base 0
   type: update
   value:
@@ -2163,6 +2191,17 @@
         prefix-length: 31
         secondary: false
       ip: 172.30.128.37
+  weight: 51
+- path: /interfaces/interface[name=Ethernet8]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
+  summary: Create Subinterface IP 172.30.128.22
+  type: update
+  value:
+    address:
+    - config:
+        ip: 172.30.128.22
+        prefix-length: 31
+        secondary: false
+      ip: 172.30.128.22
   weight: 51
 - path: /interfaces/interface[name=Loopback1]/subinterfaces/subinterface[index=0]/ipv4/addresses/address
   summary: Create Subinterface IP 172.30.8.5
@@ -2677,6 +2716,17 @@
         recovery-interval: 300
         sampling-interval: 30
   weight: 84
+- path: /openconfig-errdisable-ext:errdisable-port/port[name=Ethernet8]/link-flap
+  summary: Create ErrDisable Interface Ethernet8
+  type: update
+  value:
+    link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+  weight: 84
 - path: /openconfig-neighbor:neighbor-globals/neighbor-global
   summary: Create Neighbor Global
   type: update
@@ -2744,6 +2794,35 @@
           bfd-profile: fabric
           enabled: true
       neighbor-address: 172.30.128.14
+  weight: 87
+- path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.23]
+  summary: Create VRF BGP neighbor 172.30.128.23
+  type: update
+  value:
+    neighbor:
+    - afi-safis:
+        afi-safi:
+        - afi-safi-name: IPV4_UNICAST
+          config:
+            afi-safi-name: IPV4_UNICAST
+            enabled: true
+        - afi-safi-name: L2VPN_EVPN
+          allow-own-as:
+            config:
+              enabled: true
+          apply-policy:
+            config:
+              import-policy:
+              - l2vpn-neighbors
+          config:
+            afi-safi-name: L2VPN_EVPN
+            enabled: true
+      config:
+        description: Gateway gateway-1/enp2s2 leaf-04--gateway--gateway-1
+        enabled: true
+        neighbor-address: 172.30.128.23
+        peer-as: 65534
+      neighbor-address: 172.30.128.23
   weight: 87
 - path: /network-instances/network-instance[name=default]/protocols/protocol[identifier=BGP][name=bgp]/bgp/neighbors/neighbor[neighbor-address=172.30.128.34]
   summary: Create VRF BGP neighbor 172.30.128.34

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.gnmi.expected.yaml
@@ -71,6 +71,13 @@ errdisable-port:
         recovery-interval: 300
         sampling-interval: 30
     name: Ethernet7
+  - link-flap:
+      config:
+        error-disable: "on"
+        flap-threshold: 3
+        recovery-interval: 300
+        sampling-interval: 30
+    name: Ethernet8
 interfaces:
   interface:
   - config:
@@ -217,6 +224,27 @@ interfaces:
                 prefix-length: 31
                 secondary: false
               ip: 172.30.128.37
+  - config:
+      description: Gateway gateway-1/enp2s2 leaf-04--gateway--gateway-1
+      enabled: true
+      name: Ethernet8
+    ethernet:
+      config:
+        auto-negotiate: false
+    name: Ethernet8
+    subinterfaces:
+      subinterface:
+      - config:
+          index: 0
+        index: 0
+        ipv4:
+          addresses:
+            address:
+            - config:
+                ip: 172.30.128.22
+                prefix-length: 31
+                secondary: false
+              ip: 172.30.128.22
   - config:
       description: Protocol loopback
       enabled: true
@@ -721,6 +749,29 @@ network-instances:
                   bfd-profile: fabric
                   enabled: true
               neighbor-address: 172.30.128.14
+            - afi-safis:
+                afi-safi:
+                - afi-safi-name: IPV4_UNICAST
+                  config:
+                    afi-safi-name: IPV4_UNICAST
+                    enabled: true
+                - afi-safi-name: L2VPN_EVPN
+                  allow-own-as:
+                    config:
+                      enabled: true
+                  apply-policy:
+                    config:
+                      import-policy:
+                      - l2vpn-neighbors
+                  config:
+                    afi-safi-name: L2VPN_EVPN
+                    enabled: true
+              config:
+                description: Gateway gateway-1/enp2s2 leaf-04--gateway--gateway-1
+                enabled: true
+                neighbor-address: 172.30.128.23
+                peer-as: 65534
+              neighbor-address: 172.30.128.23
             - afi-safis:
                 afi-safi:
                 - afi-safi-name: IPV4_UNICAST

--- a/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/reg-leaf-4.out.spec.expected.yaml
@@ -117,6 +117,10 @@ errDisableInterfaces:
     flapThreshold: 3
     recoveryInterval: 300
     samplingInterval: 30
+  Ethernet8:
+    flapThreshold: 3
+    recoveryInterval: 300
+    samplingInterval: 30
 hostname: leaf-04
 interfaces:
   Ethernet0:
@@ -186,6 +190,15 @@ interfaces:
       "0":
         ips:
           172.30.128.37:
+            prefixLen: 31
+  Ethernet8:
+    autoNegotiate: false
+    description: Gateway gateway-1/enp2s2 leaf-04--gateway--gateway-1
+    enabled: true
+    subinterfaces:
+      "0":
+        ips:
+          172.30.128.22:
             prefixLen: 31
   Loopback1:
     description: Protocol loopback
@@ -767,6 +780,15 @@ vrfs:
           ipv4UnicastExportPolicies:
           - protocol-loopback-only
           remoteAS: 65100
+        172.30.128.23:
+          description: Gateway gateway-1/enp2s2 leaf-04--gateway--gateway-1
+          enabled: true
+          ipv4Unicast: true
+          l2vpnEvpn: true
+          l2vpnEvpnAllowOwnAS: true
+          l2vpnEvpnImportPolicies:
+          - l2vpn-neighbors
+          remoteAS: 65534
         172.30.128.34:
           bfdProfile: fabric
           description: Fabric spine-02/E1/7 spine-02--fabric--leaf-04

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.actions.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.actions.expected.yaml
@@ -294,6 +294,16 @@
         name: vpc-subnets--vpc-04
       name: vpc-subnets--vpc-04
   weight: 8
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]
+  summary: Create Prefix List Base vtep-prefix
+  type: update
+  value:
+    prefix-set:
+    - config:
+        mode: IPV4
+        name: vtep-prefix
+      name: vtep-prefix
+  weight: 8
 - path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=all-vtep-prefixes]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.0/22][masklength-range=22..32]
   summary: Create Prefix Lists Entry 10
   type: update
@@ -713,6 +723,20 @@
       ip-prefix: 10.0.8.0/24
       masklength-range: 24..32
       sequence-number: 2
+  weight: 10
+- path: /routing-policy/defined-sets/prefix-sets/prefix-set[name=vtep-prefix]/extended-prefixes/extended-prefix[sequence-number=10][ip-prefix=172.30.12.1/32][masklength-range=32..32]
+  summary: Create Prefix Lists Entry 10
+  type: update
+  value:
+    extended-prefix:
+    - config:
+        action: PERMIT
+        ip-prefix: 172.30.12.1/32
+        masklength-range: 32..32
+        sequence-number: 10
+      ip-prefix: 172.30.12.1/32
+      masklength-range: 32..32
+      sequence-number: 10
   weight: 10
 - path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/community-set[community-set-name=all-externals]
   summary: Create Community Lists all-externals
@@ -1351,6 +1375,15 @@
     - config:
         name: loopback-all-vteps
       name: loopback-all-vteps
+  weight: 19
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]
+  summary: Create Route Maps Base loopback-vtep
+  type: update
+  value:
+    policy-definition:
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
   weight: 19
 - path: /routing-policy/policy-definitions/policy-definition[name=protocol-loopback-only]
   summary: Create Route Maps Base protocol-loopback-only
@@ -2124,6 +2157,38 @@
       name: "10"
   weight: 21
 - path: /routing-policy/policy-definitions/policy-definition[name=loopback-all-vteps]/statements/statement[name=100]
+  summary: Create Route Map Statement 100
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: static-ext-subnets
+      config:
+        name: "100"
+      name: "100"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=10]
+  summary: Create Route Map Statement 10
+  type: update
+  value:
+    statement:
+    - actions:
+        config:
+          policy-result: ACCEPT_ROUTE
+      conditions:
+        match-prefix-set:
+          config:
+            prefix-set: vtep-prefix
+      config:
+        name: "10"
+      name: "10"
+  weight: 21
+- path: /routing-policy/policy-definitions/policy-definition[name=loopback-vtep]/statements/statement[name=100]
   summary: Create Route Map Statement 100
   type: update
   value:
@@ -3839,7 +3904,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true
@@ -3873,7 +3938,7 @@
           apply-policy:
             config:
               export-policy:
-              - loopback-all-vteps
+              - loopback-vtep
           config:
             afi-safi-name: IPV4_UNICAST
             enabled: true

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.gnmi.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.gnmi.expected.yaml
@@ -970,7 +970,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -998,7 +998,7 @@ network-instances:
                   apply-policy:
                     config:
                       export-policy:
-                      - loopback-all-vteps
+                      - loopback-vtep
                   config:
                     afi-safi-name: IPV4_UNICAST
                     enabled: true
@@ -1683,6 +1683,20 @@ routing-policy:
             masklength-range: 24..32
             sequence-number: 2
         name: vpc-subnets--vpc-04
+      - config:
+          mode: IPV4
+          name: vtep-prefix
+        extended-prefixes:
+          extended-prefix:
+          - config:
+              action: PERMIT
+              ip-prefix: 172.30.12.1/32
+              masklength-range: 32..32
+              sequence-number: 10
+            ip-prefix: 172.30.12.1/32
+            masklength-range: 32..32
+            sequence-number: 10
+        name: vtep-prefix
   policy-definitions:
     policy-definition:
     - config:
@@ -2200,6 +2214,31 @@ routing-policy:
             match-prefix-set:
               config:
                 prefix-set: all-vtep-prefixes
+          config:
+            name: "10"
+          name: "10"
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: static-ext-subnets
+          config:
+            name: "100"
+          name: "100"
+    - config:
+        name: loopback-vtep
+      name: loopback-vtep
+      statements:
+        statement:
+        - actions:
+            config:
+              policy-result: ACCEPT_ROUTE
+          conditions:
+            match-prefix-set:
+              config:
+                prefix-set: vtep-prefix
           config:
             name: "10"
           name: "10"

--- a/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.spec.expected.yaml
+++ b/pkg/agent/dozer/bcm/testdata/unnum-reg-leaf-3.out.spec.expected.yaml
@@ -542,6 +542,13 @@ prefixLists:
         prefix:
           le: 32
           prefix: 10.0.8.0/24
+  vtep-prefix:
+    prefixes:
+      "10":
+        action: permit
+        prefix:
+          le: 32
+          prefix: 172.30.12.1/32
 routeMaps:
   ext-import--external-01:
     statements:
@@ -744,6 +751,16 @@ routeMaps:
       "10":
         conditions:
           matchPrefixLists: all-vtep-prefixes
+        result: accept
+      "100":
+        conditions:
+          matchPrefixLists: static-ext-subnets
+        result: accept
+  loopback-vtep:
+    statements:
+      "10":
+        conditions:
+          matchPrefixLists: vtep-prefix
         result: accept
       "100":
         conditions:
@@ -1032,7 +1049,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors
@@ -1044,7 +1061,7 @@ vrfs:
           enabled: true
           ipv4Unicast: true
           ipv4UnicastExportPolicies:
-          - loopback-all-vteps
+          - loopback-vtep
           l2vpnEvpn: true
           l2vpnEvpnImportPolicies:
           - l2vpn-neighbors


### PR DESCRIPTION
Partially reverts 212553b55d, which made every leaf advertise the whole VTEP subnet to its spines. That was done so that a gateway hanging off a leaf in a spine-leaf topology would have its VTEP propagated into the fabric, which we still cannot do explicitly: the gateway VTEP lives on the Gateway object rather than on the connection.

So keep the broad policy only where it is needed, i.e. on a leaf that owns a gateway connection, and restore loopback-vtep for every other leaf. This matters for the future case of a leaf shared between two otherwise disjoint spine-leaf fabrics, where the VTEPs of one fabric have no business being advertised into the other.

Adds a gateway connection to the reg-leaf-4 golden input so both flavors of the export policy are covered, plus a focused unit test, and documents the two route-maps in README.plan.md.