### PR TITLE
fix: key unnumbered peers by the port name the agent reports

### DIFF
--- a/pkg/agent/dozer/bcm/README.plan.md
+++ b/pkg/agent/dozer/bcm/README.plan.md
@@ -386,7 +386,10 @@ multihop either way.
 The session has no peer IP to be reported under, so the agent keys its state (and the BFD
 session under it) by the port instead — `E1/1`, or `E1/1.3123` for the TH5 workaround SVI
 below. The NOS interface name the device actually uses (`Ethernet3`, `Vlan3123`) is
-translated away in `state.go`, so it never reaches the API.
+translated away in `state.go`, so it never reaches the API. On a breakout-capable port that
+port name is the first subport, `E1/53/1` rather than the `E1/53` the wiring spells, since the
+agent resolves interfaces through the NOS port mapping; `apiutil` normalizes the wiring name
+the same way before matching.
 
 ### Mesh Connections (i.e. leaf-leaf)
 

--- a/pkg/util/apiutil/bgp.go
+++ b/pkg/util/apiutil/bgp.go
@@ -35,27 +35,36 @@ const (
 	BGPNeighborTypeGateway  BGPNeighborType = "gateway"
 )
 
-// bgpNeighborKey returns the key the agent reports the session over the given link under: the peer
-// IP for a numbered link, the local port for an unnumbered one, since that is what the session is
-// keyed by. On TH5 the peering runs over the workaround SVI, reported as port.vlan.
-func bgpNeighborKey(ag *agentapi.Agent, local wiringapi.ConnFabricLinkSwitch, remoteIP string) (string, error) {
-	if remoteIP != "" {
-		return strings.Split(remoteIP, "/")[0], nil
-	}
-
+// bgpNeighborKey returns the local port as the agent names it and the key the agent reports the
+// session over the given link under: the peer IP for a numbered link, the local port for an
+// unnumbered one, since that is what the session is keyed by. On TH5 the peering runs over the
+// workaround SVI, reported as port.vlan.
+func bgpNeighborKey(ag *agentapi.Agent, local wiringapi.ConnFabricLinkSwitch, remoteIP string) (string, string, error) {
 	if ag.Spec.SwitchProfile == nil {
-		return "", fmt.Errorf("switch profile is not set for %s", ag.Name) //nolint:goerr113
+		return "", "", fmt.Errorf("switch profile is not set for %s", ag.Name) //nolint:goerr113
 	}
 
-	port := local.LocalPortName()
+	// a breakout-capable port is E1/53 in the wiring but E1/53/1 to the agent, which resolves
+	// interfaces through the NOS port mapping
+	wiringPort := local.LocalPortName()
+	port, err := ag.Spec.SwitchProfile.NormalizePortName(wiringPort)
+	if err != nil {
+		return "", "", fmt.Errorf("normalizing port name %s: %w", wiringPort, err)
+	}
+
+	if remoteIP != "" {
+		return port, strings.Split(remoteIP, "/")[0], nil
+	}
 
 	if ag.Spec.SwitchProfile.SwitchSilicon == switchprofile.SiliconBroadcomTH5 {
-		if vlan, ok := ag.Spec.Catalog.TH5WorkaroundVLANs[port]; ok {
-			return fmt.Sprintf("%s.%d", port, vlan), nil
+		// the catalog keys the workaround VLANs by the port name as the wiring spells it, and the
+		// agent reports the SVI under that same name
+		if vlan, ok := ag.Spec.Catalog.TH5WorkaroundVLANs[wiringPort]; ok {
+			return port, fmt.Sprintf("%s.%d", wiringPort, vlan), nil
 		}
 	}
 
-	return port, nil
+	return port, port, nil
 }
 
 func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.FabricConfig, sw *wiringapi.Switch) (map[string]map[string]BGPNeighborStatus, error) {
@@ -134,7 +143,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				}
 				fabricPeers[other.DeviceName()] = true
 
-				key, err := bgpNeighborKey(ag, curr, other.IP)
+				port, key, err := bgpNeighborKey(ag, curr, other.IP)
 				if err != nil {
 					return nil, fmt.Errorf("fabric connection %s: %w", conn.Name, err)
 				}
@@ -150,7 +159,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				neigh.Expected = true
 				neigh.ConnectionName = conn.Name
 				neigh.ConnectionType = conn.Spec.Type()
-				neigh.Port = curr.LocalPortName()
+				neigh.Port = port
 
 				out["default"][key] = neigh
 			}
@@ -164,7 +173,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				}
 				fabricPeers[other.DeviceName()] = true
 
-				key, err := bgpNeighborKey(ag, curr, other.IP)
+				port, key, err := bgpNeighborKey(ag, curr, other.IP)
 				if err != nil {
 					return nil, fmt.Errorf("mesh connection %s: %w", conn.Name, err)
 				}
@@ -180,7 +189,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				neigh.Expected = true
 				neigh.ConnectionName = conn.Name
 				neigh.ConnectionType = conn.Spec.Type()
-				neigh.Port = curr.LocalPortName()
+				neigh.Port = port
 
 				out["default"][key] = neigh
 			}
@@ -188,7 +197,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 			extConns[conn.Name] = &conn
 		} else if conn.Spec.Gateway != nil {
 			for _, link := range conn.Spec.Gateway.Links {
-				key, err := bgpNeighborKey(ag, link.Switch, link.Gateway.IP)
+				port, key, err := bgpNeighborKey(ag, link.Switch, link.Gateway.IP)
 				if err != nil {
 					return nil, fmt.Errorf("gateway connection %s: %w", conn.Name, err)
 				}
@@ -204,7 +213,7 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 				neigh.Expected = true
 				neigh.ConnectionName = conn.Name
 				neigh.ConnectionType = conn.Spec.Type()
-				neigh.Port = link.Switch.LocalPortName()
+				neigh.Port = port
 
 				out["default"][key] = neigh
 			}
@@ -260,10 +269,15 @@ func GetBGPNeighbors(ctx context.Context, kube kclient.Reader, fabCfg *meta.Fabr
 			out[vrf][extAtt.Spec.Neighbor.IP] = BGPNeighborStatus{}
 		}
 
+		port, err := ag.Spec.SwitchProfile.NormalizePortName(conn.Spec.External.Link.Switch.LocalPortName())
+		if err != nil {
+			return nil, fmt.Errorf("external connection %s: %w", conn.Name, err)
+		}
+
 		neigh.RemoteName = ext.Name
 		neigh.Expected = true
 		neigh.Type = BGPNeighborTypeExternal
-		neigh.Port = conn.Spec.External.Link.Switch.LocalPortName()
+		neigh.Port = port
 		neigh.ConnectionName = conn.Name
 		neigh.ConnectionType = conn.Spec.Type()
 

--- a/pkg/util/apiutil/bgp_test.go
+++ b/pkg/util/apiutil/bgp_test.go
@@ -48,18 +48,25 @@ func TestGetBGPNeighborsUnnumbered(t *testing.T) {
 						Spine: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(spine + "/E1/2")},
 						Leaf:  wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(self + "/E1/2")},
 					},
+					// a breakout-capable port, which the agent reports as E1/53/1
+					{
+						Spine: wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(spine + "/E1/53")},
+						Leaf:  wiringapi.ConnFabricLinkSwitch{BasePortName: wiringapi.NewBasePortName(self + "/E1/53")},
+					},
 				},
 			},
 		},
 	}
 
+	// E1/1 and E1/2 are plain SFP28 ports on the S5248F, E1/53 a breakout-capable QSFP28
 	newAgent := func(silicon string) *agentapi.Agent {
 		ag := &agentapi.Agent{ObjectMeta: kmetav1.ObjectMeta{Name: self, Namespace: kmetav1.NamespaceDefault}}
-		ag.Spec.SwitchProfile = &wiringapi.SwitchProfileSpec{SwitchSilicon: silicon}
+		ag.Spec.SwitchProfile = switchprofile.DellS5248FON.Spec.DeepCopy()
+		ag.Spec.SwitchProfile.SwitchSilicon = silicon
 		ag.Spec.Switches = map[string]wiringapi.SwitchSpec{
 			spine: {ASN: spineASN, ProtocolIP: "172.30.11.2/32"},
 		}
-		ag.Spec.Catalog.TH5WorkaroundVLANs = map[string]uint16{"E1/1": wVLAN, "E1/2": wVLAN + 1}
+		ag.Spec.Catalog.TH5WorkaroundVLANs = map[string]uint16{"E1/1": wVLAN, "E1/2": wVLAN + 1, "E1/53": wVLAN + 2}
 
 		return ag
 	}
@@ -74,31 +81,39 @@ func TestGetBGPNeighborsUnnumbered(t *testing.T) {
 		return map[string]map[string]agentapi.SwitchStateBGPNeighbor{"default": neighs}
 	}
 
+	type neighbor struct {
+		conn string
+		port string
+	}
+
 	for _, tt := range []struct {
 		name     string
 		silicon  string
 		reported []string
-		expected map[string]string // neighbor key -> connection it belongs to
+		expected map[string]neighbor // neighbor key -> connection and port it belongs to
 	}{
 		{
 			name:     "fabric links",
 			silicon:  switchprofile.SiliconVS,
-			reported: []string{"E1/1", "E1/2", "172.30.11.2"},
-			expected: map[string]string{
-				"E1/1":        fabricConn.Name,
-				"E1/2":        fabricConn.Name,
-				"172.30.11.2": "",
+			reported: []string{"E1/1", "E1/2", "E1/53/1", "172.30.11.2"},
+			expected: map[string]neighbor{
+				"E1/1":        {conn: fabricConn.Name, port: "E1/1"},
+				"E1/2":        {conn: fabricConn.Name, port: "E1/2"},
+				"E1/53/1":     {conn: fabricConn.Name, port: "E1/53/1"},
+				"172.30.11.2": {port: "Lo"},
 			},
 		},
 		{
-			// the peering runs over the workaround SVI, one per link
+			// the peering runs over the workaround SVI, one per link, named after the port the
+			// VLAN was allocated for
 			name:     "on TH5",
 			silicon:  switchprofile.SiliconBroadcomTH5,
-			reported: []string{"E1/1.3123", "E1/2.3124", "172.30.11.2"},
-			expected: map[string]string{
-				"E1/1.3123":   fabricConn.Name,
-				"E1/2.3124":   fabricConn.Name,
-				"172.30.11.2": "",
+			reported: []string{"E1/1.3123", "E1/2.3124", "E1/53.3125", "172.30.11.2"},
+			expected: map[string]neighbor{
+				"E1/1.3123":   {conn: fabricConn.Name, port: "E1/1"},
+				"E1/2.3124":   {conn: fabricConn.Name, port: "E1/2"},
+				"E1/53.3125":  {conn: fabricConn.Name, port: "E1/53/1"},
+				"172.30.11.2": {port: "Lo"},
 			},
 		},
 	} {
@@ -129,11 +144,12 @@ func TestGetBGPNeighborsUnnumbered(t *testing.T) {
 			// entry, which is what keying every unnumbered session by "unnum" used to do
 			require.Len(t, neighs["default"], len(tt.expected))
 
-			for key, conn := range tt.expected {
+			for key, want := range tt.expected {
 				neigh, ok := neighs["default"][key]
 				require.True(t, ok, "neighbor %s must be present", key)
 				require.True(t, neigh.Expected, "neighbor %s must be expected", key)
-				require.Equal(t, conn, neigh.ConnectionName)
+				require.Equal(t, want.conn, neigh.ConnectionName)
+				require.Equal(t, want.port, neigh.Port)
 				require.Equal(t, agentapi.BGPNeighborSessionStateEstablished, neigh.SessionState,
 					"neighbor %s must join the state the agent reports", key)
 			}


### PR DESCRIPTION
A breakout-capable port is registered under both spellings by GetAPI2NOSPortsFor - E1/53 and E1/53/1 both map to Ethernet64 - and GetNOS2APIPortsFor resolves the collision in favour of the subport form. The agent resolves the interface an unnumbered session runs over through that map, so it reports the session under E1/53/1, while apiutil keyed the expected neighbor by the raw wiring name E1/53.

So 5113d2c7 fixed the unnumbered keys for plain ports only: on a breakout-capable one the session still showed up in `hhfctl inspect bgp` twice, as an unexpected E1/53/1 and as a phantom E1/53 that never established, and --strict could not pass. BFD inherited it, since the peers are enriched from the BGP neighbors.

bgpNeighborKey now runs the wiring port name through NormalizePortName, the call GetLLDPNeighbors already uses, and returns that port alongside the key so the port column agrees with it rather than reading E1/53 next to "E1/53/1 IPv6 LL". The TH5 branch still looks the workaround VLAN up by the raw wiring name, since that is how the librarian keys the catalog and therefore how the agent names the SVI. Numbered fabric, mesh, gateway and external ports are normalized too, so the column is consistently the port name the rest of the switch state uses.